### PR TITLE
Link to suppliers guide on GOV.UK

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/declaration/readUnderstoodGuidance.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/declaration/readUnderstoodGuidance.yml
@@ -1,2 +1,2 @@
-question: Have you read and understood the guidance on [how to apply](https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/suppliers-guide) to Digital Outcomes and Specialists using the Digital Marketplace?
+question: Have you read and understood the guidance on [how to apply](https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide) to Digital Outcomes and Specialists using the Digital Marketplace?
 type: boolean


### PR DESCRIPTION
[This](http://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide) is where the suppliers guide will be.

It isn’t there yet.

--

https://www.pivotaltracker.com/story/show/106106748