### PR TITLE
Add message for error around min/max pricing

### DIFF
--- a/service/pricing.yml
+++ b/service/pricing.yml
@@ -5,6 +5,7 @@ Pricing:
     validationNoMinPriceSpecified: "Minimum price requires an answer."
     validationNoUnitSpecified: "Pricing unit requires an answer. If none of the provided units apply, please choose 'Unit'."
     validationNotANumber: "Prices must be numbers only, without units, eg 99.95"
+    validationMaxLessThanMin: "Minimum price must be less than maximum price"
     fields:
       - type: pricing
   VAT included:


### PR DESCRIPTION
If the user gives their minimum price as being greater than their maximum price then we should tell them that this doesn't make sense.
