### PR TITLE
Add manifests for G-Cloud 6 and 7

### DIFF
--- a/frameworks/g-cloud-6/manifests/display_service.yml
+++ b/frameworks/g-cloud-6/manifests/display_service.yml
@@ -1,0 +1,177 @@
+-
+  name: Support
+  questions:
+    - supportTypes
+    - supportForThirdParties
+    - supportAvailability
+    - supportResponseTime
+    - incidentEscalation
+-
+  name: Open standards
+  questions:
+    - openStandardsSupported
+-
+  name: Onboarding and offboarding
+  questions:
+    - serviceOnboarding
+    - serviceOffboarding
+-
+  name: Analytics
+  questions:
+    - analyticsAvailable
+-
+  name: Cloud features
+  questions:
+    - elasticCloud
+    - guaranteedResources
+    - persistentStorage
+-
+  name: Provisioning
+  questions:
+    - selfServiceProvisioning
+    - provisioningTime
+    - deprovisioningTime
+-
+  name: Open source
+  questions:
+    - openSource
+-
+  name: Code libraries
+  questions:
+    - codeLibraryLanguages
+-
+  name: API access
+  questions:
+    - apiAccess
+    - apiType
+-
+  name: Networks and connectivity
+  questions:
+    - networksConnected
+-
+  name: Access
+  questions:
+    - supportedBrowsers
+    - offlineWorking
+    - supportedDevices
+-
+  name: Certifications
+  questions:
+    - vendorCertifications
+-
+  name: Identity standards
+  questions:
+    - identityStandards
+-
+  name: Data storage
+  questions:
+    - datacentresEUCode
+    - datacentresSpecifyLocation
+    - datacentreTier
+    - dataBackupRecovery
+    - dataExtractionRemoval
+-
+  name: Data-in-transit protection
+  questions:
+    - dataProtectionBetweenUserAndService
+    - dataProtectionWithinService
+    - dataProtectionBetweenServices
+-
+  name: Asset protection and resilience
+  questions:
+    - datacentreLocations
+    - dataManagementLocations
+    - legalJurisdiction
+    - datacentreProtectionDisclosure
+    - dataAtRestProtections
+    - dataSecureDeletion
+    - dataStorageMediaDisposal
+    - dataSecureEquipmentDisposal
+    - dataRedundantEquipmentAccountsRevoked
+    - serviceAvailabilityPercentage
+-
+  name: Separation between consumers
+  questions:
+    - cloudDeploymentModel
+    - otherConsumers
+    - servicesSeparation
+    - servicesManagementSeparation
+-
+  name: Governance
+  questions:
+    - governanceFramework
+-
+  name: Configuration and change management
+  questions:
+    - configurationTracking
+    - changeImpactAssessment
+-
+  name: Vulnerabilility management
+  questions:
+    - vulnerabilityAssessment
+    - vulnerabilityMonitoring
+    - vulnerabilityMitigationPrioritisation
+    - vulnerabilityTracking
+    - vulnerabilityTimescales
+-
+  name: Event monitoring
+  questions:
+    - eventMonitoring
+-
+  name: Incident management
+  questions:
+    - incidentManagementProcess
+    - incidentManagementReporting
+    - incidentDefinitionPublished
+-
+  name: Personnel security
+  questions:
+    - personnelSecurityChecks
+-
+  name: Secure development
+  questions:
+    - secureDevelopment
+    - secureDesign
+    - secureConfigurationManagement
+-
+  name: Supply-chain security
+  questions:
+    - thirdPartyDataSharingInformation
+    - thirdPartySecurityRequirements
+    - thirdPartyRiskAssessment
+    - thirdPartyComplianceMonitoring
+    - hardwareSoftwareVerification
+-
+  name: Authentication of consumers
+  questions:
+    - userAuthenticateManagement
+    - userAuthenticateSupport
+-
+  name: Separation and access control within management interfaces
+  questions:
+    - userAccessControlManagement
+    - restrictAdministratorPermissions
+    - managementInterfaceProtection
+-
+  name: Identity and authentication
+  questions:
+    - identityAuthenticationControls
+-
+  name: External interface protection
+  questions:
+    - onboardingGuidance
+    - interconnectionMethods
+-
+  name: Secure service administration
+  questions:
+    - serviceManagementModel
+-
+  name: Audit information provision to consumers
+  questions:
+    - auditInformationProvided
+-
+  name: Secure use of the service by the customer
+  questions:
+    - deviceAccessMethod
+    - serviceConfigurationGuidance
+    - trainingProvided

--- a/frameworks/g-cloud-6/manifests/edit_service.yml
+++ b/frameworks/g-cloud-6/manifests/edit_service.yml
@@ -1,0 +1,18 @@
+-
+  name: Service attributes
+  editable: false
+  questions:
+    - id
+    - lot
+-
+  name: Description
+  editable: edit
+  questions:
+    - serviceName
+    - serviceSummary
+-
+  name: Features and benefits
+  editable: edit
+  questions:
+    - serviceFeatures
+    - serviceBenefits

--- a/frameworks/g-cloud-6/manifests/edit_service_as_admin.yml
+++ b/frameworks/g-cloud-6/manifests/edit_service_as_admin.yml
@@ -1,0 +1,37 @@
+-
+  name: Service attributes
+  editable: false
+  questions:
+    - id
+    - lot
+-
+  name: Description
+  editable: true
+  questions:
+    - serviceName
+    - serviceSummary
+-
+  name: Features and benefits
+  editable: true
+  questions:
+    - serviceFeatures
+    - serviceBenefits
+-
+  name: Pricing
+  editable: true
+  questions:
+    - priceString
+    - vatIncluded
+    - educationPricing
+    - terminationCost
+    - trialOption
+    - freeOption
+    - minimumContractPeriod
+-
+  name: Documents
+  editable: true
+  questions:
+    - serviceDefinitionDocumentURL
+    - termsAndConditionsDocumentURL
+    - sfiaRateDocumentURL
+    - pricingDocumentURL

--- a/frameworks/g-cloud-6/manifests/search_filters.yml
+++ b/frameworks/g-cloud-6/manifests/search_filters.yml
@@ -1,0 +1,37 @@
+-
+  name: Categories
+  questions:
+    - serviceTypesSCS
+    - serviceTypesSaaS
+    - serviceTypesIaaS
+-
+  name: Pricing
+  questions:
+    - freeOption
+    - trialOption
+-
+  name: Minimum contract period
+  questions:
+    - minimumContractPeriod
+-
+  name: Service management
+  questions:
+    - dataExtractionRemoval
+    - datacentresEUCode
+    - dataBackupRecovery
+    - selfServiceProvisioning
+    - supportForThirdParties
+-
+  name: Datacentre tier
+  questions:
+    - datacentreTier
+-
+  name: Networks the service is directly connected to
+  questions:
+    - networksConnected
+-
+  name: Interoperability
+  questions:
+    - apiAccess
+    - openStandardsSupported
+    - openSource

--- a/frameworks/g-cloud-6/questions/services/analyticsAvailable.yml
+++ b/frameworks/g-cloud-6/questions/services/analyticsAvailable.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Real-time management information available'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Real-time management information available'

--- a/frameworks/g-cloud-6/questions/services/apiAccess.yml
+++ b/frameworks/g-cloud-6/questions/services/apiAccess.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'API access available and supported'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'API access available and supported'

--- a/frameworks/g-cloud-6/questions/services/apiType.yml
+++ b/frameworks/g-cloud-6/questions/services/apiType.yml
@@ -1,0 +1,21 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: 'Examples of API include RESTful and SOAP.'
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'API type must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "API type can't be more than 200 characters."
+question: 'API type'
+optional: true

--- a/frameworks/g-cloud-6/questions/services/auditInformationProvided.yml
+++ b/frameworks/g-cloud-6/questions/services/auditInformationProvided.yml
@@ -1,0 +1,29 @@
+requirements: 'Consumers are aware of the audit information that will be provided to them, how and when it will be made available to them, the format of the data, and the retention period associated with it.'
+filters: 'Consumers are aware of the audit information that will be provided to them, how and when it will be made available to them, the format of the data, and the retention period associated with it.'
+hint: 'Do you provide audit information to consumers? Choose 1.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: radios
+options:
+    -
+        label: None
+    -
+        label: 'Data made available'
+        filterLabel: 'Data made available'
+    -
+        label: 'Data made available by negotiation'
+        filterLabel: 'Data made available by negotiation'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Audit information provided'

--- a/frameworks/g-cloud-6/questions/services/changeImpactAssessment.yml
+++ b/frameworks/g-cloud-6/questions/services/changeImpactAssessment.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that changes to the service are assessed for potential security impact. Changes are managed and tracked through to completion.'
+filters: 'Consumers should have confidence that changes to the service are assessed for potential security impact. Changes are managed and tracked through to completion.'
+hint: 'Are changes to the service assessed for potential security impact, and are changes managed and tracked through to completion?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Change impact assessment'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Change impact assessment'

--- a/frameworks/g-cloud-6/questions/services/cloudDeploymentModel.yml
+++ b/frameworks/g-cloud-6/questions/services/cloudDeploymentModel.yml
@@ -1,0 +1,33 @@
+requirements: 'Service providers must state whether the service is a public, private or community cloud service.'
+filters: 'Service providers must state whether the service is a public, private or community cloud service.'
+hint: 'Is the service a public, private, community or hybrid cloud service?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: radios
+options:
+    -
+        label: 'Public cloud'
+        filterLabel: 'Public cloud'
+    -
+        label: 'Community cloud'
+        filterLabel: 'Community cloud'
+    -
+        label: 'Private cloud'
+        filterLabel: 'Private cloud'
+    -
+        label: 'Hybrid cloud'
+        filterLabel: 'Hybrid cloud'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Cloud deployment model'

--- a/frameworks/g-cloud-6/questions/services/codeLibraryLanguages.yml
+++ b/frameworks/g-cloud-6/questions/services/codeLibraryLanguages.yml
@@ -1,0 +1,21 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) '
+listItemName: 'code libraries example'
+type: list
+addthing: 'Add another code library'
+validations:
+  -
+    name: under_10_words
+    message: 'Each code library must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer code libraries.'
+  -
+    name: under_character_limit
+    message: 'Each code library must be no more than 100 characters.'
+question: 'Languages your code libraries are written in'
+optional: true

