### PR TITLE
[#107188910] Generate JSON schemas which validate "at least one of" a group of questions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "3.4"
 install:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Question keys
 * `assuranceApproach` contains the name of the set of possible assurance answers for the question. Assurance answer sets are
   listed in the supplier frontend.
 * `questions` a list of nested questions (only valid for `multiquestion` questions)
+* `any_of` groups nested questions for "anyOf" validations and helps us return a helpful validation message (only valid for `multiquestion` questions)
 * `fields` a mapping of toolkit form field key to the service data key used for multi-input field types (only valid for `pricing`)
 * `max_length_in_words` sets the limit on question value length in words
 

--- a/frameworks/digital-outcomes-and-specialists/questions/services/agileCoach.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/agileCoach.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - agileCoachLocations
   - agileCoachDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/businessAnalyst.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/businessAnalyst.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - businessAnalystLocations
   - businessAnalystDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/communicationsManager.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/communicationsManager.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - communicationsManagerLocations
   - communicationsManagerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/contentDesigner.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/contentDesigner.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - contentDesignerLocations
   - contentDesignerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/deliveryManager.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/deliveryManager.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - deliveryManagerLocations
   - deliveryManagerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/designer.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/designer.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - designerLocations
   - designerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/developer.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/developer.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - developerLocations
   - developerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/performanceAnalyst.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/performanceAnalyst.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - performanceAnalystLocations
   - performanceAnalystDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/portfolioManager.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/portfolioManager.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - portfolioManagerLocations
   - portfolioManagerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/productManager.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/productManager.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - productManagerLocations
   - productManagerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/programmeManager.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/programmeManager.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - programmeManagerLocations
   - programmeManagerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/qualityAssurance.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/qualityAssurance.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - qualityAssuranceLocations
   - qualityAssuranceDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/securityConsultant.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/securityConsultant.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - securityConsultantLocations
   - securityConsultantDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/serviceManager.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/serviceManager.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - serviceManagerLocations
   - serviceManagerDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/technicalArchitect.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/technicalArchitect.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - technicalArchitectLocations
   - technicalArchitectDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/userResearcher.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/userResearcher.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - userResearcherLocations
   - userResearcherDayRate

--- a/frameworks/digital-outcomes-and-specialists/questions/services/webOperations.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/webOperations.yml
@@ -5,6 +5,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - webOperationsLocations
   - webOperationsDayRate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docopt==0.4.0
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@13.2.0#egg=digitalmarketplace-utils==13.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@14.0.1#egg=digitalmarketplace-utils==14.0.1

--- a/schemas/questions.json
+++ b/schemas/questions.json
@@ -60,6 +60,9 @@
         "type": "string"
       }
     },
+    "any_of": {
+      "type": "string"
+    },
     "validations": {
       "type": "array",
       "items": {

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -50,7 +50,6 @@ def empty_schema(schema_name):
         "type": "object",
         "additionalProperties": False,
         "properties": {},
-        "anyOf": [],
         "required": [],
     }
 

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -278,9 +278,10 @@ def build_question_properties(question):
     return question_data
 
 
-def build_any_of(fields):
+def build_any_of(any_of, fields):
     return {
-        'required': [field for field in sorted(fields)]
+        'required': [field for field in sorted(fields)],
+        'title': any_of
     }
 
 
@@ -293,7 +294,7 @@ def build_schema_properties(schema, questions):
             pass
 
         elif question.get('any_of'):
-            any_ofs[question.id] = build_any_of(question.fields)
+            any_ofs[question.id] = build_any_of(question.get('any_of'), question.fields)
 
         else:
             if key == 'priceString':

--- a/scripts/generate_dos_specialists_questions.sh
+++ b/scripts/generate_dos_specialists_questions.sh
@@ -10,6 +10,7 @@ depends:
     being:
       - digital-specialists
 type: multiquestion
+any_of: specialist
 questions:
   - QUESTIONLocations
   - QUESTIONDayRate


### PR DESCRIPTION
Generates JSON files to correctly validate services where a "at least one of" a group of questions have to be present.  For example, at least one specialist needs to be present for a service to validate, and a specialist consists of more than one related keys.

Needs pull request [#213](https://github.com/alphagov/digitalmarketplace-utils/pull/213) in utils to pass tests.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/107188910)

##### Structure of the JSON schema

As before, all of the possible keys a schema will accept need to be defined in the top-level `"properties"` dictionary, and then groups of related keys must be specified in their own schemas in under a top-level [`"anyOf"` key](http://json-schema.org/latest/json-schema-validation.html#anchor85). 

Kind of looks like this:

```json
{
  "properties": { 
    "thing": {
      "type": "string"
    },
    "subthing_1": {
      "type": "string"
    },
    "subthing_2": {
      "type": "string"
    }
  },
  "anyOf": [
    {
      "required": [ "subthing_1", "subthing_2"],
      "title": "specialist"
    }
  ]
}
```

Also added a (not strictly necessary) `"title"` key to the `"anyOf"` subschemas so that we can return it when an `"anyOf"` validation fails.  The default error message that comes out of the JSON schema validator isn't really that helpful. 