### PR TITLE
Some validations for dos questions

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/services/anonymousRecruitment.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/anonymousRecruitment.yml
@@ -4,3 +4,7 @@ depends:
   - "on": "lot"
     being:
       - user-research-participants
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/bespokeSystemInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/bespokeSystemInformation.yml
@@ -5,3 +5,7 @@ depends:
     being:
       - digital-outcomes
       - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/dataProtocols.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/dataProtocols.yml
@@ -5,3 +5,7 @@ depends:
     being:
       - digital-outcomes
       - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/helpGovernmentImproveServices.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/helpGovernmentImproveServices.yml
@@ -5,3 +5,7 @@ depends:
     being:
       - digital-outcomes
       - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAccessibility.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAccessibility.yml
@@ -1,11 +1,19 @@
 question: How accessible is your studio?
-
+hint: This is to help buyers understand how easy it is for them to reach your studio.
 depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: textbox_large
+max_length_in_words: 50
+
 validations:
-  - name: answer_required
+  -
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must not be more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description can't be more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAccessibility.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAccessibility.yml
@@ -13,7 +13,7 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_50_words
-    message: 'Your description must not be more than 50 words.'
+    message: 'Your description must be no more than 50 words.'
   -
     name: under_character_limit
-    message: "Your description can't be more than 500 characters."
+    message: "Your description must be no more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressBuilding.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressBuilding.yml
@@ -16,4 +16,4 @@ validations:
     message: 'Your answer must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Your answer can't be more than 200 characters."
+    message: "Your answer must be no more than 200 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressBuilding.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressBuilding.yml
@@ -5,8 +5,15 @@ depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: text
+
 validations:
-  - name: answer_required
+  -
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Your answer must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Your answer can't be more than 200 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressPostcode.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressPostcode.yml
@@ -4,8 +4,12 @@ depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: text
+
 validations:
-  - name: answer_required
+  -
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your answer can't be more than 10 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressPostcode.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressPostcode.yml
@@ -12,4 +12,4 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_character_limit
-    message: "Your answer can't be more than 10 characters."
+    message: "Your answer must be no more than than 10 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml
@@ -4,8 +4,15 @@ depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: text
+
 validations:
-  - name: answer_required
+  -
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Your answer must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Your answer can't be more than 200 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml
@@ -15,4 +15,4 @@ validations:
     message: 'Your answer must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Your answer can't be more than 200 characters."
+    message: "Your answer must be no more than 200 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labCarPark.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labCarPark.yml
@@ -13,7 +13,7 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_50_words
-    message: 'Your description must not be more than 50 words.'
+    message: 'Your description must be no more than 50 words.'
   -
     name: under_character_limit
-    message: "Your description can't be more than 500 characters."
+    message: "Your description must be no more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labCarPark.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labCarPark.yml
@@ -1,11 +1,19 @@
 question: Where can visitors to your studio park?
-
+hint: This is to help buyers understand how easy it is for them to reach your studio.
 depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: textbox_large
+max_length_in_words: 50
+
 validations:
-  - name: answer_required
+  -
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must not be more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description can't be more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labPublicTransport.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labPublicTransport.yml
@@ -13,7 +13,7 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_50_words
-    message: 'Your description must not be more than 50 words.'
+    message: 'Your description must be no more than 50 words.'
   -
     name: under_character_limit
-    message: "Your description can't be more than 500 characters."
+    message: "Your description must be no more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labPublicTransport.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labPublicTransport.yml
@@ -1,11 +1,19 @@
 question: How do visitors get to your studio using public transport?
-
+hint: This is to help buyers understand how easy it is for them to reach your studio.
 depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: textbox_large
+max_length_in_words: 50
+
 validations:
-  - name: answer_required
+  -
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must not be more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description can't be more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labSize.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labSize.yml
@@ -1,11 +1,15 @@
 question: How many people can the lab accommodate?