--- a/frameworks/g-cloud-6/questions/services/configurationTracking.yml
+++ b/frameworks/g-cloud-6/questions/services/configurationTracking.yml
@@ -1,0 +1,20 @@
+requirements: 'Consumers should have confidence that the status, location and configuration of service components (including hardware and software components) are tracked throughout their lifetime within the service.'
+filters: 'Consumers should have confidence that the status, location and configuration of service components (including hardware and software components) are tracked throughout their lifetime within the service.'
+hint: 'Do you track the status, location and configuration of service components throughout their lifetime?'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Configuration and change management tracking'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Configuration and change management tracking'

--- a/frameworks/g-cloud-6/questions/services/dataAtRestProtections.yml
+++ b/frameworks/g-cloud-6/questions/services/dataAtRestProtections.yml
@@ -1,0 +1,38 @@
+requirements: 'Consumers should have sufficient confidence that storage media containing their data is protected from unauthorised access.'
+filters: 'Consumers should have sufficient confidence that storage media containing their data is protected from unauthorised access.'
+hint: 'How is storage media containing consumer data protected from unauthorised physical access? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type1
+type: checkboxes
+options:
+    -
+        label: 'CPA Foundation-grade assured components'
+        filterLabel: 'CPA Foundation-grade assured components'
+    -
+        label: 'FIPS-assured encryption'
+        filterLabel: 'FIPS-assured encryption'
+    -
+        label: 'Other encryption'
+        filterLabel: 'Other encryption'
+    -
+        label: 'Secure containers, racks or cages'
+        filterLabel: 'Secure containers, racks or cages'
+    -
+        label: 'Physical access control'
+        filterLabel: 'Physical access control'
+    -
+        label: 'No protection'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Data-at-rest protection'

--- a/frameworks/g-cloud-6/questions/services/dataBackupRecovery.yml
+++ b/frameworks/g-cloud-6/questions/services/dataBackupRecovery.yml
@@ -1,0 +1,16 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+servicePageLabel: 'Backup, disaster recovery and resilience plan in place'
+hint: 'You can provide more detail on your disaster recovery plan in your service definition document.'
+type: boolean
+filterLabel: 'Backup, disaster recovery and resilience plan in place'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Backup, disaster recovery and resilience plan in place'

--- a/frameworks/g-cloud-6/questions/services/dataExtractionRemoval.yml
+++ b/frameworks/g-cloud-6/questions/services/dataExtractionRemoval.yml
@@ -1,0 +1,15 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+servicePageLabel: 'Data extraction/removal plan in place'
+type: boolean
+filterLabel: 'Data extraction/removal plan in place'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Data extraction/removal plan in place'

--- a/frameworks/g-cloud-6/questions/services/dataManagementLocations.yml
+++ b/frameworks/g-cloud-6/questions/services/dataManagementLocations.yml
@@ -1,0 +1,35 @@
+requirements: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
+filters: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
+hint: 'Where are the services managed from? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: checkboxes
+options:
+    -
+        label: UK
+        filterLabel: UK
+    -
+        label: EU
+        filterLabel: EU
+    -
+        label: 'USA - Safe Harbor'
+        filterLabel: 'USA - Safe Harbor'
+    -
+        label: 'Other countries with data protection treaties'
+        filterLabel: 'Other countries with data protection treaties'
+    -
+        label: 'Rest of world'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Data management location'

--- a/frameworks/g-cloud-6/questions/services/dataProtectionBetweenServices.yml
+++ b/frameworks/g-cloud-6/questions/services/dataProtectionBetweenServices.yml
@@ -1,0 +1,37 @@
+requirements: 'Data in transit is protected between the service and other services (eg where APIs are exposed)'
+filters: 'Data in transit is protected between the service and other services (eg where APIs are exposed)'
+hint: 'Choose all that apply'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type1
+type: checkboxes
+options:
+    -
+        label: 'Encrypted PSN service'
+        filterLabel: 'Encrypted PSN service'
+    -
+        label: 'PSN service'
+        filterLabel: 'PSN service'
+    -
+        label: 'CPA Foundation VPN Gateway'
+        filterLabel: 'CPA Foundation VPN Gateway'
+    -
+        label: 'VPN using TLS, version 1.2 or later'
+        filterLabel: 'VPN using TLS, version 1.2 or later'
+    -
+        label: 'VPN using legacy SSL or TLS'
+        filterLabel: 'VPN using legacy SSL or TLS'
+    -
+        label: 'No encryption'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Data protection between services'

--- a/frameworks/g-cloud-6/questions/services/dataProtectionBetweenUserAndService.yml
+++ b/frameworks/g-cloud-6/questions/services/dataProtectionBetweenUserAndService.yml
@@ -1,0 +1,38 @@
+requirements: 'Data in transit is protected between the user’s devices and the service'
+filters: 'Data in transit is protected between the user’s devices and the service'
+hint: 'Choose all that apply'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type1
+type: checkboxes
+options:
+    -
+        label: 'Encrypted PSN service'
+        filterLabel: 'Encrypted PSN service'
+    -
+        label: 'PSN service'
+        filterLabel: 'PSN service'
+    -
+        label: 'CPA Foundation VPN Gateway'
+        filterLabel: 'CPA Foundation VPN Gateway'
+    -
+        label: 'VPN using TLS, version 1.2 or later'
+        filterLabel: 'VPN using TLS, version 1.2 or later'
+    -
+        label: 'VPN using legacy SSL or TLS'
+        filterLabel: 'VPN using legacy SSL or TLS'
+    -
+        label: 'No encryption'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Data protection between user device and service'

--- a/frameworks/g-cloud-6/questions/services/dataProtectionWithinService.yml
+++ b/frameworks/g-cloud-6/questions/services/dataProtectionWithinService.yml
@@ -1,0 +1,37 @@
+requirements: 'Data in transit is protected internally within the service'
+filters: 'Data in transit is protected internally within the service'
+hint: 'Choose all that apply'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type1
+type: checkboxes
+options:
+    -
+        label: 'VPN using TLS, version 1.2 or later'
+        filterLabel: 'VPN using TLS, version 1.2 or later'
+    -
+        label: 'VPN using legacy SSL or TLS'
+        filterLabel: 'VPN using legacy SSL or TLS'
+    -
+        label: VLAN
+        filterLabel: VLAN
+    -
+        label: 'Bonded fibre optic connections'
+        filterLabel: 'Bonded fibre optic connections'
+    -
+        label: 'Other network protection'
+        filterLabel: 'Other network protection'
+    -
+        label: 'No encryption'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Data protection within service'

--- a/frameworks/g-cloud-6/questions/services/dataRedundantEquipmentAccountsRevoked.yml
+++ b/frameworks/g-cloud-6/questions/services/dataRedundantEquipmentAccountsRevoked.yml
@@ -1,0 +1,20 @@
+requirements: 'Consumers should be sufficiently confident that accounts or credentials specific to redundant equipment are revoked to reduce their value to an attacker.'
+filters: 'Consumers should be sufficiently confident that accounts or credentials specific to redundant equipment are revoked to reduce their value to an attacker.'
+hint: 'Are accounts or credentials specific to redundant equipment revoked to reduce their value to an attacker?'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: boolean
+filterLabel: 'Redundant equipment accounts revoked'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Redundant equipment accounts revoked'

--- a/frameworks/g-cloud-6/questions/services/dataSecureDeletion.yml
+++ b/frameworks/g-cloud-6/questions/services/dataSecureDeletion.yml
@@ -1,0 +1,32 @@
+requirements: 'Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.'
+filters: 'Consumers should be sufficiently confident that their data is erased when resources are moved or re-provisioned, when they leave the service or when they request it to be erased.'
+hint: 'How do you erase consumer data when resources are moved or re-provisioned, or when the consumer leaves the service, or when they request it to be erased? Choose 1.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type1
+type: radios
+options:
+    -
+        label: 'CPA Foundation-grade erasure product'
+        filterLabel: 'CPA Foundation-grade erasure product'
+    -
+        label: 'CESG or CPNI-approved erasure process'
+        filterLabel: 'CESG or CPNI-approved erasure process'
+    -
+        label: 'Other secure erasure process'
+        filterLabel: 'Other secure erasure process'
+    -
+        label: 'Other erasure process'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Secure data deletion'

--- a/frameworks/g-cloud-6/questions/services/dataSecureEquipmentDisposal.yml
+++ b/frameworks/g-cloud-6/questions/services/dataSecureEquipmentDisposal.yml
@@ -1,0 +1,20 @@
+requirements: 'Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).'
+filters: 'Consumers should be sufficiently confident that all equipment potentially containing consumer data, credentials, or configuration information for the service is identified at the end of its life (or prior to being recycled).'
+hint: 'Is all equipment potentially containing consumer data, credentials or configuration information identified at the end of its life or prior to being recycled? Choose 1.'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type2
+type: boolean
+filterLabel: 'Secure equipment disposal'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Secure equipment disposal'

--- a/frameworks/g-cloud-6/questions/services/dataStorageMediaDisposal.yml
+++ b/frameworks/g-cloud-6/questions/services/dataStorageMediaDisposal.yml
@@ -1,0 +1,40 @@
+requirements: 'Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life'
+filters: 'Consumers should be sufficiently confident that storage media which has held consumer data is sanitised or securely destroyed at the end of its life'
+hint: 'How is storage media containing consumer data sanitised or securely destroyed at the end of its usable lifetime? Choose 1.'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 5answers-type1
+type: radios
+options:
+    -
+        label: 'CESG-assured destruction service (CAS(T))'
+        filterLabel: 'CESG-assured destruction service (CAS(T))'
+    -
+        label: 'CPA Foundation-assured product'
+        filterLabel: 'CPA Foundation-assured product'
+    -
+        label: 'CPNI-approved destruction service'
+        filterLabel: 'CPNI-approved destruction service'
+    -
+        label: 'BS EN 151713:2009-compliant destruction'
+        filterLabel: 'BS EN 151713:2009-compliant destruction'
+    -
+        label: 'CESG or CPNI-approved erasure process'
+        filterLabel: 'CESG or CPNI-approved erasure process'
+    -
+        label: 'Other secure erasure process'
+        filterLabel: 'Other secure erasure process'
+    -
+        label: 'Other destruction/erasure process'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Storage media disposal'

