### PR TITLE
Remove security questions from SCS flow

### DIFF
--- a/service/security/asset-protection-and-resilience.yml
+++ b/service/security/asset-protection-and-resilience.yml
@@ -39,7 +39,7 @@ Asset protection and resilience:
     requirements: The legal jurisdiction(s) in which the service provider operates
     filters: The legal jurisdiction(s) in which the service provider operates
     hint: "Choose 1"
-    dependsOnLots: SaaS, PaaS, IaaS, SCS
+    dependsOnLots: SaaS, PaaS, IaaS
     assuranceApproach: 3answers-type1
     fields:
       - type: radio

--- a/service/security/incident-management.yml
+++ b/service/security/incident-management.yml
@@ -3,7 +3,7 @@ Incident management:
     requirements: Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.
     filters: Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.
     hint: "Do you have incident management processes in place and are they enacted in response to security incidents?"
-    dependsOnLots: SaaS, PaaS, IaaS, SCS
+    dependsOnLots: SaaS, PaaS, IaaS
     assuranceApproach: 2answers-type1
     fields:
       - type: boolean

--- a/service/security/personnel-security.yml
+++ b/service/security/personnel-security.yml
@@ -3,7 +3,7 @@ Personnel security:
     requirements: Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.
     filters: Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.
     hint: "What kind of personnel security do you apply to staff who have access to the service? Choose all that apply."
-    dependsOnLots: SaaS, PaaS, IaaS, SCS
+    dependsOnLots: SaaS, PaaS, IaaS
     assuranceApproach: 2answers-type1
     fields:
       - type: checkbox

--- a/service/security/supply-chain-security.yml
+++ b/service/security/supply-chain-security.yml
@@ -3,7 +3,7 @@ Supply-chain security:
     requirements: The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.
     filters: The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.
     hint: "Do you inform consumers how much of their information is shared with, or accessible by, third-party suppliers and their supply chains?"
-    dependsOnLots: SaaS, PaaS, IaaS, SCS
+    dependsOnLots: SaaS, PaaS, IaaS
     assuranceApproach: 2answers-type1
     fields:
       - type: boolean


### PR DESCRIPTION
- The security questions are no longer required if you are submitting an SCS service
- To avoid confusion, this commit removes any reference to SCS from the security questions, althought it does not have any functional implications