-
+hint: This is the total number of people including participants and facilitators.
 depends:
   - "on": lot
     being:
       - user-research-studios
-
 type: text
+
 validations:
-  - name: answer_required
+  - 
+    name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your answer can't be more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labSize.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labSize.yml
@@ -12,4 +12,4 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_character_limit
-    message: "Your answer can't be more than 100 characters."
+    message: "Your answer must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/services/labWiFi.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/labWiFi.yml
@@ -1,4 +1,4 @@
-question: Do you provide wifi?
+question: Do you provide Wi-Fi?
 
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists/questions/services/manageIncentives.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/manageIncentives.yml
@@ -4,3 +4,7 @@ depends:
   - "on": "lot"
     being:
       - user-research-participants
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/openSourceLicence.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/openSourceLicence.yml
@@ -5,3 +5,7 @@ depends:
     being:
       - digital-outcomes
       - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/openStandardsPrinciples.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/openStandardsPrinciples.yml
@@ -1,7 +1,11 @@
-question: Will you work according to the government's [Open Standards Principles](https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles) and use the [open standards selected for use across government](http://standards.data.gov.uk/challenges/adopted)?
+question: "Will you work according to the government's [Open Standards Principles](https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles) and use the [open standards selected for use across government](http://standards.data.gov.uk/challenges/adopted)?"
 type: boolean
 depends:
   - "on": "lot"
     being:
       - digital-outcomes
       - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/recruitFromList.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/recruitFromList.yml
@@ -4,8 +4,8 @@ depends:
   - "on": lot
     being:
       - user-research-participants
-
 type: boolean
+
 validations:
   - name: answer_required
     message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/recruitMethods.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/recruitMethods.yml
@@ -10,8 +10,8 @@ options:
   - label: Entirely offline
   - label: Initial recruitment offline, but then contact them online
   - label: Entirely online
-
 type: boolean
+
 validations:
   - name: answer_required
     message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/services/serviceName.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/serviceName.yml
@@ -14,4 +14,4 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_character_limit
-    message: "Your studio name can't be more than 100 characters."
+    message: "Your studio name must be no more than 100 characters."

--- a/frameworks/g-cloud-6/questions/services/apiType.yml
+++ b/frameworks/g-cloud-6/questions/services/apiType.yml
@@ -19,6 +19,6 @@ validations:
     message: 'API type must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "API type can't be more than 200 characters."
+    message: "API type must be no more than 200 characters."
 question: 'API type'
 optional: true

--- a/frameworks/g-cloud-6/questions/services/deprovisioningTime.yml
+++ b/frameworks/g-cloud-6/questions/services/deprovisioningTime.yml
@@ -19,5 +19,5 @@ validations:
     message: 'Deprovisioning time must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Deprovisioning time can't be more than 200 characters."
+    message: "Deprovisioning time must be no more than 200 characters."
 question: 'Service deprovisioning time'

--- a/frameworks/g-cloud-6/questions/services/provisioningTime.yml
+++ b/frameworks/g-cloud-6/questions/services/provisioningTime.yml
@@ -19,5 +19,5 @@ validations:
     message: 'Provisioning time must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Provisioning time can't be more than 200 characters."
+    message: "Provisioning time must be no more than 200 characters."
 question: 'Service provisioning time'

--- a/frameworks/g-cloud-6/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceName.yml
@@ -18,5 +18,5 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_character_limit
-    message: "Your service name can't be more than 100 characters."
+    message: "Your service name must be no more than 100 characters."
 question: 'Service name'

--- a/frameworks/g-cloud-6/questions/services/serviceSummary.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceSummary.yml
@@ -19,9 +19,9 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_50_words
-    message: 'Your description must not be more than 50 words.'
+    message: 'Your description must be no more than 50 words.'
   -
     name: under_character_limit
-    message: "Your description can't be more than 500 characters."
+    message: "Your description must be no more than 500 characters."
 question: 'Service summary'
 type: textbox_large