--- a/frameworks/g-cloud-6/questions/services/datacentreLocations.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentreLocations.yml
@@ -1,0 +1,35 @@
+requirements: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
+filters: 'The geographic location(s) where consumer data is stored, processed or managed from (to country level)'
+hint: 'Where are the service provider''s datacentres located? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: checkboxes
+options:
+    -
+        label: UK
+        filterLabel: UK
+    -
+        label: EU
+        filterLabel: EU
+    -
+        label: 'USA - Safe Harbor'
+        filterLabel: 'USA - Safe Harbor'
+    -
+        label: 'Other countries with data protection treaties'
+        filterLabel: 'Other countries with data protection treaties'
+    -
+        label: 'Rest of world'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Datacentre location'

--- a/frameworks/g-cloud-6/questions/services/datacentreProtectionDisclosure.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentreProtectionDisclosure.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.'
+filters: 'Consumers should be confident that the physical security measures employed by the provider are sufficient for their intended use of the service.'
+hint: 'Do you tell your consumers what physical security your datacentres have?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: boolean
+filterLabel: 'Datacentre protection'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Datacentre protection'

--- a/frameworks/g-cloud-6/questions/services/datacentreTier.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentreTier.yml
@@ -1,0 +1,42 @@
+hint: 'Choose one'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+servicePageLabel: 'Datacentre tier'
+type: radios
+options:
+    -
+        label: 'TIA-942 Tier 1'
+        filterLabel: 'TIA-942 Tier 1 datacentre'
+    -
+        label: 'TIA-942 Tier 2'
+        filterLabel: 'TIA-942 Tier 2 datacentre'
+    -
+        label: 'TIA-942 Tier 3'
+        filterLabel: 'TIA-942 Tier 3 datacentre'
+    -
+        label: 'TIA-942 Tier 4'
+        filterLabel: 'TIA-942 Tier 4 datacentre'
+    -
+        label: 'Uptime Institute Tier 1'
+        filterLabel: 'Uptime Institute Tier 1 datacentre'
+    -
+        label: 'Uptime Institute Tier 2'
+        filterLabel: 'Uptime Institute Tier 2 datacentre'
+    -
+        label: 'Uptime Institute Tier 3'
+        filterLabel: 'Uptime Institute Tier 3 datacentre'
+    -
+        label: 'Uptime Institute Tier 4'
+        filterLabel: 'Uptime Institute Tier 4 datacentre'
+    -
+        label: 'None of the above'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Datacentre tier'

--- a/frameworks/g-cloud-6/questions/services/datacentresEUCode.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentresEUCode.yml
@@ -1,0 +1,15 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+servicePageLabel: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'
+type: boolean
+filterLabel: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'

--- a/frameworks/g-cloud-6/questions/services/datacentresSpecifyLocation.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentresSpecifyLocation.yml
@@ -1,0 +1,15 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+servicePageLabel: 'User-defined data location'
+type: boolean
+filterLabel: 'User-defined data location'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'User-defined data location'

--- a/frameworks/g-cloud-6/questions/services/deprovisioningTime.yml
+++ b/frameworks/g-cloud-6/questions/services/deprovisioningTime.yml
@@ -1,0 +1,20 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: ""
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Deprovisioning time must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Deprovisioning time can't be more than 200 characters."
+question: 'Service deprovisioning time'

--- a/frameworks/g-cloud-6/questions/services/deviceAccessMethod.yml
+++ b/frameworks/g-cloud-6/questions/services/deviceAccessMethod.yml
@@ -1,0 +1,30 @@
+requirements: 'The consumer understands any service configuration options available to them and the security implications of choices they make.'
+filters: 'The consumer understands any service configuration options available to them and the security implications of choices they make.'
+hint: 'Which end devices are the cloud service accessible from? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: checkboxes
+options:
+    -
+        label: 'Corporate/enterprise devices'
+        filterLabel: 'Corporate/enterprise devices'
+    -
+        label: 'Partner devices'
+        filterLabel: 'Partner devices'
+    -
+        label: 'Unknown devices'
+        filterLabel: 'Unknown devices'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Device access method'

--- a/frameworks/g-cloud-6/questions/services/educationPricing.yml
+++ b/frameworks/g-cloud-6/questions/services/educationPricing.yml
@@ -1,0 +1,16 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'Do you offer special pricing for educational organisations?'
+type: boolean
+filterLabel: 'Education pricing'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Education pricing'

--- a/frameworks/g-cloud-6/questions/services/elasticCloud.yml
+++ b/frameworks/g-cloud-6/questions/services/elasticCloud.yml
@@ -1,0 +1,15 @@
+hint: 'Elasticity is similar to scalability. An elastic cloud environment can automatically expand and contract to meet business needs in real time.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Elastic cloud approach supported'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Elastic cloud approach supported'

--- a/frameworks/g-cloud-6/questions/services/eventMonitoring.yml
+++ b/frameworks/g-cloud-6/questions/services/eventMonitoring.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that events generated in service components required to support effective identification of suspicious activity are collected and fed into an analysis system.'
+filters: 'Consumers should have confidence that events generated in service components required to support effective identification of suspicious activity are collected and fed into an analysis system.'
+hint: 'Do you conduct event monitoring and analysis to identify suspicious activity?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Event monitoring'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Event monitoring'

--- a/frameworks/g-cloud-6/questions/services/freeOption.yml
+++ b/frameworks/g-cloud-6/questions/services/freeOption.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Free option'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Free option'

--- a/frameworks/g-cloud-6/questions/services/governanceFramework.yml
+++ b/frameworks/g-cloud-6/questions/services/governanceFramework.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.'
+filters: 'The consumer should have sufficient confidence that the governance framework and processes in place for the service are appropriate for their intended use of it.'
+hint: 'Do you have a governance framework and process in place for the service, eg ISO27001:2013?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Governance framework'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Governance framework'

--- a/frameworks/g-cloud-6/questions/services/guaranteedResources.yml
+++ b/frameworks/g-cloud-6/questions/services/guaranteedResources.yml
@@ -1,0 +1,15 @@
+hint: 'Guaranteed resources are a stated minimum of memory, CPU and disk size or space.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Guaranteed resources defined'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Guaranteed resources defined'

--- a/frameworks/g-cloud-6/questions/services/hardwareSoftwareVerification.yml
+++ b/frameworks/g-cloud-6/questions/services/hardwareSoftwareVerification.yml
@@ -1,0 +1,20 @@
+requirements: 'The consumer understands and accepts how the service provider verifies that hardware and software used in the service is genuine and has not been tampered with.'
+filters: 'The consumer understands and accepts how the service provider verifies that hardware and software used in the service is genuine and has not been tampered with.'
+hint: 'Do you verify that the hardware and software used in the service are genuine and have not been obviously tampered with?'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Hardware and software verification'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Hardware and software verification'

--- a/frameworks/g-cloud-6/questions/services/id.yml
+++ b/frameworks/g-cloud-6/questions/services/id.yml
@@ -1,0 +1,2 @@
+question: 'Service ID'
+type: service_id

--- a/frameworks/g-cloud-6/questions/services/identityAuthenticationControls.yml
+++ b/frameworks/g-cloud-6/questions/services/identityAuthenticationControls.yml
@@ -1,0 +1,41 @@
+requirements: 'Consumers should have sufficient confidence that identity and authentication controls ensure users are authorised to access specific interfaces.'
+filters: 'Consumers should have sufficient confidence that identity and authentication controls ensure users are authorised to access specific interfaces.'
+hint: 'How do your identity and authentication controls ensure that users are authorised to access specific interfaces? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type3
+type: checkboxes
+options:
+    -
+        label: 'Username and two-factor authentication'
+        filterLabel: 'Username and two-factor authentication'
+    -
+        label: 'Username and TLS client certificate'
+        filterLabel: 'Username and TLS client certificate'
+    -
+        label: 'Authentication federation'
+        filterLabel: 'Authentication federation'
+    -
+        label: 'Limited access over dedicated link, enterprise or community network'
+        filterLabel: 'Limited access over dedicated link, enterprise or community network'
+    -
+        label: 'Username and password'
+        filterLabel: 'Username and password'
+    -
+        label: 'Username and strong password/passphrase enforcement'
+        filterLabel: 'Username and strong password/passphrase enforcement'
+    -
+        label: 'Other mechanism'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Identity and authentication controls'

--- a/frameworks/g-cloud-6/questions/services/identityStandards.yml
+++ b/frameworks/g-cloud-6/questions/services/identityStandards.yml
@@ -1,0 +1,21 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
+listItemName: 'identity standards example'
+type: list
+addthing: 'Add another standard'
+validations:
+  -
+    name: under_10_words
+    message: 'Each identity standard must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer identity standards.'
+  -
+    name: under_character_limit
+    message: 'Each identity standard must be no more than 100 characters.'
+question: 'Identity standards your service uses'
+optional: true

--- a/frameworks/g-cloud-6/questions/services/incidentDefinitionPublished.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentDefinitionPublished.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that a defined process and contact route exists for reporting of security incidents by consumers and external entities.'
+filters: 'Consumers should have confidence that a defined process and contact route exists for reporting of security incidents by consumers and external entities.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+hint: 'Do you publish to consumers your definition of a security incident, along with the format, incident triggers and timescales for reporting such incidents?'
+type: boolean
+filterLabel: 'Security incident definition published'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Security incident definition published'

--- a/frameworks/g-cloud-6/questions/services/incidentEscalation.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentEscalation.yml
@@ -1,0 +1,15 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: boolean
+filterLabel: 'Incident escalation process available'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Incident escalation process available'

--- a/frameworks/g-cloud-6/questions/services/incidentManagementProcess.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentManagementProcess.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.'
+filters: 'Consumers should have confidence that incident management processes are in place for the service and are enacted in response to security incidents.'
+hint: 'Do you have incident management processes in place and are they enacted in response to security incidents?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Incident management processes'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Incident management processes'

--- a/frameworks/g-cloud-6/questions/services/incidentManagementReporting.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentManagementReporting.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that pre-defined processes are in place for responding to common types of incident and attack.'
+filters: 'Consumers should have confidence that pre-defined processes are in place for responding to common types of incident and attack.'
+hint: 'Do you have a defined process for reporting security incidents experienced by consumers and external entities?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Consumer reporting of security incidents'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Consumer reporting of security incidents'

