### PR TITLE
Alphabetise checkboxes

### DIFF
--- a/service/service-type-SCS.yml
+++ b/service/service-type-SCS.yml
@@ -5,13 +5,13 @@ Service type:
     mockAnswer: Content management system
     fields:
       - type: checkbox
-        label: Planning
-      - type: checkbox
         label: Implementation
+      - type: checkbox
+        label: Ongoing support
+      - type: checkbox
+        label: Planning
       - type: checkbox
         label: Testing
       - type: checkbox
         label: Training
-      - type: checkbox
-        label: Ongoing support
     validationNotAnswered: "This question requires an answer."

--- a/service/service-type-SaaS.yml
+++ b/service/service-type-SaaS.yml
@@ -11,23 +11,25 @@ Service type:
       - type: checkbox
         label: Collaboration
       - type: checkbox
-        label: Telecoms
+        label: Creative and design
       - type: checkbox
         label: Customer relationship management (CRM)
       - type: checkbox
-        label: Creative and design
-      - type: checkbox
         label: Data management
       - type: checkbox
-        label: Sales
-      - type: checkbox
-        label: Software development tools
-      - type: checkbox
         label: Electronic document and records management (EDRM)
+      - type: checkbox
+        label: Energy and environment
+      - type: checkbox
+        label: Healthcare
       - type: checkbox
         label: Human resources and employee management
       - type: checkbox
         label: IT management
+      - type: checkbox
+        label: Legal
+      - type: checkbox
+        label: Libraries
       - type: checkbox
         label: Marketing
       - type: checkbox
@@ -35,17 +37,15 @@ Service type:
       - type: checkbox
         label: Project management and planning
       - type: checkbox
-        label: Security
-      - type: checkbox
-        label: Libraries
+        label: Sales
       - type: checkbox
         label: Schools and education
       - type: checkbox
-        label: Energy and environment
+        label: Security
       - type: checkbox
-        label: Healthcare
+        label: Software development tools
       - type: checkbox
-        label: Legal
+        label: Telecoms
       - type: checkbox
         label: Transport and logistics
     validationNotAnswered: "This question requires an answer."


### PR DESCRIPTION
The checkoboxes for the Service Type questions appear to be in random order,
which may confuse users (especially for SaaS which is a long list).

With no other obvious natural ordering obvious, alphabetical seems the best option.