--- a/frameworks/g-cloud-6/questions/services/supportAvailability.yml
+++ b/frameworks/g-cloud-6/questions/services/supportAvailability.yml
@@ -21,5 +21,5 @@ validations:
     message: 'Support availability must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Support availability can't be more than 200 characters."
+    message: "Support availability must be no more than 200 characters."
 question: 'Support availability'

--- a/frameworks/g-cloud-6/questions/services/supportResponseTime.yml
+++ b/frameworks/g-cloud-6/questions/services/supportResponseTime.yml
@@ -21,5 +21,5 @@ validations:
     message: 'Support response time must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Support response time can't be more than 200 characters."
+    message: "Support response time must be no more than 200 characters."
 question: 'Standard support response times'

--- a/frameworks/g-cloud-7/questions/services/apiType.yml
+++ b/frameworks/g-cloud-7/questions/services/apiType.yml
@@ -19,6 +19,6 @@ validations:
     message: 'API type must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "API type can't be more than 200 characters."
+    message: "API type must be no more than 200 characters."
 question: 'API type'
 optional: true

--- a/frameworks/g-cloud-7/questions/services/deprovisioningTime.yml
+++ b/frameworks/g-cloud-7/questions/services/deprovisioningTime.yml
@@ -19,5 +19,5 @@ validations:
     message: 'Deprovisioning time must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Deprovisioning time can't be more than 200 characters."
+    message: "Deprovisioning time must be no more than 200 characters."
 question: 'Service deprovisioning time'

--- a/frameworks/g-cloud-7/questions/services/provisioningTime.yml
+++ b/frameworks/g-cloud-7/questions/services/provisioningTime.yml
@@ -19,5 +19,5 @@ validations:
     message: 'Provisioning time must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Provisioning time can't be more than 200 characters."
+    message: "Provisioning time must be no more than 200 characters."
 question: 'Service provisioning time'

--- a/frameworks/g-cloud-7/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceName.yml
@@ -18,5 +18,5 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_character_limit
-    message: "Your service name can't be more than 100 characters."
+    message: "Your service name must be no more than 100 characters."
 question: 'Service name'

--- a/frameworks/g-cloud-7/questions/services/serviceSummary.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceSummary.yml
@@ -19,9 +19,9 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_50_words
-    message: 'Your description must not be more than 50 words.'
+    message: 'Your description must be no more than 50 words.'
   -
     name: under_character_limit
-    message: "Your description can't be more than 500 characters."
+    message: "Your description must be no more than 500 characters."
 question: 'Service summary'
 type: textbox_large

--- a/frameworks/g-cloud-7/questions/services/supportAvailability.yml
+++ b/frameworks/g-cloud-7/questions/services/supportAvailability.yml
@@ -21,5 +21,5 @@ validations:
     message: 'Support availability must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Support availability can't be more than 200 characters."
+    message: "Support availability must be no more than 200 characters."
 question: 'Support availability'

--- a/frameworks/g-cloud-7/questions/services/supportResponseTime.yml
+++ b/frameworks/g-cloud-7/questions/services/supportResponseTime.yml
@@ -21,5 +21,5 @@ validations:
     message: 'Support response time must be no more than 20 words.'
   -
     name: under_character_limit
-    message: "Support response time can't be more than 200 characters."
+    message: "Support response time must be no more than 200 characters."
 question: 'Standard support response times'


### PR DESCRIPTION
This adds some validations to the DOS service questions:
 * Length limits of 50 words/500 characters on large textboxes
 * Length limits of 20 words/200 characters for address lines
 * Length limit of 10 characters for a postcode
 * Length limit of 100 characters on how many people a lab can accommodate
 * `answer_required` on boolean questions that didn't previously have it

I've also added some hint text taken from the prototype on a couple of questions.

I haven't done anything with:
 * multi-questions (I think validations for these should be at the sub-question level?)
 * prices (I know @tommorris has been working on these)
 * locations (they don't feel like they are required - e.g. for remote working only)
