### PR TITLE
Add linebreaks for markdown interpreter

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/declaration.yml
@@ -6,8 +6,9 @@
     Specialists. You can come back and change your answers at any time before
     3pm, 19 January 2016.
 
-    You must be able to truthfully answer 'yes' to every question under ‘Essentials' 
-    for your bid to be considered eligible. If you can't answer 'yes' to every 
+
+    You must be able to truthfully answer 'yes' to every question under ‘Essentials'
+    for your bid to be considered eligible. If you can't answer 'yes' to every
     question in this section, it's very unlikely that your bid will be accepted.
   questions:
     - termsOfParticipation

--- a/frameworks/digital-outcomes-and-specialists/questions/services/openStandardsPrinciples.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/openStandardsPrinciples.yml
@@ -2,6 +2,7 @@ name: Use of open standards
 question: >
   Will you work according to the government's [Open Standards Principles](https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles) and use the [open standards selected for use across government](http://standards.data.gov.uk/challenges/adopted)?
 
+
   This includes publishing any software you build for the government under the appropriate open source licence.
 type: boolean
 depends:

--- a/frameworks/digital-outcomes-and-specialists/questions/services/serviceName.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/services/serviceName.yml
@@ -2,6 +2,7 @@ name: What is the name of the lab?
 question: >
   What is the name of the lab?
 
+
   Provide the name of the room where participants and researchers carry out testing.
 type: text
 


### PR DESCRIPTION
Our `markdown` filter doesn't insert newlines unless it sees two consecutive newlines. 

So I've added several where @sarahcunliffe pointed them out.