### PR TITLE
Limit schema price string to 15 digits before decimal point

### DIFF
--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -110,7 +110,7 @@ def list_property(question):
 
 
 def price_string(optional):
-    pattern = r"^\d+(?:\.\d{1,5})?$"
+    pattern = r"^\d{1,15}(?:\.\d{1,5})?$"
     if optional:
         pattern = r"^$|" + pattern
     return {


### PR DESCRIPTION
Long price string without spaces break the layout and since there's
no reason to have them we just limit the strings accepted by the
JSON schema to 15 character before the decimal point and 5 after.