--- a/frameworks/g-cloud-6/questions/services/interconnectionMethods.yml
+++ b/frameworks/g-cloud-6/questions/services/interconnectionMethods.yml
@@ -1,0 +1,32 @@
+requirements: 'The consumer understands what physical and logical interfaces their information is available from.'
+filters: 'The consumer understands what physical and logical interfaces their information is available from.'
+hint: 'What method of interconnection to the service do you provide? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: checkboxes
+options:
+    -
+        label: 'Encrypted PSN service'
+        filterLabel: 'Encrypted PSN service'
+    -
+        label: 'PSN service'
+        filterLabel: 'PSN service'
+    -
+        label: 'Private WAN'
+        filterLabel: 'Private WAN'
+    -
+        label: Internet
+        filterLabel: Internet
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Interconnection method provided'

--- a/frameworks/g-cloud-6/questions/services/legalJurisdiction.yml
+++ b/frameworks/g-cloud-6/questions/services/legalJurisdiction.yml
@@ -1,0 +1,35 @@
+requirements: 'The legal jurisdiction(s) in which the service provider operates'
+filters: 'The legal jurisdiction(s) in which the service provider operates'
+hint: 'Choose 1'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: radios
+options:
+    -
+        label: UK
+        filterLabel: UK
+    -
+        label: EU
+        filterLabel: EU
+    -
+        label: 'USA - Safe Harbor'
+        filterLabel: 'USA - Safe Harbor'
+    -
+        label: 'Other countries with data protection treaties'
+        filterLabel: 'Other countries with data protection treaties'
+    -
+        label: 'Rest of world'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Legal jurisdiction of service provider'

--- a/frameworks/g-cloud-6/questions/services/lot.yml
+++ b/frameworks/g-cloud-6/questions/services/lot.yml
@@ -1,0 +1,32 @@
+question: 'Service type'
+type: radios
+options:
+  -
+    label: Infrastructure as a Service (IaaS)
+    value: IaaS
+    description: >
+      Infrastructure is the hardware that makes software work. It’s the
+      networks, hosting facilities and servers that platforms and software
+      depend on. IaaS is infrastructure you can order and run entirely over
+      the internet, without having to pay for your own hardware.
+  -
+    label: Software as a Service (SaaS)
+    value: SaaS
+    description: >
+      SaaS is an application or service that can be run over the internet or
+      in the cloud. Examples of SaaS include web-based email services,
+      customer relationship management (CRM) software and analytics tools.
+  -
+    label: Platform as a Service (PaaS)
+    value: PaaS
+    description: >
+      PaaS is a software platform that provides a basis for building other
+      services and applications. With PaaS, you can set up, order, pay for
+      and manage platforms in the cloud.
+  -
+    label: Specialist Cloud Services (SCS)
+    value: SCS
+    description: >
+      Specialist Cloud Services support your transition to SaaS, PaaS and
+      IaaS. Examples of SCS include cloud strategy, data transfer between
+      providers, or day-to-day support of cloud-based services.

--- a/frameworks/g-cloud-6/questions/services/managementInterfaceProtection.yml
+++ b/frameworks/g-cloud-6/questions/services/managementInterfaceProtection.yml
@@ -1,0 +1,20 @@
+requirements: 'The consumer understands how management interfaces are protected (see Principle 11) and what functionality is available via those interfaces.'
+filters: 'The consumer understands how management interfaces are protected (see Principle 11) and what functionality is available via those interfaces.'
+hint: 'Do you tell consumers what functionality and protection is available for management interfaces?'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type2
+type: boolean
+filterLabel: 'Management interface protection'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Management interface protection'

--- a/frameworks/g-cloud-6/questions/services/minimumContractPeriod.yml
+++ b/frameworks/g-cloud-6/questions/services/minimumContractPeriod.yml
@@ -1,0 +1,29 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: radios
+options:
+    -
+        label: Hour
+        filterLabel: Hour
+    -
+        label: Day
+        filterLabel: Day
+    -
+        label: Month
+        filterLabel: Month
+    -
+        label: Year
+        filterLabel: Year
+    -
+        label: Other
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Minimum contract period'

--- a/frameworks/g-cloud-6/questions/services/networksConnected.yml
+++ b/frameworks/g-cloud-6/questions/services/networksConnected.yml
@@ -1,0 +1,35 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: 'Choose all that apply.'
+type: checkboxes
+options:
+    -
+        label: Internet
+        filterLabel: Internet
+    -
+        label: 'Public Services Network (PSN)'
+        filterLabel: 'Public Services Network (PSN)'
+    -
+        label: 'Government Secure intranet (GSi)'
+        filterLabel: 'Government Secure intranet (GSi)'
+    -
+        label: 'Police National Network (PNN)'
+        filterLabel: 'Police National Network (PNN)'
+    -
+        label: 'New NHS Network (N3)'
+        filterLabel: 'New NHS Network (N3)'
+    -
+        label: 'Joint Academic Network (JANET)'
+        filterLabel: 'Joint Academic Network (JANET)'
+    -
+        label: Other
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Networks the service is directly connected to'

--- a/frameworks/g-cloud-6/questions/services/offlineWorking.yml
+++ b/frameworks/g-cloud-6/questions/services/offlineWorking.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Offline working and syncing supported'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Offline working and syncing supported'

--- a/frameworks/g-cloud-6/questions/services/onboardingGuidance.yml
+++ b/frameworks/g-cloud-6/questions/services/onboardingGuidance.yml
@@ -1,0 +1,20 @@
+requirements: 'The consumer understands how to safely connect to the service whilst minimising risk to the consumer’s systems.'
+filters: 'The consumer understands how to safely connect to the service whilst minimising risk to the consumer’s systems.'
+hint: 'Do you provide onboarding guidance covering secure connection to the service?'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Onboarding guidance provided'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Onboarding guidance provided'

--- a/frameworks/g-cloud-6/questions/services/openSource.yml
+++ b/frameworks/g-cloud-6/questions/services/openSource.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Open-source software used and supported'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Open-source software used and supported'

--- a/frameworks/g-cloud-6/questions/services/openStandardsSupported.yml
+++ b/frameworks/g-cloud-6/questions/services/openStandardsSupported.yml
@@ -1,0 +1,15 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: 'Take a look at the [GOV.UK Open Standards principles](https://www.gov.uk/government/publications/open-standards-for-government) for more information on open standards.'
+type: boolean
+filterLabel: 'Open standards supported and documented'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Open standards supported and documented'

--- a/frameworks/g-cloud-6/questions/services/otherConsumers.yml
+++ b/frameworks/g-cloud-6/questions/services/otherConsumers.yml
@@ -1,0 +1,32 @@
+requirements: 'Consumers should understand the types of consumer they share the service or platform with.'
+filters: 'Consumers should understand the types of consumer they share the service or platform with.'
+hint: 'What types of other consumer do you share the service or platform with?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: radios
+options:
+    -
+        label: 'No other consumer'
+        filterLabel: 'No other consumer'
+    -
+        label: 'Only government consumers'
+        filterLabel: 'Only government consumers'
+    -
+        label: 'A specific consumer group, eg Police, Defence or Health'
+        filterLabel: 'A specific consumer group, eg Police, Defence or Health'
+    -
+        label: 'Anyone - public'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Type of consumer'

--- a/frameworks/g-cloud-6/questions/services/persistentStorage.yml
+++ b/frameworks/g-cloud-6/questions/services/persistentStorage.yml
@@ -1,0 +1,15 @@
+hint: 'Storage is persistent if recorded data is available indefinitely.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Persistent storage supported'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Persistent storage supported'

--- a/frameworks/g-cloud-6/questions/services/personnelSecurityChecks.yml
+++ b/frameworks/g-cloud-6/questions/services/personnelSecurityChecks.yml
@@ -1,0 +1,33 @@
+requirements: 'Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.'
+filters: 'Consumers should be content with the level of security screening conducted on service provider staff with access to their information or with ability to affect their service.'
+hint: 'What kind of personnel security do you apply to staff who have access to the service? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: checkboxes
+options:
+    -
+        label: 'Security clearance national vetting (SC)'
+        filterLabel: 'Security clearance national vetting (SC)'
+    -
+        label: 'Baseline personnel security standard (BPSS)'
+        filterLabel: 'Baseline personnel security standard (BPSS)'
+    -
+        label: 'Background checks in accordance with BS7858:2012'
+        filterLabel: 'Background checks in accordance with BS7858:2012'
+    -
+        label: 'Employment checks'
+        filterLabel: 'Employment checks'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Personnel security checks'

--- a/frameworks/g-cloud-6/questions/services/priceString.yml
+++ b/frameworks/g-cloud-6/questions/services/priceString.yml
@@ -1,0 +1,30 @@
+hint: 'This is an indicative price. Users will be able to refer to your pricing document for more information.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+validations:
+  -
+    name: no_min_price_specified
+    message: 'Minimum price requires an answer.'
+  -
+    name: no_unit_specified
+    message: 'Pricing unit requires an answer. If none of the provided units apply, please choose ''Unit''.'
+  -
+    name: min_price_not_a_number
+    message: 'Minimum price must be a number, without units, eg 99.95'
+  -
+    name: max_price_not_a_number
+    message: 'Maximum price must be a number, without units, eg 99.95'
+  -
+    name: max_less_than_min
+    message: 'Minimum price must be less than maximum price'
+  -
+    name: price_string_can_be_composed
+    message: 'An error has occured'
+type: pricing
+question: 'Service price'

--- a/frameworks/g-cloud-6/questions/services/pricingDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/pricingDocumentURL.yml
@@ -1,0 +1,24 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'Please upload your pricing document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+type: upload
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: file_is_open_document_format
+    message: 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
+  -
+    name: file_is_less_than_5mb
+    message: 'Your document exceeds the 5MB limit. Please reduce file size.'
+  -
+    name: file_can_be_saved
+    message: 'Your document failed to upload. Please try again.'
+question: 'Pricing document'

