### PR TITLE
Add dates as messages

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/messages/dates.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/dates.yml
@@ -1,0 +1,4 @@
+clarifications_close_date: "5pm, 6 January 2016"
+clarifications_publish_date: "5pm, 13 January 2016"
+framework_close_date: "3pm, 19 January 2016"
+framework_live_date: ""

--- a/frameworks/g-cloud-7/messages/dates.yml
+++ b/frameworks/g-cloud-7/messages/dates.yml
@@ -1,0 +1,4 @@
+clarifications_close_date: "5pm, 22 September 2015"
+clarifications_publish_date: "5pm, 29 September 2015"
+framework_close_date: "3pm, 6 October 2015"
+framework_live_date: "23 November 2015"

--- a/schemas/messages.json
+++ b/schemas/messages.json
@@ -2,16 +2,37 @@
   "title": "Message",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
-  "properties": {
-    "coming": {
-      "type": "object"
+  "anyOf": [
+    {"$ref": "#/definitions/dates"},
+    {"$ref": "#/definitions/frameworkStates"}
+  ],
+  "definitions": {
+    "dates": {
+      "properties": {
+        "clarifications_close_date": {"type": "string"},
+        "clarifications_publish_date": {"type": "string"},
+        "framework_close_date": {"type": "string"},
+        "framework_live_date": {"type": "string"}
+      },
+      "required": [
+        "clarifications_close_date", "clarifications_publish_date",
+        "framework_close_date"
+      ],
+      "additionalProperties": false
     },
-    "open": {
-      "type": "object"
-    },
-    "pending": {
-      "type": "object"
+    "frameworkStates": {
+      "properties": {
+        "coming": {
+          "type": "object"
+        },
+        "open": {
+          "type": "object"
+        },
+        "pending": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
-  },
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
Ultimately these should be stored in the API but for the moment we don't know how many different dates there will be and it is therefore difficult to know what the right way of managing them is.