### PR TITLE
Add serviceName question for user research studios

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_submission.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_submission.yml
@@ -1,8 +1,8 @@
 -
-  name: Service attributes
-  editable: false
+  name: Studio name
+  editable: True
   questions:
-    - lot
+    - serviceName
 
 - name: Supplier information
   editable: True

--- a/frameworks/digital-outcomes-and-specialists/questions/services/serviceName.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/serviceName.yml
@@ -1,0 +1,17 @@
+question: What is the name of the studio?
+type: text
+hint: A studio is the room in which the participant(s) and moderator(s) carry out testing. The name will help buyers refer to the right studio when communicating with you.
+
+depends:
+  -
+    "on": lot
+    being:
+      - user-research-studios
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your studio name can't be more than 100 characters."


### PR DESCRIPTION
Sets serviceName to be the first question so that every created
draft has a name to display in the service list, similar to G7.

Question is copied from the current prototype.