--- a/frameworks/g-cloud-6/questions/services/provisioningTime.yml
+++ b/frameworks/g-cloud-6/questions/services/provisioningTime.yml
@@ -1,0 +1,20 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: 'How long does it take to get your service up and running? eg 1 to 5 hours or 2 to 3 days. (Maximum 20 words.)'
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Provisioning time must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Provisioning time can't be more than 200 characters."
+question: 'Service provisioning time'

--- a/frameworks/g-cloud-6/questions/services/restrictAdministratorPermissions.yml
+++ b/frameworks/g-cloud-6/questions/services/restrictAdministratorPermissions.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer can manage the risks of their own privileged access, e.g. through ‘principle of least privilege’, providing the ability to constrain permissions given to consumer administrators.'
+filters: 'The consumer can manage the risks of their own privileged access, e.g. through ‘principle of least privilege’, providing the ability to constrain permissions given to consumer administrators.'
+hint: 'Can consumers restrict permissions given to their administrators?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type2
+type: boolean
+filterLabel: 'Administrator permissions'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Administrator permissions'

--- a/frameworks/g-cloud-6/questions/services/secureConfigurationManagement.yml
+++ b/frameworks/g-cloud-6/questions/services/secureConfigurationManagement.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should be sufficiently confident that configuration management processes are in place to ensure the integrity of the solution through development, testing and deployment.'
+filters: 'Consumers should be sufficiently confident that configuration management processes are in place to ensure the integrity of the solution through development, testing and deployment.'
+hint: 'Do you have configuration management in place to ensure the integrity of the service through development, testing and deployment?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Software configuration management'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Software configuration management'

--- a/frameworks/g-cloud-6/questions/services/secureDesign.yml
+++ b/frameworks/g-cloud-6/questions/services/secureDesign.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should be sufficiently confident that development is carried out in line with industry good practice regarding secure design, coding, testing and deployment.'
+filters: 'Consumers should be sufficiently confident that development is carried out in line with industry good practice regarding secure design, coding, testing and deployment.'
+hint: 'Is development carried out in line with industry good practice regarding secure design, coding, testing and deployment?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Secure design, coding, testing and deployment'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Secure design, coding, testing and deployment'

--- a/frameworks/g-cloud-6/questions/services/secureDevelopment.yml
+++ b/frameworks/g-cloud-6/questions/services/secureDevelopment.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should be sufficiently confident that new and evolving threats are reviewed and the service improved in line with them.'
+filters: 'Consumers should be sufficiently confident that new and evolving threats are reviewed and the service improved in line with them.'
+hint: 'Are new and evolving threats reviewed and your services improved accordingly?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Secure development'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Secure development'

--- a/frameworks/g-cloud-6/questions/services/selfServiceProvisioning.yml
+++ b/frameworks/g-cloud-6/questions/services/selfServiceProvisioning.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Self-service provisioning supported'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Self-service provisioning supported'

--- a/frameworks/g-cloud-6/questions/services/serviceAvailabilityPercentage.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceAvailabilityPercentage.yml
@@ -1,0 +1,24 @@
+requirements: 'Consumers should be sufficiently confident that the availability commitments of the service, including their ability to recover from outages, meets their business needs.'
+filters: 'Consumers should be sufficiently confident that the availability commitments of the service, including their ability to recover from outages, meets their business needs.'
+hint: 'What is the availability of the service? eg 99.99'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type1
+type: percentage
+filterLabel: 'Service availability'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_a_number
+    message: 'Availability must be a number less than 100.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Service availability'

--- a/frameworks/g-cloud-6/questions/services/serviceBenefits.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceBenefits.yml
@@ -1,0 +1,26 @@
+hint: 'Include benefits that show how your service helps users improve their business. Use active phrases, eg publish content from multiple devices, quickly manage content on the move.  This content will be indexed by search. Using additional keywords may impact your acceptance on to the Digital Marketplace. Read the [guidance on writing good service descriptions](https://digitalmarketplace.blog.gov.uk/2014/10/21/digital-marketplace-content-its-all-change/). (Maximum 10 words per benefit. Maximum 10 benefits.)'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+listItemName: 'service benefit'
+type: list
+addthing: 'Add another business benefit'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_10_words
+    message: 'Each benefit must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer benefits.'
+  -
+    name: under_character_limit
+    message: 'Each benefit must be no more than 100 characters.'
+question: 'Service benefits'

--- a/frameworks/g-cloud-6/questions/services/serviceConfigurationGuidance.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceConfigurationGuidance.yml
@@ -1,0 +1,20 @@
+requirements: 'The consumer understands the security requirements on their processes, uses, and infrastructure related to the use of the service.'
+filters: 'The consumer understands the security requirements on their processes, uses, and infrastructure related to the use of the service.'
+hint: 'Do you provide guidance on service configuration options and the relative impacts on security?'
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+assuranceApproach: 3answers-type2
+type: boolean
+filterLabel: 'Service configuration guidance'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Service configuration guidance'

--- a/frameworks/g-cloud-6/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceDefinitionDocumentURL.yml
@@ -1,0 +1,24 @@
+question: 'Service definition document'
+hint: 'Please upload your service definition. Refer to the G-Cloud 7 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: upload
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: file_is_open_document_format
+    message: 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
+  -
+    name: file_is_less_than_5mb
+    message: 'Your document exceeds the 5MB limit. Please reduce file size.'
+  -
+    name: file_can_be_saved
+    message: 'Your document failed to upload. Please try again.'

--- a/frameworks/g-cloud-6/questions/services/serviceFeatures.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceFeatures.yml
@@ -1,0 +1,26 @@
+hint: 'Include the technical features of your product, eg real-time reporting, remote access. This content will be indexed by search. Using additional keywords may impact your acceptance on to the Digital Marketplace. Read the [guidance on writing good service descriptions](https://digitalmarketplace.blog.gov.uk/2014/10/21/digital-marketplace-content-its-all-change/). (Maximum 10 words per feature. Maximum 10 features.)'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+listItemName: 'service feature'
+type: list
+addthing: 'Add another feature'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_10_words
+    message: 'Each feature must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer features.'
+  -
+    name: under_character_limit
+    message: 'Each feature must be no more than 100 characters.'
+question: 'Service features'

--- a/frameworks/g-cloud-6/questions/services/serviceManagementModel.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceManagementModel.yml
@@ -1,0 +1,36 @@
+requirements: 'Consumers have sufficient confidence that the technical approach the service provider uses to manage the service does not put their data or service at risk.'
+filters: 'Consumers have sufficient confidence that the technical approach the service provider uses to manage the service does not put their data or service at risk.'
+hint: 'Which technical approach do you use for your service management? Choose all that apply.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: checkboxes
+options:
+    -
+        label: 'Dedicated devices on a segregated network'
+        filterLabel: 'Dedicated devices on a segregated network'
+    -
+        label: 'Dedicated devices for community service management'
+        filterLabel: 'Dedicated devices for community service management'
+    -
+        label: 'Dedicated devices for multiple community service management'
+        filterLabel: 'Dedicated devices for multiple community service management'
+    -
+        label: 'Service management via bastion hosts'
+        filterLabel: 'Service management via bastion hosts'
+    -
+        label: 'Direct service management'
+        filterLabel: 'Direct service management'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Service management model'

--- a/frameworks/g-cloud-6/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceName.yml
@@ -1,0 +1,18 @@
+hint: 'Include your product name only. Using additional keywords may impact your acceptance on to the Digital Marketplace.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your service name can't be more than 100 characters."
+question: 'Service name'

--- a/frameworks/g-cloud-6/questions/services/serviceOffboarding.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceOffboarding.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Service offboarding process included'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Service offboarding process included'

--- a/frameworks/g-cloud-6/questions/services/serviceOnboarding.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceOnboarding.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Service onboarding process included'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Service onboarding process included'

--- a/frameworks/g-cloud-6/questions/services/serviceSummary.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceSummary.yml
@@ -1,0 +1,23 @@
+hint: 'Please provide a short description of your service. You''ll be asked to go into more detail about the features and benefits of your service on the next page. Company information should not be included here. You can provide a company description for your supplier page elsewhere. This content will be indexed by search. Using additional keywords may impact your acceptance onto the Digital Marketplace. (Maximum 50 words.)'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: textarea
+maxLengthInWords: 50
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must not be more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description can't be more than 500 characters."
+question: 'Service summary'
+type: textbox_large

--- a/frameworks/g-cloud-6/questions/services/serviceTypesIaaS.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceTypesIaaS.yml
@@ -1,0 +1,19 @@
+depends:
+  -
+    "on": lot
+    being:
+      - IaaS
+hint: 'You can choose multiple categories.'
+type: checkboxes
+options:
+  -
+    label: Compute
+    filterLabel: Compute
+  -
+    label: Storage
+    filterLabel: Storage
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Choose the categories that apply to your service'

--- a/frameworks/g-cloud-6/questions/services/serviceTypesSCS.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceTypesSCS.yml
@@ -1,0 +1,28 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SCS
+hint: 'You can choose multiple categories'
+type: checkboxes
+options:
+    -
+        label: Implementation
+        filterLabel: Implementation
+    -
+        label: 'Ongoing support'
+        filterLabel: 'Ongoing support'
+    -
+        label: Planning
+        filterLabel: Planning
+    -
+        label: Testing
+        filterLabel: Testing
+    -
+        label: Training
+        filterLabel: Training
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Choose the categories that apply to your service'

--- a/frameworks/g-cloud-6/questions/services/serviceTypesSaaS.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceTypesSaaS.yml
@@ -1,0 +1,79 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+hint: 'You can choose multiple categories'
+type: checkboxes
+options:
+  -
+    label: Accounting and finance
+    filterLabel: Accounting and finance
+  -
+    label: Business intelligence and analytics
+    filterLabel: Business intelligence and analytics
+  -
+    label: Collaboration
+    filterLabel: Collaboration
+  -
+    label: Creative and design
+    filterLabel: Creative and design
+  -
+    label: Customer relationship management (CRM)
+    filterLabel: Customer relationship management (CRM)
+  -
+    label: Data management
+    filterLabel: Data management
+  -
+    label: Electronic document and records management (EDRM)
+    filterLabel: Electronic document and records management (EDRM)
+  -
+    label: Energy and environment
+    filterLabel: Energy and environment
+  -
+    label: Healthcare
+    filterLabel: Healthcare
+  -
+    label: Human resources and employee management
+    filterLabel: Human resources and employee management
+  -
+    label: IT management
+    filterLabel: IT management
+  -
+    label: Legal
+    filterLabel: Legal
+  -
+    label: Libraries
+    filterLabel: Libraries
+  -
+    label: Marketing
+    filterLabel: Marketing
+  -
+    label: Operations management
+    filterLabel: Operations management
+  -
+    label: Project management and planning
+    filterLabel: Project management and planning
+  -
+    label: Sales
+    filterLabel: Sales
+  -
+    label: Schools and education
+    filterLabel: Schools and education
+  -
+    label: Security
+    filterLabel: Security
+  -
+    label: Software development tools
+    filterLabel: Software development tools
+  -
+    label: Telecoms
+    filterLabel: Telecoms
+  -
+    label: Transport and logistics
+    filterLabel: Transport and logistics
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Choose the categories that apply to your service'

