### PR TITLE
What to do if you have an account and link to blog

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
@@ -8,16 +8,19 @@ coming:
     You can apply to provide:
 
       - digital outcomes,
-        eg a discovery phase or an online billing application
+        eg a discovery phase for an online billing application
       - digital specialists,
         eg service managers or developers
       - user research studios
       - user research participants
 
-    [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) to receive an email when Digital Outcomes and Specialists opens.
-
-
-    [Find out how to apply](https://www.digitalmarketplace.service.gov.uk/)
+    [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) to receive an email when Digital Outcomes and Specialists opens. 
+    
+    
+    If you already have an account you’ll be notified by email when Digital Outcomes and Specialists opens.
+    
+    
+    [Find out if your services are suitable](https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/)
 
 open:  
   template_name: 'framework-notice'
@@ -30,7 +33,7 @@ open:
     You can apply to provide:
 
       - digital outcomes,
-        eg a discovery phase or an online billing application
+        eg a discovery phase for an online billing application
       - digital specialists,
         eg service managers or developers
       - user research studios
@@ -39,4 +42,4 @@ open:
     [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) or [log in](https://www.digitalmarketplace.service.gov.uk/suppliers/login) to apply.
 
 
-    [Find out how to apply](https://www.digitalmarketplace.service.gov.uk/)
+    [Find out if your services are suitable](https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/)

--- a/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
@@ -17,7 +17,7 @@ coming:
     [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) to receive an email when Digital Outcomes and Specialists opens.
 
 
-    If you already have an account you’ll be notified by email when Digital Outcomes and Specialists opens.
+    If you already have an account we’ll email you when Digital Outcomes and Specialists opens.
 
 
     [Find out if your services are suitable](https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/)

--- a/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml
@@ -14,15 +14,15 @@ coming:
       - user research studios
       - user research participants
 
-    [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) to receive an email when Digital Outcomes and Specialists opens. 
-    
-    
+    [Create an account](https://www.digitalmarketplace.service.gov.uk/suppliers/create) to receive an email when Digital Outcomes and Specialists opens.
+
+
     If you already have an account you’ll be notified by email when Digital Outcomes and Specialists opens.
-    
-    
+
+
     [Find out if your services are suitable](https://digitalmarketplace.blog.gov.uk/2015/11/12/digital-outcomes-and-specialists-suitable-suppliers-and-services/)
 
-open:  
+open:
   template_name: 'framework-notice'
   heading: 'Become a Digital Outcomes and Specialists supplier'
   subheading: 'Deadline: 14 February 2016'
@@ -33,7 +33,7 @@ open:
     You can apply to provide:
 
       - digital outcomes,
-        eg a discovery phase for an online billing application
+        eg delivering the beta phase of an NHS booking system
       - digital specialists,
         eg service managers or developers
       - user research studios


### PR DESCRIPTION
On the 'coming' state I added:
``` If you already have an account you’ll be notified by email when Digital Outcomes and Specialists opens````

Fixed a typo on both states:
eg a discovery phase **or** an online billing application
to:
eg a discovery phase **for** an online billing application

Placeholder for ```Find out how to apply``` changed to ```Find out if your services are suitable``` and linked to corresponding blog post.