### PR TITLE
Lowercase lot values

### DIFF
--- a/frameworks/g-cloud-6/manifests/edit_service.yml
+++ b/frameworks/g-cloud-6/manifests/edit_service.yml
@@ -3,7 +3,7 @@
   editable: false
   questions:
     - id
-    - lot
+    - lotName
 -
   name: Description
   editable: edit

--- a/frameworks/g-cloud-6/manifests/edit_service_as_admin.yml
+++ b/frameworks/g-cloud-6/manifests/edit_service_as_admin.yml
@@ -3,7 +3,7 @@
   editable: false
   questions:
     - id
-    - lot
+    - lotName
 -
   name: Description
   editable: true

--- a/frameworks/g-cloud-6/questions/services/analyticsAvailable.yml
+++ b/frameworks/g-cloud-6/questions/services/analyticsAvailable.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Real-time management information available'
 validations:

--- a/frameworks/g-cloud-6/questions/services/apiAccess.yml
+++ b/frameworks/g-cloud-6/questions/services/apiAccess.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'API access available and supported'
 validations:

--- a/frameworks/g-cloud-6/questions/services/apiType.yml
+++ b/frameworks/g-cloud-6/questions/services/apiType.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Examples of API include RESTful and SOAP.'
 type: text
 validations:

--- a/frameworks/g-cloud-6/questions/services/auditInformationProvided.yml
+++ b/frameworks/g-cloud-6/questions/services/auditInformationProvided.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/changeImpactAssessment.yml
+++ b/frameworks/g-cloud-6/questions/services/changeImpactAssessment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Change impact assessment'

--- a/frameworks/g-cloud-6/questions/services/cloudDeploymentModel.yml
+++ b/frameworks/g-cloud-6/questions/services/cloudDeploymentModel.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/codeLibraryLanguages.yml
+++ b/frameworks/g-cloud-6/questions/services/codeLibraryLanguages.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
 hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) '
 listItemName: 'code libraries example'
 type: list

--- a/frameworks/g-cloud-6/questions/services/configurationTracking.yml
+++ b/frameworks/g-cloud-6/questions/services/configurationTracking.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Configuration and change management tracking'

--- a/frameworks/g-cloud-6/questions/services/dataAtRestProtections.yml
+++ b/frameworks/g-cloud-6/questions/services/dataAtRestProtections.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/dataBackupRecovery.yml
+++ b/frameworks/g-cloud-6/questions/services/dataBackupRecovery.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Backup, disaster recovery and resilience plan in place'
 hint: 'You can provide more detail on your disaster recovery plan in your service definition document.'
 type: boolean

--- a/frameworks/g-cloud-6/questions/services/dataExtractionRemoval.yml
+++ b/frameworks/g-cloud-6/questions/services/dataExtractionRemoval.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Data extraction/removal plan in place'
 type: boolean
 filterLabel: 'Data extraction/removal plan in place'

--- a/frameworks/g-cloud-6/questions/services/dataManagementLocations.yml
+++ b/frameworks/g-cloud-6/questions/services/dataManagementLocations.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/dataProtectionBetweenServices.yml
+++ b/frameworks/g-cloud-6/questions/services/dataProtectionBetweenServices.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/dataProtectionBetweenUserAndService.yml
+++ b/frameworks/g-cloud-6/questions/services/dataProtectionBetweenUserAndService.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/dataProtectionWithinService.yml
+++ b/frameworks/g-cloud-6/questions/services/dataProtectionWithinService.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/dataRedundantEquipmentAccountsRevoked.yml
+++ b/frameworks/g-cloud-6/questions/services/dataRedundantEquipmentAccountsRevoked.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: boolean
 filterLabel: 'Redundant equipment accounts revoked'

--- a/frameworks/g-cloud-6/questions/services/dataSecureDeletion.yml
+++ b/frameworks/g-cloud-6/questions/services/dataSecureDeletion.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/dataSecureEquipmentDisposal.yml
+++ b/frameworks/g-cloud-6/questions/services/dataSecureEquipmentDisposal.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type2
 type: boolean
 filterLabel: 'Secure equipment disposal'

--- a/frameworks/g-cloud-6/questions/services/dataStorageMediaDisposal.yml
+++ b/frameworks/g-cloud-6/questions/services/dataStorageMediaDisposal.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 5answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/datacentreLocations.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentreLocations.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/datacentreProtectionDisclosure.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentreProtectionDisclosure.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: boolean
 filterLabel: 'Datacentre protection'

--- a/frameworks/g-cloud-6/questions/services/datacentreTier.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentreTier.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Datacentre tier'
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/datacentresEUCode.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentresEUCode.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'
 type: boolean
 filterLabel: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'

--- a/frameworks/g-cloud-6/questions/services/datacentresSpecifyLocation.yml
+++ b/frameworks/g-cloud-6/questions/services/datacentresSpecifyLocation.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'User-defined data location'
 type: boolean
 filterLabel: 'User-defined data location'

--- a/frameworks/g-cloud-6/questions/services/deprovisioningTime.yml
+++ b/frameworks/g-cloud-6/questions/services/deprovisioningTime.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: ""
 type: text
 validations:

--- a/frameworks/g-cloud-6/questions/services/deviceAccessMethod.yml
+++ b/frameworks/g-cloud-6/questions/services/deviceAccessMethod.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/educationPricing.yml
+++ b/frameworks/g-cloud-6/questions/services/educationPricing.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Do you offer special pricing for educational organisations?'
 type: boolean
 filterLabel: 'Education pricing'

--- a/frameworks/g-cloud-6/questions/services/elasticCloud.yml
+++ b/frameworks/g-cloud-6/questions/services/elasticCloud.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Elastic cloud approach supported'
 validations:

--- a/frameworks/g-cloud-6/questions/services/eventMonitoring.yml
+++ b/frameworks/g-cloud-6/questions/services/eventMonitoring.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Event monitoring'

--- a/frameworks/g-cloud-6/questions/services/freeOption.yml
+++ b/frameworks/g-cloud-6/questions/services/freeOption.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Free option'
 validations:

--- a/frameworks/g-cloud-6/questions/services/governanceFramework.yml
+++ b/frameworks/g-cloud-6/questions/services/governanceFramework.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Governance framework'

--- a/frameworks/g-cloud-6/questions/services/guaranteedResources.yml
+++ b/frameworks/g-cloud-6/questions/services/guaranteedResources.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Guaranteed resources defined'
 validations:

--- a/frameworks/g-cloud-6/questions/services/hardwareSoftwareVerification.yml
+++ b/frameworks/g-cloud-6/questions/services/hardwareSoftwareVerification.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Hardware and software verification'

--- a/frameworks/g-cloud-6/questions/services/identityAuthenticationControls.yml
+++ b/frameworks/g-cloud-6/questions/services/identityAuthenticationControls.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type3
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/identityStandards.yml
+++ b/frameworks/g-cloud-6/questions/services/identityStandards.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
 hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
 listItemName: 'identity standards example'
 type: list

--- a/frameworks/g-cloud-6/questions/services/incidentDefinitionPublished.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentDefinitionPublished.yml
@@ -5,8 +5,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 hint: 'Do you publish to consumers your definition of a security incident, along with the format, incident triggers and timescales for reporting such incidents?'
 type: boolean

--- a/frameworks/g-cloud-6/questions/services/incidentEscalation.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentEscalation.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'Incident escalation process available'
 validations:

--- a/frameworks/g-cloud-6/questions/services/incidentManagementProcess.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentManagementProcess.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Incident management processes'

--- a/frameworks/g-cloud-6/questions/services/incidentManagementReporting.yml
+++ b/frameworks/g-cloud-6/questions/services/incidentManagementReporting.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Consumer reporting of security incidents'

--- a/frameworks/g-cloud-6/questions/services/interconnectionMethods.yml
+++ b/frameworks/g-cloud-6/questions/services/interconnectionMethods.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/legalJurisdiction.yml
+++ b/frameworks/g-cloud-6/questions/services/legalJurisdiction.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/lot.yml
+++ b/frameworks/g-cloud-6/questions/services/lot.yml
@@ -3,7 +3,7 @@ type: radios
 options:
   -
     label: Infrastructure as a Service (IaaS)
-    value: IaaS
+    value: iaas
     description: >
       Infrastructure is the hardware that makes software work. It’s the
       networks, hosting facilities and servers that platforms and software
@@ -11,21 +11,21 @@ options:
       the internet, without having to pay for your own hardware.
   -
     label: Software as a Service (SaaS)
-    value: SaaS
+    value: saas
     description: >
       SaaS is an application or service that can be run over the internet or
       in the cloud. Examples of SaaS include web-based email services,
       customer relationship management (CRM) software and analytics tools.
   -
     label: Platform as a Service (PaaS)
-    value: PaaS
+    value: paas
     description: >
       PaaS is a software platform that provides a basis for building other
       services and applications. With PaaS, you can set up, order, pay for
       and manage platforms in the cloud.
   -
     label: Specialist Cloud Services (SCS)
-    value: SCS
+    value: scs
     description: >
       Specialist Cloud Services support your transition to SaaS, PaaS and
       IaaS. Examples of SCS include cloud strategy, data transfer between

--- a/frameworks/g-cloud-6/questions/services/lotName.yml
+++ b/frameworks/g-cloud-6/questions/services/lotName.yml
@@ -1,0 +1,2 @@
+question: 'Service type'
+type: text

--- a/frameworks/g-cloud-6/questions/services/managementInterfaceProtection.yml
+++ b/frameworks/g-cloud-6/questions/services/managementInterfaceProtection.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'Management interface protection'

--- a/frameworks/g-cloud-6/questions/services/minimumContractPeriod.yml
+++ b/frameworks/g-cloud-6/questions/services/minimumContractPeriod.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: radios
 options:
     -

--- a/frameworks/g-cloud-6/questions/services/networksConnected.yml
+++ b/frameworks/g-cloud-6/questions/services/networksConnected.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/offlineWorking.yml
+++ b/frameworks/g-cloud-6/questions/services/offlineWorking.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Offline working and syncing supported'
 validations:

--- a/frameworks/g-cloud-6/questions/services/onboardingGuidance.yml
+++ b/frameworks/g-cloud-6/questions/services/onboardingGuidance.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Onboarding guidance provided'

--- a/frameworks/g-cloud-6/questions/services/openSource.yml
+++ b/frameworks/g-cloud-6/questions/services/openSource.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Open-source software used and supported'
 validations:

--- a/frameworks/g-cloud-6/questions/services/openStandardsSupported.yml
+++ b/frameworks/g-cloud-6/questions/services/openStandardsSupported.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Take a look at the [GOV.UK Open Standards principles](https://www.gov.uk/government/publications/open-standards-for-government) for more information on open standards.'
 type: boolean
 filterLabel: 'Open standards supported and documented'

--- a/frameworks/g-cloud-6/questions/services/otherConsumers.yml
+++ b/frameworks/g-cloud-6/questions/services/otherConsumers.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-6/questions/services/persistentStorage.yml
+++ b/frameworks/g-cloud-6/questions/services/persistentStorage.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Persistent storage supported'
 validations:

--- a/frameworks/g-cloud-6/questions/services/personnelSecurityChecks.yml
+++ b/frameworks/g-cloud-6/questions/services/personnelSecurityChecks.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/priceString.yml
+++ b/frameworks/g-cloud-6/questions/services/priceString.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 validations:
   -
     name: no_min_price_specified

--- a/frameworks/g-cloud-6/questions/services/pricingDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/pricingDocumentURL.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Please upload your pricing document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 validations:

--- a/frameworks/g-cloud-6/questions/services/provisioningTime.yml
+++ b/frameworks/g-cloud-6/questions/services/provisioningTime.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'How long does it take to get your service up and running? eg 1 to 5 hours or 2 to 3 days. (Maximum 20 words.)'
 type: text
 validations:

--- a/frameworks/g-cloud-6/questions/services/restrictAdministratorPermissions.yml
+++ b/frameworks/g-cloud-6/questions/services/restrictAdministratorPermissions.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'Administrator permissions'

--- a/frameworks/g-cloud-6/questions/services/secureConfigurationManagement.yml
+++ b/frameworks/g-cloud-6/questions/services/secureConfigurationManagement.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Software configuration management'

--- a/frameworks/g-cloud-6/questions/services/secureDesign.yml
+++ b/frameworks/g-cloud-6/questions/services/secureDesign.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Secure design, coding, testing and deployment'

--- a/frameworks/g-cloud-6/questions/services/secureDevelopment.yml
+++ b/frameworks/g-cloud-6/questions/services/secureDevelopment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Secure development'

--- a/frameworks/g-cloud-6/questions/services/selfServiceProvisioning.yml
+++ b/frameworks/g-cloud-6/questions/services/selfServiceProvisioning.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Self-service provisioning supported'
 validations:

--- a/frameworks/g-cloud-6/questions/services/serviceAvailabilityPercentage.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceAvailabilityPercentage.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: percentage
 filterLabel: 'Service availability'

--- a/frameworks/g-cloud-6/questions/services/serviceBenefits.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceBenefits.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 listItemName: 'service benefit'
 type: list
 addthing: 'Add another business benefit'

--- a/frameworks/g-cloud-6/questions/services/serviceConfigurationGuidance.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceConfigurationGuidance.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type2
 type: boolean
 filterLabel: 'Service configuration guidance'

--- a/frameworks/g-cloud-6/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceDefinitionDocumentURL.yml
@@ -5,9 +5,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: upload
 validations:
   -

--- a/frameworks/g-cloud-6/questions/services/serviceFeatures.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceFeatures.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 listItemName: 'service feature'
 type: list
 addthing: 'Add another feature'

--- a/frameworks/g-cloud-6/questions/services/serviceManagementModel.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceManagementModel.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceName.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: text
 validations:
   -

--- a/frameworks/g-cloud-6/questions/services/serviceOffboarding.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceOffboarding.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Service offboarding process included'
 validations:

--- a/frameworks/g-cloud-6/questions/services/serviceOnboarding.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceOnboarding.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Service onboarding process included'
 validations:

--- a/frameworks/g-cloud-6/questions/services/serviceSummary.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceSummary.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: textarea
 maxLengthInWords: 50
 validations:

--- a/frameworks/g-cloud-6/questions/services/serviceTypesIaaS.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceTypesIaaS.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - IaaS
+      - iaas
 hint: 'You can choose multiple categories.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/serviceTypesSCS.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceTypesSCS.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SCS
+      - scs
 hint: 'You can choose multiple categories'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/serviceTypesSaaS.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceTypesSaaS.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
 hint: 'You can choose multiple categories'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/servicesManagementSeparation.yml
+++ b/frameworks/g-cloud-6/questions/services/servicesManagementSeparation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type3
 type: boolean
 filterLabel: 'Services management separation'

--- a/frameworks/g-cloud-6/questions/services/servicesSeparation.yml
+++ b/frameworks/g-cloud-6/questions/services/servicesSeparation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type3
 type: boolean
 filterLabel: 'Services separation'

--- a/frameworks/g-cloud-6/questions/services/sfiaRateDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/sfiaRateDocumentURL.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Please upload your SFIA rate card if you have one. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 optional: yes

--- a/frameworks/g-cloud-6/questions/services/supportAvailability.yml
+++ b/frameworks/g-cloud-6/questions/services/supportAvailability.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'eg 24/7 or 9 to 5. (Maximum 20 words.)'
 type: text
 validations:

--- a/frameworks/g-cloud-6/questions/services/supportForThirdParties.yml
+++ b/frameworks/g-cloud-6/questions/services/supportForThirdParties.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'Support accessible to any third-party suppliers'
 validations:

--- a/frameworks/g-cloud-6/questions/services/supportResponseTime.yml
+++ b/frameworks/g-cloud-6/questions/services/supportResponseTime.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'How long will it take until support can begin to be provided? eg 1 hour or 1 business day. (Maximum 20 words.)'
 type: text
 validations:

--- a/frameworks/g-cloud-6/questions/services/supportTypes.yml
+++ b/frameworks/g-cloud-6/questions/services/supportTypes.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/supportedBrowsers.yml
+++ b/frameworks/g-cloud-6/questions/services/supportedBrowsers.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/supportedDevices.yml
+++ b/frameworks/g-cloud-6/questions/services/supportedDevices.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-6/questions/services/terminationCost.yml
+++ b/frameworks/g-cloud-6/questions/services/terminationCost.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'Termination cost'
 validations:

--- a/frameworks/g-cloud-6/questions/services/termsAndConditionsDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/termsAndConditionsDocumentURL.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Please upload your terms and conditions document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 validations:

--- a/frameworks/g-cloud-6/questions/services/thirdPartyComplianceMonitoring.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartyComplianceMonitoring.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier compliance monitoring'

--- a/frameworks/g-cloud-6/questions/services/thirdPartyDataSharingInformation.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartyDataSharingInformation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Visibility of data shared with third-party suppliers'

--- a/frameworks/g-cloud-6/questions/services/thirdPartyRiskAssessment.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartyRiskAssessment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier risk assessment'

--- a/frameworks/g-cloud-6/questions/services/thirdPartySecurityRequirements.yml
+++ b/frameworks/g-cloud-6/questions/services/thirdPartySecurityRequirements.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier security requirements'

--- a/frameworks/g-cloud-6/questions/services/trainingProvided.yml
+++ b/frameworks/g-cloud-6/questions/services/trainingProvided.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: Training

--- a/frameworks/g-cloud-6/questions/services/trialOption.yml
+++ b/frameworks/g-cloud-6/questions/services/trialOption.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Trial option'
 validations:

--- a/frameworks/g-cloud-6/questions/services/userAccessControlManagement.yml
+++ b/frameworks/g-cloud-6/questions/services/userAccessControlManagement.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User access control within management interfaces'

--- a/frameworks/g-cloud-6/questions/services/userAuthenticateManagement.yml
+++ b/frameworks/g-cloud-6/questions/services/userAuthenticateManagement.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User authentication and access management'

--- a/frameworks/g-cloud-6/questions/services/userAuthenticateSupport.yml
+++ b/frameworks/g-cloud-6/questions/services/userAuthenticateSupport.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User access control through support channels'

--- a/frameworks/g-cloud-6/questions/services/vatIncluded.yml
+++ b/frameworks/g-cloud-6/questions/services/vatIncluded.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'VAT included'
 validations:

--- a/frameworks/g-cloud-6/questions/services/vendorCertifications.yml
+++ b/frameworks/g-cloud-6/questions/services/vendorCertifications.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Examples of employee or company certifications include VMware Certified Professional and Oracle Gold Partner. (Optional.)'
 listItemName: 'certification example'
 type: list

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityAssessment.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityAssessment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability assessment'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityMitigationPrioritisation.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityMitigationPrioritisation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability mitigation prioritisation'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityMonitoring.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityMonitoring.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability monitoring'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityTimescales.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityTimescales.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability mitigation timescales'

--- a/frameworks/g-cloud-6/questions/services/vulnerabilityTracking.yml
+++ b/frameworks/g-cloud-6/questions/services/vulnerabilityTracking.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability tracking'

--- a/frameworks/g-cloud-7/manifests/edit_service.yml
+++ b/frameworks/g-cloud-7/manifests/edit_service.yml
@@ -3,7 +3,7 @@
   editable: false
   questions:
     - id
-    - lot
+    - lotName
 -
   name: Description
   editable: edit

--- a/frameworks/g-cloud-7/manifests/edit_service_as_admin.yml
+++ b/frameworks/g-cloud-7/manifests/edit_service_as_admin.yml
@@ -3,7 +3,7 @@
   editable: false
   questions:
     - id
-    - lot
+    - lotName
 -
   name: Description
   editable: true

--- a/frameworks/g-cloud-7/manifests/edit_submission.yml
+++ b/frameworks/g-cloud-7/manifests/edit_submission.yml
@@ -2,7 +2,7 @@
   name: Service attributes
   editable: false
   questions:
-    - lot
+    - lotName
 -
   name: Service name
   editable: true

--- a/frameworks/g-cloud-7/questions/services/analyticsAvailable.yml
+++ b/frameworks/g-cloud-7/questions/services/analyticsAvailable.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Real-time management information available'
 validations:

--- a/frameworks/g-cloud-7/questions/services/apiAccess.yml
+++ b/frameworks/g-cloud-7/questions/services/apiAccess.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'API access available and supported'
 validations:

--- a/frameworks/g-cloud-7/questions/services/apiType.yml
+++ b/frameworks/g-cloud-7/questions/services/apiType.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Examples of API include RESTful and SOAP.'
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/services/auditInformationProvided.yml
+++ b/frameworks/g-cloud-7/questions/services/auditInformationProvided.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/changeImpactAssessment.yml
+++ b/frameworks/g-cloud-7/questions/services/changeImpactAssessment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Change impact assessment'

--- a/frameworks/g-cloud-7/questions/services/cloudDeploymentModel.yml
+++ b/frameworks/g-cloud-7/questions/services/cloudDeploymentModel.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/codeLibraryLanguages.yml
+++ b/frameworks/g-cloud-7/questions/services/codeLibraryLanguages.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
 hint: 'Examples of code libraries include AWS Ruby SDK and Stripe-Java. Examples of languages include PHP and Python. (Maximum 10 languages.) (Optional.) '
 listItemName: 'code libraries example'
 type: list

--- a/frameworks/g-cloud-7/questions/services/configurationTracking.yml
+++ b/frameworks/g-cloud-7/questions/services/configurationTracking.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Configuration and change management tracking'

--- a/frameworks/g-cloud-7/questions/services/dataAtRestProtections.yml
+++ b/frameworks/g-cloud-7/questions/services/dataAtRestProtections.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/dataBackupRecovery.yml
+++ b/frameworks/g-cloud-7/questions/services/dataBackupRecovery.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Backup, disaster recovery and resilience plan in place'
 hint: 'You can provide more detail on your disaster recovery plan in your service definition document.'
 type: boolean

--- a/frameworks/g-cloud-7/questions/services/dataExtractionRemoval.yml
+++ b/frameworks/g-cloud-7/questions/services/dataExtractionRemoval.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Data extraction/removal plan in place'
 type: boolean
 filterLabel: 'Data extraction/removal plan in place'

--- a/frameworks/g-cloud-7/questions/services/dataManagementLocations.yml
+++ b/frameworks/g-cloud-7/questions/services/dataManagementLocations.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/dataProtectionBetweenServices.yml
+++ b/frameworks/g-cloud-7/questions/services/dataProtectionBetweenServices.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/dataProtectionBetweenUserAndService.yml
+++ b/frameworks/g-cloud-7/questions/services/dataProtectionBetweenUserAndService.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/dataProtectionWithinService.yml
+++ b/frameworks/g-cloud-7/questions/services/dataProtectionWithinService.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/dataRedundantEquipmentAccountsRevoked.yml
+++ b/frameworks/g-cloud-7/questions/services/dataRedundantEquipmentAccountsRevoked.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: boolean
 filterLabel: 'Redundant equipment accounts revoked'

--- a/frameworks/g-cloud-7/questions/services/dataSecureDeletion.yml
+++ b/frameworks/g-cloud-7/questions/services/dataSecureDeletion.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/dataSecureEquipmentDisposal.yml
+++ b/frameworks/g-cloud-7/questions/services/dataSecureEquipmentDisposal.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type2
 type: boolean
 filterLabel: 'Secure equipment disposal'

--- a/frameworks/g-cloud-7/questions/services/dataStorageMediaDisposal.yml
+++ b/frameworks/g-cloud-7/questions/services/dataStorageMediaDisposal.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 5answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/datacentreLocations.yml
+++ b/frameworks/g-cloud-7/questions/services/datacentreLocations.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/datacentreProtectionDisclosure.yml
+++ b/frameworks/g-cloud-7/questions/services/datacentreProtectionDisclosure.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: boolean
 filterLabel: 'Datacentre protection'

--- a/frameworks/g-cloud-7/questions/services/datacentreTier.yml
+++ b/frameworks/g-cloud-7/questions/services/datacentreTier.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Datacentre tier'
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/datacentresEUCode.yml
+++ b/frameworks/g-cloud-7/questions/services/datacentresEUCode.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'
 type: boolean
 filterLabel: 'Datacentres adhere to the EU code of conduct for energy-efficient datacentres'

--- a/frameworks/g-cloud-7/questions/services/datacentresSpecifyLocation.yml
+++ b/frameworks/g-cloud-7/questions/services/datacentresSpecifyLocation.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 servicePageLabel: 'User-defined data location'
 type: boolean
 filterLabel: 'User-defined data location'

--- a/frameworks/g-cloud-7/questions/services/deprovisioningTime.yml
+++ b/frameworks/g-cloud-7/questions/services/deprovisioningTime.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: ""
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/services/deviceAccessMethod.yml
+++ b/frameworks/g-cloud-7/questions/services/deviceAccessMethod.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/educationPricing.yml
+++ b/frameworks/g-cloud-7/questions/services/educationPricing.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Do you offer special pricing for educational organisations?'
 type: boolean
 filterLabel: 'Education pricing'

--- a/frameworks/g-cloud-7/questions/services/elasticCloud.yml
+++ b/frameworks/g-cloud-7/questions/services/elasticCloud.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Elastic cloud approach supported'
 validations:

--- a/frameworks/g-cloud-7/questions/services/eventMonitoring.yml
+++ b/frameworks/g-cloud-7/questions/services/eventMonitoring.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Event monitoring'

--- a/frameworks/g-cloud-7/questions/services/freeOption.yml
+++ b/frameworks/g-cloud-7/questions/services/freeOption.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Free option'
 validations:

--- a/frameworks/g-cloud-7/questions/services/governanceFramework.yml
+++ b/frameworks/g-cloud-7/questions/services/governanceFramework.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Governance framework'

--- a/frameworks/g-cloud-7/questions/services/guaranteedResources.yml
+++ b/frameworks/g-cloud-7/questions/services/guaranteedResources.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Guaranteed resources defined'
 validations:

--- a/frameworks/g-cloud-7/questions/services/hardwareSoftwareVerification.yml
+++ b/frameworks/g-cloud-7/questions/services/hardwareSoftwareVerification.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Hardware and software verification'

--- a/frameworks/g-cloud-7/questions/services/identityAuthenticationControls.yml
+++ b/frameworks/g-cloud-7/questions/services/identityAuthenticationControls.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type3
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/identityStandards.yml
+++ b/frameworks/g-cloud-7/questions/services/identityStandards.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
 hint: 'Examples of identity standards include OAuth and SAML. (Optional.)'
 listItemName: 'identity standards example'
 type: list

--- a/frameworks/g-cloud-7/questions/services/incidentDefinitionPublished.yml
+++ b/frameworks/g-cloud-7/questions/services/incidentDefinitionPublished.yml
@@ -5,8 +5,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 hint: 'Do you publish to consumers your definition of a security incident, along with the format, incident triggers and timescales for reporting such incidents?'
 type: boolean

--- a/frameworks/g-cloud-7/questions/services/incidentEscalation.yml
+++ b/frameworks/g-cloud-7/questions/services/incidentEscalation.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'Incident escalation process available'
 validations:

--- a/frameworks/g-cloud-7/questions/services/incidentManagementProcess.yml
+++ b/frameworks/g-cloud-7/questions/services/incidentManagementProcess.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Incident management processes'

--- a/frameworks/g-cloud-7/questions/services/incidentManagementReporting.yml
+++ b/frameworks/g-cloud-7/questions/services/incidentManagementReporting.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Consumer reporting of security incidents'

--- a/frameworks/g-cloud-7/questions/services/interconnectionMethods.yml
+++ b/frameworks/g-cloud-7/questions/services/interconnectionMethods.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/legalJurisdiction.yml
+++ b/frameworks/g-cloud-7/questions/services/legalJurisdiction.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/lot.yml
+++ b/frameworks/g-cloud-7/questions/services/lot.yml
@@ -3,7 +3,7 @@ type: radios
 options:
   -
     label: Infrastructure as a Service (IaaS)
-    value: IaaS
+    value: iaas
     description: >
       Infrastructure is the hardware that makes software work. It’s the
       networks, hosting facilities and servers that platforms and software
@@ -11,21 +11,21 @@ options:
       the internet, without having to pay for your own hardware.
   -
     label: Software as a Service (SaaS)
-    value: SaaS
+    value: saas
     description: >
       SaaS is an application or service that can be run over the internet or
       in the cloud. Examples of SaaS include web-based email services,
       customer relationship management (CRM) software and analytics tools.
   -
     label: Platform as a Service (PaaS)
-    value: PaaS
+    value: paas
     description: >
       PaaS is a software platform that provides a basis for building other
       services and applications. With PaaS, you can set up, order, pay for
       and manage platforms in the cloud.
   -
     label: Specialist Cloud Services (SCS)
-    value: SCS
+    value: scs
     description: >
       Specialist Cloud Services support your transition to SaaS, PaaS and
       IaaS. Examples of SCS include cloud strategy, data transfer between

--- a/frameworks/g-cloud-7/questions/services/lotName.yml
+++ b/frameworks/g-cloud-7/questions/services/lotName.yml
@@ -1,0 +1,2 @@
+question: 'Service type'
+type: text

--- a/frameworks/g-cloud-7/questions/services/managementInterfaceProtection.yml
+++ b/frameworks/g-cloud-7/questions/services/managementInterfaceProtection.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'Management interface protection'

--- a/frameworks/g-cloud-7/questions/services/minimumContractPeriod.yml
+++ b/frameworks/g-cloud-7/questions/services/minimumContractPeriod.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: radios
 options:
     -

--- a/frameworks/g-cloud-7/questions/services/networksConnected.yml
+++ b/frameworks/g-cloud-7/questions/services/networksConnected.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/offlineWorking.yml
+++ b/frameworks/g-cloud-7/questions/services/offlineWorking.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Offline working and syncing supported'
 validations:

--- a/frameworks/g-cloud-7/questions/services/onboardingGuidance.yml
+++ b/frameworks/g-cloud-7/questions/services/onboardingGuidance.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Onboarding guidance provided'

--- a/frameworks/g-cloud-7/questions/services/openSource.yml
+++ b/frameworks/g-cloud-7/questions/services/openSource.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Open-source software used and supported'
 validations:

--- a/frameworks/g-cloud-7/questions/services/openStandardsSupported.yml
+++ b/frameworks/g-cloud-7/questions/services/openStandardsSupported.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Take a look at the [GOV.UK Open Standards principles](https://www.gov.uk/government/publications/open-standards-for-government) for more information on open standards.'
 type: boolean
 filterLabel: 'Open standards supported and documented'

--- a/frameworks/g-cloud-7/questions/services/otherConsumers.yml
+++ b/frameworks/g-cloud-7/questions/services/otherConsumers.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: radios
 options:

--- a/frameworks/g-cloud-7/questions/services/persistentStorage.yml
+++ b/frameworks/g-cloud-7/questions/services/persistentStorage.yml
@@ -4,8 +4,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Persistent storage supported'
 validations:

--- a/frameworks/g-cloud-7/questions/services/personnelSecurityChecks.yml
+++ b/frameworks/g-cloud-7/questions/services/personnelSecurityChecks.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/priceString.yml
+++ b/frameworks/g-cloud-7/questions/services/priceString.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 validations:
   -
     name: no_min_price_specified

--- a/frameworks/g-cloud-7/questions/services/pricingDocumentURL.yml
+++ b/frameworks/g-cloud-7/questions/services/pricingDocumentURL.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Please upload your pricing document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 validations:

--- a/frameworks/g-cloud-7/questions/services/provisioningTime.yml
+++ b/frameworks/g-cloud-7/questions/services/provisioningTime.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'How long does it take to get your service up and running? eg 1 to 5 hours or 2 to 3 days. (Maximum 20 words.)'
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/services/restrictAdministratorPermissions.yml
+++ b/frameworks/g-cloud-7/questions/services/restrictAdministratorPermissions.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'Administrator permissions'

--- a/frameworks/g-cloud-7/questions/services/secureConfigurationManagement.yml
+++ b/frameworks/g-cloud-7/questions/services/secureConfigurationManagement.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Software configuration management'

--- a/frameworks/g-cloud-7/questions/services/secureDesign.yml
+++ b/frameworks/g-cloud-7/questions/services/secureDesign.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Secure design, coding, testing and deployment'

--- a/frameworks/g-cloud-7/questions/services/secureDevelopment.yml
+++ b/frameworks/g-cloud-7/questions/services/secureDevelopment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Secure development'

--- a/frameworks/g-cloud-7/questions/services/selfServiceProvisioning.yml
+++ b/frameworks/g-cloud-7/questions/services/selfServiceProvisioning.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Self-service provisioning supported'
 validations:

--- a/frameworks/g-cloud-7/questions/services/serviceAvailabilityPercentage.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceAvailabilityPercentage.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type1
 type: percentage
 filterLabel: 'Service availability'

--- a/frameworks/g-cloud-7/questions/services/serviceBenefits.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceBenefits.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 listItemName: 'service benefit'
 type: list
 addthing: 'Add another business benefit'

--- a/frameworks/g-cloud-7/questions/services/serviceConfigurationGuidance.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceConfigurationGuidance.yml
@@ -6,7 +6,9 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 3answers-type2
 type: boolean
 filterLabel: 'Service configuration guidance'

--- a/frameworks/g-cloud-7/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceDefinitionDocumentURL.yml
@@ -5,9 +5,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: upload
 validations:
   -

--- a/frameworks/g-cloud-7/questions/services/serviceFeatures.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceFeatures.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 listItemName: 'service feature'
 type: list
 addthing: 'Add another feature'

--- a/frameworks/g-cloud-7/questions/services/serviceManagementModel.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceManagementModel.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceName.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: text
 validations:
   -

--- a/frameworks/g-cloud-7/questions/services/serviceOffboarding.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceOffboarding.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Service offboarding process included'
 validations:

--- a/frameworks/g-cloud-7/questions/services/serviceOnboarding.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceOnboarding.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Service onboarding process included'
 validations:

--- a/frameworks/g-cloud-7/questions/services/serviceSummary.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceSummary.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: textarea
 maxLengthInWords: 50
 validations:

--- a/frameworks/g-cloud-7/questions/services/serviceTypesIaaS.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceTypesIaaS.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - IaaS
+      - iaas
 hint: 'You can choose multiple categories.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/serviceTypesSCS.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceTypesSCS.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SCS
+      - scs
 hint: 'You can choose multiple categories'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/serviceTypesSaaS.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceTypesSaaS.yml
@@ -3,6 +3,7 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
 hint: 'You can choose multiple categories'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/servicesManagementSeparation.yml
+++ b/frameworks/g-cloud-7/questions/services/servicesManagementSeparation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type3
 type: boolean
 filterLabel: 'Services management separation'

--- a/frameworks/g-cloud-7/questions/services/servicesSeparation.yml
+++ b/frameworks/g-cloud-7/questions/services/servicesSeparation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 4answers-type3
 type: boolean
 filterLabel: 'Services separation'

--- a/frameworks/g-cloud-7/questions/services/sfiaRateDocumentURL.yml
+++ b/frameworks/g-cloud-7/questions/services/sfiaRateDocumentURL.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Please upload your SFIA rate card if you have one. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 optional: yes

--- a/frameworks/g-cloud-7/questions/services/supportAvailability.yml
+++ b/frameworks/g-cloud-7/questions/services/supportAvailability.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'eg 24/7 or 9 to 5. (Maximum 20 words.)'
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/services/supportForThirdParties.yml
+++ b/frameworks/g-cloud-7/questions/services/supportForThirdParties.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'Support accessible to any third-party suppliers'
 validations:

--- a/frameworks/g-cloud-7/questions/services/supportResponseTime.yml
+++ b/frameworks/g-cloud-7/questions/services/supportResponseTime.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'How long will it take until support can begin to be provided? eg 1 hour or 1 business day. (Maximum 20 words.)'
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/services/supportTypes.yml
+++ b/frameworks/g-cloud-7/questions/services/supportTypes.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/supportedBrowsers.yml
+++ b/frameworks/g-cloud-7/questions/services/supportedBrowsers.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/supportedDevices.yml
+++ b/frameworks/g-cloud-7/questions/services/supportedDevices.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 hint: 'Choose all that apply.'
 type: checkboxes
 options:

--- a/frameworks/g-cloud-7/questions/services/terminationCost.yml
+++ b/frameworks/g-cloud-7/questions/services/terminationCost.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'Termination cost'
 validations:

--- a/frameworks/g-cloud-7/questions/services/termsAndConditionsDocumentURL.yml
+++ b/frameworks/g-cloud-7/questions/services/termsAndConditionsDocumentURL.yml
@@ -4,9 +4,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Please upload your terms and conditions document. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 type: upload
 validations:

--- a/frameworks/g-cloud-7/questions/services/thirdPartyComplianceMonitoring.yml
+++ b/frameworks/g-cloud-7/questions/services/thirdPartyComplianceMonitoring.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier compliance monitoring'

--- a/frameworks/g-cloud-7/questions/services/thirdPartyDataSharingInformation.yml
+++ b/frameworks/g-cloud-7/questions/services/thirdPartyDataSharingInformation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Visibility of data shared with third-party suppliers'

--- a/frameworks/g-cloud-7/questions/services/thirdPartyRiskAssessment.yml
+++ b/frameworks/g-cloud-7/questions/services/thirdPartyRiskAssessment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier risk assessment'

--- a/frameworks/g-cloud-7/questions/services/thirdPartySecurityRequirements.yml
+++ b/frameworks/g-cloud-7/questions/services/thirdPartySecurityRequirements.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Third-party supplier security requirements'

--- a/frameworks/g-cloud-7/questions/services/trainingProvided.yml
+++ b/frameworks/g-cloud-7/questions/services/trainingProvided.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: Training

--- a/frameworks/g-cloud-7/questions/services/trialOption.yml
+++ b/frameworks/g-cloud-7/questions/services/trialOption.yml
@@ -3,8 +3,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 type: boolean
 filterLabel: 'Trial option'
 validations:

--- a/frameworks/g-cloud-7/questions/services/userAccessControlManagement.yml
+++ b/frameworks/g-cloud-7/questions/services/userAccessControlManagement.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User access control within management interfaces'

--- a/frameworks/g-cloud-7/questions/services/userAuthenticateManagement.yml
+++ b/frameworks/g-cloud-7/questions/services/userAuthenticateManagement.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User authentication and access management'

--- a/frameworks/g-cloud-7/questions/services/userAuthenticateSupport.yml
+++ b/frameworks/g-cloud-7/questions/services/userAuthenticateSupport.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type2
 type: boolean
 filterLabel: 'User access control through support channels'

--- a/frameworks/g-cloud-7/questions/services/vatIncluded.yml
+++ b/frameworks/g-cloud-7/questions/services/vatIncluded.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 type: boolean
 filterLabel: 'VAT included'
 validations:

--- a/frameworks/g-cloud-7/questions/services/vendorCertifications.yml
+++ b/frameworks/g-cloud-7/questions/services/vendorCertifications.yml
@@ -3,9 +3,13 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
       - SCS
+      - scs
 hint: 'Examples of employee or company certifications include VMware Certified Professional and Oracle Gold Partner. (Optional.)'
 listItemName: 'certification example'
 type: list

--- a/frameworks/g-cloud-7/questions/services/vulnerabilityAssessment.yml
+++ b/frameworks/g-cloud-7/questions/services/vulnerabilityAssessment.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability assessment'

--- a/frameworks/g-cloud-7/questions/services/vulnerabilityMitigationPrioritisation.yml
+++ b/frameworks/g-cloud-7/questions/services/vulnerabilityMitigationPrioritisation.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability mitigation prioritisation'

--- a/frameworks/g-cloud-7/questions/services/vulnerabilityMonitoring.yml
+++ b/frameworks/g-cloud-7/questions/services/vulnerabilityMonitoring.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability monitoring'

--- a/frameworks/g-cloud-7/questions/services/vulnerabilityTimescales.yml
+++ b/frameworks/g-cloud-7/questions/services/vulnerabilityTimescales.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability mitigation timescales'

--- a/frameworks/g-cloud-7/questions/services/vulnerabilityTracking.yml
+++ b/frameworks/g-cloud-7/questions/services/vulnerabilityTracking.yml
@@ -6,8 +6,11 @@ depends:
     "on": lot
     being:
       - SaaS
+      - saas
       - PaaS
+      - paas
       - IaaS
+      - iaas
 assuranceApproach: 2answers-type1
 type: boolean
 filterLabel: 'Vulnerability tracking'


### PR DESCRIPTION
Related to https://github.com/alphagov/digitalmarketplace-api/pull/273 and should be deployed to all apps before the API can be merged

### Lowercase lot values
Lot slugs are now all lowercase when returned and accepted by the
API.

### Add uppercase and lowercase lot slugs to question depends
Supporting both lowercase and mixed-case lot slugs makes sure the
apps are working during the API lot changes deployment.

Only lowercase slugs should be used from now on and the mixed-case
abbreviations could be removed once the apps have transitioned.

### Add lotName question
Since the new lot slugs are lowercased they shouldn't be displayed
by the frontend apps. Instead, we use the new service.lotName field
for display and create a mock question to map to that field.