--- a/frameworks/g-cloud-6/questions/services/servicesManagementSeparation.yml
+++ b/frameworks/g-cloud-6/questions/services/servicesManagementSeparation.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that their management of the service is kept separate from other consumers (covered separately as part of Principle 9).'
+filters: 'Consumers should have confidence that their management of the service is kept separate from other consumers (covered separately as part of Principle 9).'
+hint: 'Is your management of a consumer’s service kept separate from other consumers?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type3
+type: boolean
+filterLabel: 'Services management separation'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Services management separation'

--- a/frameworks/g-cloud-6/questions/services/servicesSeparation.yml
+++ b/frameworks/g-cloud-6/questions/services/servicesSeparation.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.'
+filters: 'Consumers should have confidence that the service provides sufficient separation of their data and service from other consumers of the service.'
+hint: 'Do you securely separate consumer data and services from other consumers of the service?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 4answers-type3
+type: boolean
+filterLabel: 'Services separation'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Services separation'

--- a/frameworks/g-cloud-6/questions/services/sfiaRateDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/sfiaRateDocumentURL.yml
@@ -1,0 +1,22 @@
+question: 'Skills Framework for the Information Age (SFIA) rate card'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'Please upload your SFIA rate card if you have one. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+type: upload
+optional: yes
+validations:
+  -
+    name: file_is_open_document_format
+    message: 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
+  -
+    name: file_is_less_than_5mb
+    message: 'Your document exceeds the 5MB limit. Please reduce file size.'
+  -
+    name: file_can_be_saved
+    message: 'Your document failed to upload. Please try again.'

--- a/frameworks/g-cloud-6/questions/services/supportAvailability.yml
+++ b/frameworks/g-cloud-6/questions/services/supportAvailability.yml
@@ -1,0 +1,21 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'eg 24/7 or 9 to 5. (Maximum 20 words.)'
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Support availability must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Support availability can't be more than 200 characters."
+question: 'Support availability'

--- a/frameworks/g-cloud-6/questions/services/supportForThirdParties.yml
+++ b/frameworks/g-cloud-6/questions/services/supportForThirdParties.yml
@@ -1,0 +1,16 @@
+hint: 'Please confirm whether any third parties engaged by the buyer can access the support features of your service.'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: boolean
+filterLabel: 'Support accessible to any third-party suppliers'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Support accessible to any third-party suppliers'

--- a/frameworks/g-cloud-6/questions/services/supportResponseTime.yml
+++ b/frameworks/g-cloud-6/questions/services/supportResponseTime.yml
@@ -1,0 +1,21 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'How long will it take until support can begin to be provided? eg 1 hour or 1 business day. (Maximum 20 words.)'
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Support response time must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Support response time can't be more than 200 characters."
+question: 'Standard support response times'

--- a/frameworks/g-cloud-6/questions/services/supportTypes.yml
+++ b/frameworks/g-cloud-6/questions/services/supportTypes.yml
@@ -1,0 +1,31 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'Choose all that apply.'
+type: checkboxes
+options:
+    -
+        label: 'Service desk'
+        filterLabel: 'Service desk'
+    -
+        label: Email
+        filterLabel: Email
+    -
+        label: Phone
+        filterLabel: Phone
+    -
+        label: 'Live chat'
+        filterLabel: 'Live chat'
+    -
+        label: Onsite
+        filterLabel: Onsite
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Support service type'

--- a/frameworks/g-cloud-6/questions/services/supportedBrowsers.yml
+++ b/frameworks/g-cloud-6/questions/services/supportedBrowsers.yml
@@ -1,0 +1,42 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: 'Choose all that apply.'
+type: checkboxes
+options:
+    -
+        label: 'Internet Explorer 6'
+        filterLabel: 'Internet Explorer 6'
+    -
+        label: 'Internet Explorer 7'
+        filterLabel: 'Internet Explorer 7'
+    -
+        label: 'Internet Explorer 8'
+        filterLabel: 'Internet Explorer 8'
+    -
+        label: 'Internet Explorer 9'
+        filterLabel: 'Internet Explorer 9'
+    -
+        label: 'Internet Explorer 10+'
+        filterLabel: 'Internet Explorer 10+'
+    -
+        label: Firefox
+        filterLabel: Firefox
+    -
+        label: Chrome
+        filterLabel: Chrome
+    -
+        label: Safari
+        filterLabel: Safari
+    -
+        label: Opera
+        filterLabel: Opera
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Supported web browsers'

--- a/frameworks/g-cloud-6/questions/services/supportedDevices.yml
+++ b/frameworks/g-cloud-6/questions/services/supportedDevices.yml
@@ -1,0 +1,27 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+hint: 'Choose all that apply.'
+type: checkboxes
+options:
+    -
+        label: PC
+        filterLabel: PC
+    -
+        label: Mac
+        filterLabel: Mac
+    -
+        label: Smartphone
+        filterLabel: Smartphone
+    -
+        label: Tablet
+        filterLabel: Tablet
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Supported devices'

--- a/frameworks/g-cloud-6/questions/services/terminationCost.yml
+++ b/frameworks/g-cloud-6/questions/services/terminationCost.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - PaaS
+      - IaaS
+      - SCS
+type: boolean
+filterLabel: 'Termination cost'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Termination cost'

--- a/frameworks/g-cloud-6/questions/services/termsAndConditionsDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/termsAndConditionsDocumentURL.yml
@@ -1,0 +1,24 @@
+question: 'Terms and conditions document'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'Please upload your terms and conditions document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+type: upload
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: file_is_open_document_format
+    message: 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
+  -
+    name: file_is_less_than_5mb
+    message: 'Your document exceeds the 5MB limit. Please reduce file size.'
+  -
+    name: file_can_be_saved
+    message: 'Your document failed to upload. Please try again.'

--- a/frameworks/g-cloud-6/questions/services/thirdPartyComplianceMonitoring.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartyComplianceMonitoring.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer understands and accepts how the service provider manages the conformance of their suppliers with security requirements.'
+filters: 'The consumer understands and accepts how the service provider manages the conformance of their suppliers with security requirements.'
+hint: 'Do you manage your third-party suppliers'' compliance with relevant security requirements?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Third-party supplier compliance monitoring'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Third-party supplier compliance monitoring'

--- a/frameworks/g-cloud-6/questions/services/thirdPartyDataSharingInformation.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartyDataSharingInformation.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.'
+filters: 'The consumer understands and accepts how their information is shared with, or accessible by, third party suppliers and their supply chains.'
+hint: 'Do you inform consumers how much of their information is shared with, or accessible by, third-party suppliers and their supply chains?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Visibility of data shared with third-party suppliers'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Visibility of data shared with third-party suppliers'

--- a/frameworks/g-cloud-6/questions/services/thirdPartyRiskAssessment.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartyRiskAssessment.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer understands and accepts how the service provider manages security risks from third party suppliers and delivery partners.'
+filters: 'The consumer understands and accepts how the service provider manages security risks from third party suppliers and delivery partners.'
+hint: 'Do you manage the risks to your service from third-party suppliers and delivery partners?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Third-party supplier risk assessment'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Third-party supplier risk assessment'

--- a/frameworks/g-cloud-6/questions/services/thirdPartySecurityRequirements.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartySecurityRequirements.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer understands and accepts how the service provider’s procurement processes place security requirements on third party suppliers and delivery partners.'
+filters: 'The consumer understands and accepts how the service provider’s procurement processes place security requirements on third party suppliers and delivery partners.'
+hint: 'Do you ensure that relevant security requirements, such as the Cloud Security Principles, are placed on third-party suppliers and delivery partners?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Third-party supplier security requirements'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Third-party supplier security requirements'

--- a/frameworks/g-cloud-6/questions/services/trainingProvided.yml
+++ b/frameworks/g-cloud-6/questions/services/trainingProvided.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer can educate those administrating and using the service in how to use it safely and securely.'
+filters: 'The consumer can educate those administrating and using the service in how to use it safely and securely.'
+hint: 'Do you provide user or administrator training on the use of the service and its security?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: Training
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: Training

--- a/frameworks/g-cloud-6/questions/services/trialOption.yml
+++ b/frameworks/g-cloud-6/questions/services/trialOption.yml
@@ -1,0 +1,14 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+type: boolean
+filterLabel: 'Trial option'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'Trial option'

--- a/frameworks/g-cloud-6/questions/services/userAccessControlManagement.yml
+++ b/frameworks/g-cloud-6/questions/services/userAccessControlManagement.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer has sufficient confidence that other consumers cannot access, modify or otherwise affect their service management.'
+filters: 'The consumer has sufficient confidence that other consumers cannot access, modify or otherwise affect their service management.'
+hint: 'Can consumers manage only their own service, and not access, modify or otherwise affect the service of other consumers via management tools and interfaces?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type2
+type: boolean
+filterLabel: 'User access control within management interfaces'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'User access control within management interfaces'

--- a/frameworks/g-cloud-6/questions/services/userAuthenticateManagement.yml
+++ b/frameworks/g-cloud-6/questions/services/userAuthenticateManagement.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to authenticate to and access management interfaces for the service (Principle 10 should be used assess the risks of different approaches to meet this objective).'
+filters: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to authenticate to and access management interfaces for the service (Principle 10 should be used assess the risks of different approaches to meet this objective).'
+hint: 'Can only authorised individuals from the consumer organisation access management interfaces for the service?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type2
+type: boolean
+filterLabel: 'User authentication and access management'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'User authentication and access management'

