### PR TITLE
[#107188868] Split lab address into three separate fields

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_submission.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_submission.yml
@@ -57,10 +57,16 @@
     - userResearcher
     - webOperations
 
+- name: Address
+  editable: True
+  questions:
+    - labAddressBuilding
+    - labAddressTown
+    - labAddressPostcode
+
 - name: Location
   editable: True
   questions:
-    - labAddress
     - labPublicTransport
     - labCarPark
     - recruitLocations

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressBuilding.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressBuilding.yml
@@ -1,4 +1,5 @@
-question: Address
+question: Building and street
+hint: This should be the address of the building where your lab is.
 
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressPostcode.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressPostcode.yml
@@ -1,0 +1,11 @@
+question: Postcode
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: text
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml
@@ -1,0 +1,11 @@
+question: Town or city
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: text
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/107188868

The story says to split the address into three fields, but the prototype page linked to has it over four fields (https://dm-prototype.herokuapp.com/states/studio-location)

I've gone with three, but we can iterate to four if necessary:
![screen shot 2015-11-20 at 10 28 41](https://cloud.githubusercontent.com/assets/6525554/11297868/1e9e1300-8f73-11e5-8b2c-ef464f4ba89d.png)
