### PR TITLE
Add "Apply to provide" to dos lot links text

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/services/lot.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/lot.yml
@@ -2,7 +2,7 @@ question: 'Service type'
 type: radios
 options:
   -
-    label: Digital outcomes
+    label: Apply to provide teams for digital outcomes
     value: digital-outcomes
     description: >
       Provide teams to build and support digital outcomes.
@@ -10,7 +10,7 @@ options:
 
       Examples of digital outcomes include a discovery phase or an online billing application.
   -
-    label: Digital specialists
+    label: Apply to provide individual digital specialists
     value: digital-specialists
     description: >
       Provide individual specialists to work on digital services, programmes or projects.
@@ -18,7 +18,7 @@ options:
 
       Examples of digital specialists include content designers or technical architects.
   -
-    label: User research studios
+    label: Apply to provide user research studios
     value: user-research-studios
     description: >
       Add studios for user research sessions and workshops.
@@ -26,7 +26,7 @@ options:
 
       Buyers will see this information and use it to choose the studio they want to hire.
   -
-    label: User research participants
+    label: Apply to provide user research participant recruitment
     value: user-research-participants
     description: >
       Provide user research participant recruitment services.


### PR DESCRIPTION
Changes the lot question option labels to match the prototype text.
This means that lot question labels no longer match lot names, but
since the quesiton is only used for the submission lots page this
doesn't affect any other pages at the moment.