--- a/frameworks/g-cloud-6/questions/services/userAuthenticateSupport.yml
+++ b/frameworks/g-cloud-6/questions/services/userAuthenticateSupport.yml
@@ -1,0 +1,21 @@
+requirements: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to perform actions affecting the consumer’s service through support channels.'
+filters: 'The consumer has sufficient confidence that only authorised individuals from the consumer organisation are able to perform actions affecting the consumer’s service through support channels.'
+hint: 'Can only authorised individuals from the consumer organisation perform actions affecting the consumer’s service through your support channels?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type2
+type: boolean
+filterLabel: 'User access control through support channels'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'User access control through support channels'

--- a/frameworks/g-cloud-6/questions/services/vatIncluded.yml
+++ b/frameworks/g-cloud-6/questions/services/vatIncluded.yml
@@ -1,0 +1,15 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+type: boolean
+filterLabel: 'VAT included'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+question: 'VAT included'

--- a/frameworks/g-cloud-6/questions/services/vendorCertifications.yml
+++ b/frameworks/g-cloud-6/questions/services/vendorCertifications.yml
@@ -1,0 +1,24 @@
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+      - SCS
+hint: 'Examples of employee or company certifications include VMware Certified Professional and Oracle Gold Partner. (Optional.)'
+listItemName: 'certification example'
+type: list
+addthing: 'Add another certification'
+validations:
+    -
+      name: under_10_words
+      message: 'Each certification must be no more than 10 words.'
+    -
+      name: under_10_items
+      message: 'You must have 10 or fewer certifications.'
+    -
+      name: under_character_limit
+      message: 'Each certification must be no more than 100 characters.'
+question: 'Vendor certification(s)'
+optional: true

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityAssessment.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityAssessment.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that potential new threats, vulnerabilities or exploitation techniques which could affect the service are assessed and corrective action is taken.'
+filters: 'Consumers should have confidence that potential new threats, vulnerabilities or exploitation techniques which could affect the service are assessed and corrective action is taken.'
+hint: 'Are potential threats, vulnerabilities or exploitation techniques which could affect the service assessed, and are corrective actions taken?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Vulnerability assessment'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Vulnerability assessment'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityMitigationPrioritisation.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityMitigationPrioritisation.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that the severity of threats and vulnerabilities are considered within the context of the service and this information is used to prioritise implementation of mitigations.'
+filters: 'Consumers should have confidence that the severity of threats and vulnerabilities are considered within the context of the service and this information is used to prioritise implementation of mitigations.'
+hint: 'Is the severity of threats and vulnerabilities considered and do you use this information to prioritise implementation of mitigations?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Vulnerability mitigation prioritisation'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Vulnerability mitigation prioritisation'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityMonitoring.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityMonitoring.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that relevant sources of information relating to threat, vulnerability and exploitation technique information are monitored by the service provider.'
+filters: 'Consumers should have confidence that relevant sources of information relating to threat, vulnerability and exploitation technique information are monitored by the service provider.'
+hint: 'Do you monitor relevant sources of information relating to threat, vulnerability and exploitation techniques?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Vulnerability monitoring'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Vulnerability monitoring'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityTimescales.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityTimescales.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that service provider timescales for implementing mitigations to vulnerabilities found within the service are made available to them.'
+filters: 'Consumers should have confidence that service provider timescales for implementing mitigations to vulnerabilities found within the service are made available to them.'
+hint: 'Do you make timescales available for implementing mitigations to vulnerabilities?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Vulnerability mitigation timescales'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Vulnerability mitigation timescales'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityTracking.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityTracking.yml
@@ -1,0 +1,21 @@
+requirements: 'Consumers should have confidence that known vulnerabilities within the service are tracked until suitable mitigations have been deployed through a suitable change management process.'
+filters: 'Consumers should have confidence that known vulnerabilities within the service are tracked until suitable mitigations have been deployed through a suitable change management process.'
+hint: 'Are known vulnerabilities within the service tracked until suitable mitigations have been deployed?'
+depends:
+  -
+    "on": lot
+    being:
+      - SaaS
+      - PaaS
+      - IaaS
+assuranceApproach: 2answers-type1
+type: boolean
+filterLabel: 'Vulnerability tracking'
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: assurance_required
+    message: 'You need to confirm how you can back up your response.'
+question: 'Vulnerability tracking'

--- a/frameworks/g-cloud-7/manifests/declaration.yml
+++ b/frameworks/g-cloud-7/manifests/declaration.yml
@@ -1,0 +1,71 @@
+-
+  name: G-Cloud 7 essentials
+  editable: True
+  questions:
+    - PR1
+    - PR2
+    - SQC2
+    - PR5
+    - PR3
+    - PR4
+    - SQ1-3
+    - SQA2
+    - SQA3
+    - SQA4
+    - SQA5
+    - AQA3
+    - SQ5-1a
+    - SQC3
+-
+  name: About you
+  editable: True
+  questions:
+    - SQ1-2a
+    - SQ1-2b
+    - SQ1-1a
+    - SQ1-1b
+    - SQ1-1ci
+    - SQ1-1cii
+    - SQ1-1k
+    - SQ1-1d-i
+    - SQ1-1d-ii
+    - SQ1-1e
+    - SQ1-1h
+    - SQ5-2a
+    - SQ1-1i-i
+    - SQ1-1i-ii
+    - SQ1-1j-i
+    - SQ1-1j-ii
+    - SQ1-1m
+    - SQE2a
+    - SQ1-1n
+    - SQ1-1o
+-
+  name: Grounds for mandatory exclusion
+  editable: True
+  questions:
+    - SQ2-1abcd
+    - SQ2-1e
+    - SQ2-1f
+    - SQ2-1ghijklmn
+-
+  name: Grounds for discretionary exclusion
+  editable: True
+  questions:
+    - SQ2-2a
+    - SQ3-1a
+    - SQ3-1b
+    - SQ3-1c
+    - SQ3-1d
+    - SQ3-1e
+    - SQ3-1f
+    - SQ3-1g
+    - SQ3-1h-i
+    - SQ3-1h-ii
+    - SQ3-1i-i
+    - SQ3-1i-ii
+    - SQ3-1j
+    - SQ3-1k
+    - SQ4-1a
+    - SQ4-1b
+    - SQ4-1c

--- a/frameworks/g-cloud-7/manifests/display_service.yml
+++ b/frameworks/g-cloud-7/manifests/display_service.yml
@@ -1,0 +1,177 @@
+-
+  name: Support
+  questions:
+    - supportTypes
+    - supportForThirdParties
+    - supportAvailability
+    - supportResponseTime
+    - incidentEscalation
+-
+  name: Open standards
+  questions:
+    - openStandardsSupported
+-
+  name: Onboarding and offboarding
+  questions:
+    - serviceOnboarding
+    - serviceOffboarding
+-
+  name: Analytics
+  questions:
+    - analyticsAvailable
+-
+  name: Cloud features
+  questions:
+    - elasticCloud
+    - guaranteedResources
+    - persistentStorage
+-
+  name: Provisioning
+  questions:
+    - selfServiceProvisioning
+    - provisioningTime
+    - deprovisioningTime
+-
+  name: Open source
+  questions:
+    - openSource
+-
+  name: Code libraries
+  questions:
+    - codeLibraryLanguages
+-
+  name: API access
+  questions:
+    - apiAccess
+    - apiType
+-
+  name: Networks and connectivity
+  questions:
+    - networksConnected
+-
+  name: Access
+  questions:
+    - supportedBrowsers
+    - offlineWorking
+    - supportedDevices
+-
+  name: Certifications
+  questions:
+    - vendorCertifications
+-
+  name: Identity standards
+  questions:
+    - identityStandards
+-
+  name: Data storage
+  questions:
+    - datacentresEUCode
+    - datacentresSpecifyLocation
+    - datacentreTier
+    - dataBackupRecovery
+    - dataExtractionRemoval
+-
+  name: Data-in-transit protection
+  questions:
+    - dataProtectionBetweenUserAndService
+    - dataProtectionWithinService
+    - dataProtectionBetweenServices
+-
+  name: Asset protection and resilience
+  questions:
+    - datacentreLocations
+    - dataManagementLocations
+    - legalJurisdiction
+    - datacentreProtectionDisclosure
+    - dataAtRestProtections
+    - dataSecureDeletion
+    - dataStorageMediaDisposal
+    - dataSecureEquipmentDisposal
+    - dataRedundantEquipmentAccountsRevoked
+    - serviceAvailabilityPercentage
+-
+  name: Separation between consumers
+  questions:
+    - cloudDeploymentModel
+    - otherConsumers
+    - servicesSeparation
+    - servicesManagementSeparation
+-
+  name: Governance
+  questions:
+    - governanceFramework
+-
+  name: Configuration and change management
+  questions:
+    - configurationTracking
+    - changeImpactAssessment
+-
+  name: Vulnerabilility management
+  questions:
+    - vulnerabilityAssessment
+    - vulnerabilityMonitoring
+    - vulnerabilityMitigationPrioritisation
+    - vulnerabilityTracking
+    - vulnerabilityTimescales
+-
+  name: Event monitoring
+  questions:
+    - eventMonitoring
+-
+  name: Incident management
+  questions:
+    - incidentManagementProcess
+    - incidentManagementReporting
+    - incidentDefinitionPublished
+-
+  name: Personnel security
+  questions:
+    - personnelSecurityChecks
+-
+  name: Secure development
+  questions:
+    - secureDevelopment
+    - secureDesign
+    - secureConfigurationManagement
+-
+  name: Supply-chain security
+  questions:
+    - thirdPartyDataSharingInformation
+    - thirdPartySecurityRequirements
+    - thirdPartyRiskAssessment
+    - thirdPartyComplianceMonitoring
+    - hardwareSoftwareVerification
+-
+  name: Authentication of consumers
+  questions:
+    - userAuthenticateManagement
+    - userAuthenticateSupport
+-
+  name: Separation and access control within management interfaces
+  questions:
+    - userAccessControlManagement
+    - restrictAdministratorPermissions
+    - managementInterfaceProtection
+-
+  name: Identity and authentication
+  questions:
+    - identityAuthenticationControls
+-
+  name: External interface protection
+  questions:
+    - onboardingGuidance
+    - interconnectionMethods
+-
+  name: Secure service administration
+  questions:
+    - serviceManagementModel
+-
+  name: Audit information provision to consumers
+  questions:
+    - auditInformationProvided
+-
+  name: Secure use of the service by the customer
+  questions:
+    - deviceAccessMethod
+    - serviceConfigurationGuidance
+    - trainingProvided

