### PR TITLE
[#105005304] Add homepage sidebar framework messages.

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
@@ -1,0 +1,42 @@
+coming:
+  template_name: 'framework-notice'
+  heading: 'Become a Digital Outcomes and Specialists supplier'
+  message: >
+    **Digital Outcomes and Specialists will be open for applications soon.**
+
+
+    You can apply to provide:
+
+      - digital outcomes,
+        eg a discovery phase or an online billing application
+      - digital specialists,
+        eg service managers or developers
+      - user research studios
+      - user research participants
+
+    [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) to receive an email when Digital Outcomes and Specialists opens.
+
+
+    [Find out how to apply](https://www.digitalmarketplace.service.gov.uk/)
+
+open:  
+  template_name: 'framework-notice'
+  heading: 'Become a Digital Outcomes and Specialists supplier'
+  subheading: 'Deadline: 14 February 2016'
+  message: >
+    **Digital Outcomes and Specialists is open for applications.**
+
+
+    You can apply to provide:
+
+      - digital outcomes,
+        eg a discovery phase or an online billing application
+      - digital specialists,
+        eg service managers or developers
+      - user research studios
+      - user research participants
+
+    [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) or [log in](https://www.digitalmarketplace.service.gov.uk/suppliers/login) to apply.
+
+
+    [Find out how to apply](https://www.digitalmarketplace.service.gov.uk/)

--- a/frameworks/g-cloud-7/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-7/messages/homepage-sidebar.yml
@@ -1,0 +1,6 @@
+pending:
+  template_name: 'temporary-message'
+  heading: 'G-Cloud 7 is closed for applications.'
+  messages:
+    - 'Applications are being reviewed.'
+    - 'G-Cloud 7 services will be available from 23 November 2015.'

--- a/frameworks/g-cloud-7/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-7/messages/homepage-sidebar.yml
@@ -1,6 +1,6 @@
 pending:
   template_name: 'temporary-message'
-  heading: 'G-Cloud 7 is closed for applications.'
+  heading: 'G‑Cloud 7 is closed for applications'
   messages:
     - 'Applications are being reviewed.'
-    - 'G-Cloud 7 services will be available from 23 November 2015.'
+    - 'G‑Cloud 7 services will be available from 23 November 2015.'

--- a/tests/schemas/messages.json
+++ b/tests/schemas/messages.json
@@ -1,0 +1,17 @@
+{
+  "title": "Message",
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "coming": {
+      "type": "object"
+    },
+    "open": {
+      "type": "object"
+    },
+    "pending": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
#### Note that most of the links are currently incorrect.

Isolating content which is dependent on:
- a framework
- the status of that framework

Changes messages on the home page as framework statuses change.  Means we don't have to mess about with feature flags or anything silly like that.  

Added a JSON schema because the tests were breaking, but there's very little in it because messages seem like bad things to try and overdetermine.

-
[>> Ralph's prototype displaying the messages](http://dm-prototype.herokuapp.com/states/homepage?dos.framework=open)
[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/105005304)