### PR TITLE
Add digital-outcomes-and-specialists lot descriptions

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/services/lot.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/lot.yml
@@ -4,12 +4,32 @@ options:
   -
     label: Digital outcomes
     value: digital-outcomes
+    description: >
+      Provide teams to build and support digital outcomes.
+
+
+      Examples of digital outcomes include a discovery phase or an online billing application.
   -
     label: Digital specialists
     value: digital-specialists
-  - 
+    description: >
+      Provide individual specialists to work on digital services, programmes or projects.
+
+
+      Examples of digital specialists include content designers or technical architects.
+  -
     label: User research studios
     value: user-research-studios
+    description: >
+      Add studios for user research sessions and workshops.
+
+
+      Buyers will see this information and use it to choose the studio they want to hire.
   -
     label: User research participants
     value: user-research-participants
+    description: >
+      Provide user research participant recruitment services.
+
+
+      Examples of participant recruitment services include finding and managing research participants from specific user groups.


### PR DESCRIPTION
Initial descriptions copied from the digitalmarketplace-prototype.
Lot question is used to render the lot selection page with lot
descriptions for each lot.