--- a/frameworks/g-cloud-7/manifests/edit_service.yml
+++ b/frameworks/g-cloud-7/manifests/edit_service.yml
@@ -1,0 +1,18 @@
+-
+  name: Service attributes
+  editable: false
+  questions:
+    - id
+    - lot
+-
+  name: Description
+  editable: edit
+  questions:
+    - serviceName
+    - serviceSummary
+-
+  name: Features and benefits
+  editable: edit
+  questions:
+    - serviceFeatures
+    - serviceBenefits

--- a/frameworks/g-cloud-7/manifests/edit_service_as_admin.yml
+++ b/frameworks/g-cloud-7/manifests/edit_service_as_admin.yml
@@ -1,0 +1,37 @@
+-
+  name: Service attributes
+  editable: false
+  questions:
+    - id
+    - lot
+-
+  name: Description
+  editable: true
+  questions:
+    - serviceName
+    - serviceSummary
+-
+  name: Features and benefits
+  editable: true
+  questions:
+    - serviceFeatures
+    - serviceBenefits
+-
+  name: Pricing
+  editable: true
+  questions:
+    - priceString
+    - vatIncluded
+    - educationPricing
+    - terminationCost
+    - trialOption
+    - freeOption
+    - minimumContractPeriod
+-
+  name: Documents
+  editable: true
+  questions:
+    - serviceDefinitionDocumentURL
+    - termsAndConditionsDocumentURL
+    - sfiaRateDocumentURL
+    - pricingDocumentURL

--- a/frameworks/g-cloud-7/manifests/edit_submission.yml
+++ b/frameworks/g-cloud-7/manifests/edit_submission.yml
@@ -1,0 +1,272 @@
+-
+  name: Service attributes
+  editable: false
+  questions:
+    - lot
+-
+  name: Service name
+  editable: true
+  questions:
+    - serviceName
+-
+  name: Service description
+  editable: true
+  questions:
+    - serviceSummary
+-
+  name: Service type
+  editable: true
+  questions:
+    - serviceTypesIaaS
+    - serviceTypesSaaS
+    - serviceTypesSCS
+-
+  name: Features and benefits
+  editable: true
+  questions:
+    - serviceFeatures
+    - serviceBenefits
+-
+  name: Pricing
+  editable: true
+  questions:
+    - priceString
+    - vatIncluded
+    - educationPricing
+    - trialOption
+    - freeOption
+-
+  name: Terms and conditions
+  editable: true
+  questions:
+    - terminationCost
+    - minimumContractPeriod
+-
+  name: Support
+  editable: True
+  questions:
+    - supportTypes
+    - supportForThirdParties
+    - supportAvailability
+    - supportResponseTime
+    - incidentEscalation
+-
+  name: Open standards
+  editable: True
+  questions:
+    - openStandardsSupported
+-
+  name: Onboarding and offboarding
+  editable: True
+  questions:
+    - serviceOnboarding
+    - serviceOffboarding
+-
+  name: Analytics
+  editable: True
+  questions:
+    - analyticsAvailable
+-
+  name: Cloud features
+  editable: True
+  questions:
+    - elasticCloud
+    - guaranteedResources
+    - persistentStorage
+-
+  name: Provisioning
+  editable: True
+  questions:
+    - selfServiceProvisioning
+    - provisioningTime
+    - deprovisioningTime
+-
+  name: Open source
+  editable: True
+  questions:
+    - openSource
+-
+  name: Code libraries
+  editable: True
+  questions:
+    - codeLibraryLanguages
+-
+  name: API access
+  editable: True
+  questions:
+    - apiAccess
+    - apiType
+-
+  name: Networks and connectivity
+  editable: True
+  questions:
+    - networksConnected
+-
+  name: Access
+  editable: True
+  questions:
+    - supportedBrowsers
+    - offlineWorking
+    - supportedDevices
+-
+  name: Certifications
+  editable: True
+  questions:
+    - vendorCertifications
+-
+  name: Identity standards
+  editable: True
+  questions:
+    - identityStandards
+-
+  name: Data storage
+  editable: True
+  questions:
+    - datacentresEUCode
+    - datacentresSpecifyLocation
+    - datacentreTier
+    - dataBackupRecovery
+    - dataExtractionRemoval
+-
+  name: Data-in-transit protection
+  editable: True
+  questions:
+    - dataProtectionBetweenUserAndService
+    - dataProtectionWithinService
+    - dataProtectionBetweenServices
+-
+  name: Asset protection and resilience
+  editable: True
+  questions:
+    - datacentreLocations
+    - dataManagementLocations
+    - legalJurisdiction
+    - datacentreProtectionDisclosure
+    - dataAtRestProtections
+    - dataSecureDeletion
+    - dataStorageMediaDisposal
+    - dataSecureEquipmentDisposal
+    - dataRedundantEquipmentAccountsRevoked
+    - serviceAvailabilityPercentage
+-
+  name: Separation between consumers
+  editable: True
+  questions:
+    - cloudDeploymentModel
+    - otherConsumers
+    - servicesSeparation
+    - servicesManagementSeparation
+-
+  name: Governance
+  editable: True
+  questions:
+    - governanceFramework
+-
+  name: Configuration and change management
+  editable: True
+  questions:
+    - configurationTracking
+    - changeImpactAssessment
+-
+  name: Vulnerability management
+  editable: True
+  questions:
+    - vulnerabilityAssessment
+    - vulnerabilityMonitoring
+    - vulnerabilityMitigationPrioritisation
+    - vulnerabilityTracking
+    - vulnerabilityTimescales
+-
+  name: Event monitoring
+  editable: True
+  questions:
+    - eventMonitoring
+-
+  name: Incident management
+  editable: True
+  questions:
+    - incidentManagementProcess
+    - incidentManagementReporting
+    - incidentDefinitionPublished
+-
+  name: Personnel security
+  editable: True
+  questions:
+    - personnelSecurityChecks
+-
+  name: Secure development
+  editable: True
+  questions:
+    - secureDevelopment
+    - secureDesign
+    - secureConfigurationManagement
+-
+  name: Supply-chain security
+  editable: True
+  questions:
+    - thirdPartyDataSharingInformation
+    - thirdPartySecurityRequirements
+    - thirdPartyRiskAssessment
+    - thirdPartyComplianceMonitoring
+    - hardwareSoftwareVerification
+-
+  name: Authentication of consumers
+  editable: True
+  questions:
+    - userAuthenticateManagement
+    - userAuthenticateSupport
+-
+  name: Separation and access control within management interfaces
+  editable: True
+  questions:
+    - userAccessControlManagement
+    - restrictAdministratorPermissions
+    - managementInterfaceProtection
+-
+  name: Identity and authentication
+  editable: True
+  questions:
+    - identityAuthenticationControls
+-
+  name: External interface protection
+  editable: True
+  questions:
+    - onboardingGuidance
+    - interconnectionMethods
+-
+  name: Secure service administration
+  editable: True
+  questions:
+    - serviceManagementModel
+-
+  name: Audit information provision to consumers
+  editable: True
+  questions:
+    - auditInformationProvided
+-
+  name: Secure use of the service by the customer
+  editable: True
+  questions:
+    - deviceAccessMethod
+    - serviceConfigurationGuidance
+    - trainingProvided
+-
+  name: Service definition
+  editable: true
+  questions:
+    - serviceDefinitionDocumentURL
+-
+  name: Terms and conditions document
+  editable: true
+  questions:
+    - termsAndConditionsDocumentURL
+-
+  name: Pricing document
+  editable: true
+  questions:
+    - pricingDocumentURL
+-
+  name: SFIA rate card
+  editable: true
+  questions:
+    - sfiaRateDocumentURL

--- a/frameworks/g-cloud-7/manifests/search_filters.yml
+++ b/frameworks/g-cloud-7/manifests/search_filters.yml
@@ -1,0 +1,37 @@
+-
+  name: Categories
+  questions:
+    - serviceTypesSCS
+    - serviceTypesSaaS
+    - serviceTypesIaaS
+-
+  name: Pricing
+  questions:
+    - freeOption
+    - trialOption
+-
+  name: Minimum contract period
+  questions:
+    - minimumContractPeriod
+-
+  name: Service management
+  questions:
+    - dataExtractionRemoval
+    - datacentresEUCode
+    - dataBackupRecovery
+    - selfServiceProvisioning
+    - supportForThirdParties
+-
+  name: Datacentre tier
+  questions:
+    - datacentreTier
+-
+  name: Networks the service is directly connected to
+  questions:
+    - networksConnected
+-
+  name: Interoperability
+  questions:
+    - apiAccess
+    - openStandardsSupported
+    - openSource

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -15,6 +15,12 @@ def test_all_files_are_yaml(get_all_files):
 def test_questions_match_schema(get_all_files):
     question_schema = load_jsonschema('tests/schemas/question.json')
     for path in get_all_files:
+        parent_folder_path = os.path.abspath(os.path.join(
+            path.replace(os.path.basename(path), ''),
+            os.pardir
+        ))
+        if os.path.basename(parent_folder_path) is not 'questions':
+            continue
         with open(path) as f:
             data = yaml.load(f)
             try:


### PR DESCRIPTION
## Add manifest files

The commit extracts the manifest files from the apps into one central place without modifying them.

Although each file is typically only used by one app (at the moment) this will make them easier to keep organised if/when we have 2+ frameworks.


## ~~Add G-Cloud 6 framework as symlink~~

~~This commit adds the G-Cloud 6 framework as a symlink.~~

~~It could be real files in the future, but since we want to keep parity between 6 and 7 it seems reasonable not to maintain two separate collections of files.~~

~~This allows us to access the content for a G-Cloud 6 service page in a dynamic way.~~

## Add G-Cloud 6 as copy of G-Cloud 7

Excludes things which we don't have or need content for, ie declaration, submissions