### PR TITLE
Add generate-schemas script to create JSON schemas from content files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+docopt==0.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@13.2.0#egg=digitalmarketplace-utils==13.2.0

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+"""Generate JSON schemas from the frameworks questions content.
+
+Usage:
+    generate-schemas.py --output-path=<output_path>
+
+"""
+
+import os
+import re
+import json
+
+from docopt import docopt
+from dmutils.content_loader import ContentLoader
+
+
+SCHEMAS = [
+    ('G-Cloud 7 SCS', 'g-cloud-7', 'scs'),
+    ('G-Cloud 7 IaaS', 'g-cloud-7', 'iaas'),
+    ('G-Cloud 7 PaaS', 'g-cloud-7', 'paas'),
+    ('G-Cloud 7 SaaS', 'g-cloud-7', 'saas'),
+    ('Digital Outcomes and Specialists Digital outcomes',
+     'digital-outcomes-and-specialists', 'digital-outcomes'),
+    ('Digital Outcomes and Specialists Digital specialists',
+     'digital-outcomes-and-specialists', 'digital-specialists'),
+    ('Digital Outcomes and Specialists User research studios',
+     'digital-outcomes-and-specialists', 'user-research-studios'),
+    ('Digital Outcomes and Specialists User research participants',
+     'digital-outcomes-and-specialists', 'user-research-participants'),
+]
+
+
+def load_questions(framework_slug, lot_slug):
+    loader = ContentLoader('./')
+    loader.load_manifest(framework_slug, 'services', 'edit_submission')
+
+    builder = loader.get_builder(framework_slug, 'edit_submission').filter({'lot': lot_slug})
+    return {q['id']: q for q in sum((s.questions for s in builder.sections), [])}
+
+
+def drop_non_schema_questions(questions):
+    for key in ['id', 'lot', 'lotName']:
+        questions.pop(key, None)
+
+
+def empty_schema(schema_name):
+    return {
+        "title": "{} Service Schema".format(schema_name),
+        "$schema": "http://json-schema.org/schema#",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {},
+        "required": [],
+    }
+
+
+def text_property(question):
+    data = {
+        "type": "string",
+        "minLength": 0 if question.get('optional') else 1,
+    }
+
+    data.update(parse_question_limits(question))
+
+    return {question['id']: data}
+
+
+def uri_property(question):
+    return {question['id']: {
+        "type": "string",
+        "format": "uri",
+    }}
+
+
+def checkbox_property(question):
+    return {question['id']: {
+        "type": "array",
+        "uniqueItems": True,
+        "minItems": 0 if question.get('optional') else 1,
+        "maxItems": len(question['options']),
+        "items": {
+            "enum": [option['label'] for option in question['options']]
+        }
+    }}
+
+
+def radios_property(question):
+    return {question['id']: {
+        "enum": [option['label'] for option in question['options']]
+    }}
+
+
+def boolean_property(question):
+    return {question['id']: {
+        "type": "boolean"
+    }}
+
+
+def list_property(question):
+    return {question['id']: {
+        "type": "array",
+        "minItems": 0 if question.get('optional') else 1,
+        "maxItems": 10,
+        "items": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "^(?:\\S+\\s+){0,9}\\S+$"
+        }
+    }}
+
+
+def pricing_property(question):
+    return {
+        "priceMin": {
+            "type": "string",
+            "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+        },
+        "priceMax": {
+            "type": "string",
+            "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
+        },
+        "priceUnit": {
+            "enum": [
+                "Unit",
+                "Person",
+                "Licence",
+                "User",
+                "Device",
+                "Instance",
+                "Server",
+                "Virtual machine",
+                "Transaction",
+                "Megabyte",
+                "Gigabyte",
+                "Terabyte"
+            ]
+        },
+        "priceInterval": {
+            "enum": [
+                "",
+                "Second",
+                "Minute",
+                "Hour",
+                "Day",
+                "Week",
+                "Month",
+                "Quarter",
+                "6 months",
+                "Year"
+            ]
+        },
+    }
+
+
+def percentage_property(question):
+    return {question['id']: {
+        "exclusiveMaximum": True,
+        "maximum": 100,
+        "minimum": 0,
+        "type": "number"
+    }}
+
+
+QUESTION_TYPES = {
+    'text': text_property,
+    'upload': uri_property,
+    'textbox_large': text_property,
+    'checkboxes': checkbox_property,
+    'radios': radios_property,
+    'boolean': boolean_property,
+    'list': list_property,
+    'pricing': pricing_property,
+    'percentage': percentage_property,
+}
+
+
+def parse_question_limits(question):
+    limits = {}
+    word_length_validator = next(
+        iter(filter(None, (
+            re.match('under_(\d+)_words', validator['name'])
+            for validator in question.get('validations', [])
+        ))),
+        None
+    )
+    char_length_validator = next(
+        iter(filter(None, (
+            re.search('(\d+)', validator['message'])
+            for validator in question.get('validations', [])
+            if validator['name'] == 'under_character_limit'
+        ))),
+        None
+    )
+
+    char_length = question.get('max_length') or (char_length_validator and char_length_validator.group(1))
+    word_length = question.get('max_length_in_words') or (word_length_validator and word_length_validator.group(1))
+
+    if char_length:
+        limits['maxLength'] = int(char_length)
+
+    if word_length:
+        if question.get('optional'):
+            limits['pattern'] = r"^$|(^(?:\S+\s+){0,%s}\S+$)" % (int(word_length) - 1)
+        else:
+            limits['pattern'] = r"^(?:\S+\s+){0,%s}\S+$" % (int(word_length) - 1)
+
+    return limits
+
+
+def add_assurance(value_schema, assurance_approach):
+    assurance_options = {
+        '2answers-type1': [
+            'Service provider assertion', 'Independent validation of assertion'
+        ],
+        '3answers-type1': [
+            'Service provider assertion', 'Contractual commitment', 'Independent validation of assertion'
+        ],
+        '3answers-type2': [
+            'Service provider assertion', 'Independent validation of assertion',
+            'Independent testing of implementation'
+        ],
+        '3answers-type3': [
+            'Service provider assertion', 'Independent testing of implementation', 'CESG-assured components'
+        ],
+        '3answers-type4': [
+            'Service provider assertion', 'Independent validation of assertion',
+            'Independent testing of implementation'
+        ],
+        '4answers-type1': [
+            'Service provider assertion', 'Independent validation of assertion',
+            'Independent testing of implementation', 'CESG-assured components'
+        ],
+        '4answers-type2': [
+            'Service provider assertion', 'Contractual commitment',
+            'Independent validation of assertion', 'CESG-assured components'
+        ],
+        '4answers-type3': [
+            'Service provider assertion', 'Independent testing of implementation',
+            'Assurance of service design', 'CESG-assured components'
+        ],
+        '5answers-type1': [
+            'Service provider assertion', 'Contractual commitment', 'Independent validation of assertion',
+            'Independent testing of implementation', 'CESG-assured components'
+        ]
+    }
+
+    return {
+        "type": "object",
+        "properties": {
+            "assurance": {
+                "enum": assurance_options[assurance_approach]
+            },
+            "value": value_schema,
+        },
+        "required": [
+            "value",
+            "assurance"
+        ]
+    }
+
+
+def build_question_properties(question):
+    question_data = QUESTION_TYPES[question['type']](question)
+    if question.get('assuranceApproach'):
+        for key, value_schema in question_data.items():
+            question_data[key] = add_assurance(value_schema, question['assuranceApproach'])
+    return question_data
+
+
+def build_schema_properties(schema, questions):
+    for key, question in questions.items():
+        schema['properties'].update(build_question_properties(question))
+        if not question.get('optional'):
+            if key == 'priceString':
+                schema['required'].extend(['priceMin', 'priceUnit'])
+            else:
+                schema['required'].append(key)
+
+    schema['required'].sort()
+
+    return schema
+
+
+def generate_schema(path, schema_name, framework_slug, lot_slug):
+    questions = load_questions(framework_slug, lot_slug)
+    drop_non_schema_questions(questions)
+    schema = empty_schema(schema_name)
+
+    build_schema_properties(schema, questions)
+
+    with open(os.path.join(path, 'services-{}-{}.json'.format(framework_slug, lot_slug)), 'w') as f:
+        json.dump(schema, f, sort_keys=True, indent=2, separators=(',', ': '))
+        f.write('\n')
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+    for schema in SCHEMAS:
+        generate_schema(arguments['--output-path'], *schema)


### PR DESCRIPTION
Script loads the question files for the given lot and generates a schema
using predefined property templates for different question types.

Current limitations and workarounds:

* Script is using dmutils ContentLoader to get a list of questions and
  `edit_submission` manifest is assumed to contain the full list of
  service data questions
* Pricing fields are treated differently when added to the list of
  required keys
* Assertion answer sets are hardcoded and need to be updated if the
  content changes
* Question max length and word length limits are parsed from the
  question validations. This should be replaced with `max_length`
  and `max_length_in_words` question properties eventually.

Script outputs a JSON file with sorted keys and "required" list.
Script output matches the current G7 schema files, apart from the
added "minItems" and "minLength" records that were skipped in the
G7 schemas.