### PR TITLE
[#111518510] Buyer can create a brief -- content repo

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
@@ -3,25 +3,35 @@
   editable: True
   questions:
     - organisation
-
-- name: Where will the work be carried out?
+-
+  name: Specialist
+  editable: True
+  questions:
+    - specialist
+-
+  name: Outcome
+  editable: True
+  questions:
+    - outcome
+-
+  name: Where will the work be carried out?
   editable: True
   questions:
     - location
-
-- name: Working arrangements
+-
+  name: Working arrangements
   editable: True
   questions:
     - workingArrangements
     - additionalTerms
-
-- name: Your requirements
+-
+  name: Your requirements
   editable: True
   questions:
     - essentialRequirements
     - niceToHaveRequirements
-
-- name: Evaluating suppliers
+-
+  name: Evaluating suppliers
   editable: True
   questions:
     - evaluationType

--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
@@ -1,0 +1,27 @@
+-
+  name: Your organisation
+  editable: True
+  questions:
+    - organisation
+
+- name: Where will the work be carried out?
+  editable: True
+  questions:
+    - location
+
+- name: Working arrangements
+  editable: True
+  questions:
+    - workingArrangements
+    - additionalTerms
+
+- name: Your requirements
+  editable: True
+  questions:
+    - essentialRequirements
+    - niceToHaveRequirements
+
+- name: Evaluating suppliers
+  editable: True
+  questions:
+    - evaluationType

--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
@@ -4,10 +4,10 @@
   questions:
     - organisation
 -
-  name: Specialist
+  name: Specialist Role
   editable: True
   questions:
-    - specialist
+    - specialistRole
 -
   name: Outcome
   editable: True

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/additionalTerms.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/additionalTerms.yml
@@ -1,0 +1,9 @@
+name: Additional terms and conditions
+question: List any additional terms and conditions that are not included in the service contract
+hint: 'Optional'
+type: textbox_large
+max_length_in_words: 50
+validations:
+  -
+    name: under_50_words
+    message: 'Your answer must be no more than 50 words.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/additionalTerms.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/additionalTerms.yml
@@ -1,8 +1,14 @@
 name: Additional terms and conditions
 question: List any additional terms and conditions that are not included in the service contract
+optional: true
 hint: 'Optional'
 type: textbox_large
 max_length_in_words: 50
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: under_50_words

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/essentialRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/essentialRequirements.yml
@@ -1,0 +1,25 @@
+name: Essential
+question: Essential requirements
+hint: >
+  List your essential requirements as yes/no questions.
+
+
+  Suppliers must be able to answer ‘yes’ to all of these questions to proceed to the next round of evaluation.
+
+
+  eg does your organisation have experience working with open source software?
+list_item_name: 'essential requirement'
+type: list
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_10_words
+    message: 'Each requirement must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer requirements.'
+  -
+    name: under_character_limit
+    message: 'Each requirement must be no more than 100 characters.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/essentialRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/essentialRequirements.yml
@@ -10,6 +10,11 @@ hint: >
   eg does your organisation have experience working with open source software?
 list_item_name: 'essential requirement'
 type: list
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/evaluationType.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/evaluationType.yml
@@ -1,0 +1,12 @@
+name: Type of evaluation
+question: How do you want the shortlisted suppliers to demonstrate their proposed approach?
+type: checkboxes
+options:
+  - label: "provide a written proposal"
+  - label: "provide a case study or evidence of previous work"
+  - label: "presentation"
+  - label: "pitch"
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/evaluationType.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/evaluationType.yml
@@ -6,6 +6,11 @@ options:
   - label: "provide a case study or evidence of previous work"
   - label: "presentation"
   - label: "pitch"
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
@@ -15,6 +15,11 @@ options:
   - label: "South East England"
   - label: "Northern Ireland"
   - label: "Offsite"
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
@@ -20,6 +20,7 @@ depends:
     being:
       - digital-outcomes
       - digital-specialists
+      - user-research-participants
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
@@ -1,0 +1,21 @@
+name: Location
+question: Where is the work to be carried out?
+type: radios
+options:
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "East Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South East England"
+  - label: "Northern Ireland"
+  - label: "Offsite"
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/niceToHaveRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/niceToHaveRequirements.yml
@@ -1,0 +1,25 @@
+name: Nice to have
+question: Nice-to-have requirements
+  List your nice-to-have requirements as yes/no questions.
+
+
+  Suppliers will be prioritised based on the number of questions they can answer 'yes' to.
+
+
+  eg does your organisation have experience working with low technical experience users?
+list_item_name: 'nice-to-have requirement'
+optional: true
+type: list
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_10_words
+    message: 'Each requirement must be no more than 10 words.'
+  -
+    name: under_10_items
+    message: 'You must have 10 or fewer requirements.'
+  -
+    name: under_character_limit
+    message: 'Each requirement must be no more than 100 characters.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/niceToHaveRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/niceToHaveRequirements.yml
@@ -10,6 +10,11 @@ question: Nice-to-have requirements
 list_item_name: 'nice-to-have requirement'
 optional: true
 type: list
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/organisation.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/organisation.yml
@@ -7,6 +7,7 @@ depends:
     being:
       - digital-outcomes
       - digital-specialists
+      - user-research-participants
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/organisation.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/organisation.yml
@@ -1,0 +1,11 @@
+name: Organisation
+question: Organisation the work is for
+hint: 'eg Department of Work and Pensions or Goldsmiths, University of London'
+type: text
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your organisation name must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/organisation.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/organisation.yml
@@ -2,6 +2,11 @@ name: Organisation
 question: Organisation the work is for
 hint: 'eg Department of Work and Pensions or Goldsmiths, University of London'
 type: text
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: answer_required

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/outcome.yml
@@ -1,14 +1,16 @@
-name: Specialist
-question: Do you need a digital specialist?
-type: radios
-options:
-  - label: "Yes"
-  - label: "No"
+name: Problem the outcome will need to solve
+question: Overview of the problem that the supplier needs to solve
+hint: 'This is so suppliers can quickly see what this brief is about.'
+type: textbox_large
+max_length_in_words: 50
 depends:
   - "on": "lot"
     being:
-      - digital-specialists
+      - digital-outcomes
 validations:
   -
     name: answer_required
     message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your answer must be no more than 50 words.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/outcome.yml
@@ -1,0 +1,14 @@
+name: Specialist
+question: Do you need a digital specialist?
+type: radios
+options:
+  - label: "Yes"
+  - label: "No"
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/specialist.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/specialist.yml
@@ -1,24 +1,94 @@
-name: Location
-question: Where is the work to be carried out?
+name: Specialist
+question: Type of specalist you need
 type: radios
 options:
-  - label: "Scotland"
-  - label: "North East England"
-  - label: "North West England"
-  - label: "Yorkshire and the Humber"
-  - label: "East Midlands"
-  - label: "East Midlands"
-  - label: "East of England"
-  - label: "Wales"
-  - label: "London"
-  - label: "South East England"
-  - label: "South East England"
-  - label: "Northern Ireland"
-  - label: "Offsite"
+  -
+    label: Agile coach
+    value: agile_coach
+    description: >
+      Help individuals, teams and managers be as effective as possible by embedding an agile culture.
+  -
+    label: Business analyst
+    value: business_analyst
+    description: >
+      Analyse a service or organisation’s business processes and systems. Specify, collect and present findings.
+  -
+    label: Communications manager
+    value: communications_manager
+    description: >
+      Develop user-focused messages, measurement techniques and communication approaches.
+      Establish integrated communication plans across a range of digital channels
+      to ensure that communication is ongoing, open and clear.
+  -
+    label: Content designer
+    value: content_designer
+    description: >
+      Ensure content is as clear and simple as possible to meet user needs.
+  -
+    label: Cyber security consultant
+    value: cyber_security_consultant
+    description: >
+      Minimise the chance of data or information systems security breaches.
+      Ensure information is protected against unauthorised or unintended access.
+      Put systems in place to prevent data destruction or disruption.
+  -
+    label: Delivery manager
+    value: delivery_manager
+    description: >
+      Set up a team for successful delivery.
+      Remove obstacles, track progress, facilitate meetings and help the team organise itself.
+  -
+    label: Designer
+    value: designer
+    description: >
+      Provide user-centred interaction design, service design and graphic design expertise.
+  -
+    label: Developer
+    value: developer
+    description: >
+      Build software that supports user needs. Continually improve the service by
+      identifying new tools and techniques, removing technical bottlenecks, and adapting and maintaining code.
+  -
+    label: Portfolio manager
+    value: portfolio_manager
+    description: >
+      Lead a digital portfolio of projects and programmes.
+  -
+    label: Product manager
+    value: product_manager
+    description: >
+      Lead the delivery and continuous improvement of one or more digital products or platforms.
+  -
+    label: Programme manager
+    value: programme_manager
+    description: >
+      Manage and organise groups of related projects so they work together to achieve a strategic objective.
+  -
+    label: Quality assurance analyst
+    value: quality_assurance_analyst
+    description: >
+      Ensure the quality of the digital service by testing it manually and writing automated tests
+      covering a range of conditions.
+  -
+    label: Service manager
+    value: service_manager
+    description: >
+      Develop and deliver an effective user-focused digital service.
+      Manage the full product lifecycle, including user research, design, delivery and continuous improvement.
+  -
+    label: User researcher
+    value: user_researcher
+    description: >
+      Design, conduct and analyse user research using a range of techniques,
+      eg one-to-one interviews or usability tests.
+  -
+    label: Web operations engineer
+    value: web_operations_engineer
+    description: >
+      Run the production systems to help the development team build software that is easy to operate, scale and secure.
 depends:
   - "on": "lot"
     being:
-      - digital-outcomes
       - digital-specialists
 validations:
   -

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/specialist.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/specialist.yml
@@ -1,0 +1,26 @@
+name: Location
+question: Where is the work to be carried out?
+type: radios
+options:
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "East Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South East England"
+  - label: "Northern Ireland"
+  - label: "Offsite"
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
@@ -1,4 +1,4 @@
-name: Specialist
+name: Specialist role
 question: Type of specalist you need
 type: radios
 options:

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/workingArrangements.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/workingArrangements.yml
@@ -1,0 +1,12 @@
+name: Remote working arrangements
+question: Describe working arrangement preference
+hint: 'eg remote working preference or specific hours or days required'
+type: textbox_large
+max_length_in_words: 50
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must be no more than 50 words.'

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/workingArrangements.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/workingArrangements.yml
@@ -3,6 +3,11 @@ question: Describe working arrangement preference
 hint: 'eg remote working preference or specific hours or days required'
 type: textbox_large
 max_length_in_words: 50
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
 validations:
   -
     name: answer_required

--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -4,27 +4,49 @@ import json
 from dmutils.content_loader import ContentLoader
 
 
-SCHEMAS = [
-    ('G-Cloud 7 SCS', 'g-cloud-7', 'scs'),
-    ('G-Cloud 7 IaaS', 'g-cloud-7', 'iaas'),
-    ('G-Cloud 7 PaaS', 'g-cloud-7', 'paas'),
-    ('G-Cloud 7 SaaS', 'g-cloud-7', 'saas'),
-    ('Digital Outcomes and Specialists Digital outcomes',
-     'digital-outcomes-and-specialists', 'digital-outcomes'),
-    ('Digital Outcomes and Specialists Digital specialists',
-     'digital-outcomes-and-specialists', 'digital-specialists'),
-    ('Digital Outcomes and Specialists User research studios',
-     'digital-outcomes-and-specialists', 'user-research-studios'),
-    ('Digital Outcomes and Specialists User research participants',
-     'digital-outcomes-and-specialists', 'user-research-participants'),
-]
+MANIFESTS = {
+    'services': {
+        'question_set': 'services',
+        'manifest': 'edit_submission'
+    },
+    'briefs': {
+        'question_set': 'briefs',
+        'manifest': 'edit_brief'
+    }
+}
 
 
-def load_questions(framework_slug, lot_slug):
+SCHEMAS = {
+    'services': [
+        ('G-Cloud 7 SCS Service', 'g-cloud-7', 'scs'),
+        ('G-Cloud 7 IaaS Service', 'g-cloud-7', 'iaas'),
+        ('G-Cloud 7 PaaS Service', 'g-cloud-7', 'paas'),
+        ('G-Cloud 7 SaaS Service', 'g-cloud-7', 'saas'),
+        ('Digital Outcomes and Specialists Digital outcomes Service',
+         'digital-outcomes-and-specialists', 'digital-outcomes'),
+        ('Digital Outcomes and Specialists Digital specialists Service',
+         'digital-outcomes-and-specialists', 'digital-specialists'),
+        ('Digital Outcomes and Specialists User research studios Service',
+         'digital-outcomes-and-specialists', 'user-research-studios'),
+        ('Digital Outcomes and Specialists User research participants Service',
+         'digital-outcomes-and-specialists', 'user-research-participants')
+    ],
+    'briefs': [
+        ('Digital Outcomes and Specialists Digital outcomes Brief',
+         'digital-outcomes-and-specialists', 'digital-outcomes')
+    ]
+}
+
+
+def load_questions(schema_type, framework_slug, lot_slug):
     loader = ContentLoader('./')
-    loader.load_manifest(framework_slug, 'services', 'edit_submission')
+    loader.load_manifest(
+        framework_slug,
+        MANIFESTS[schema_type]['question_set'],
+        MANIFESTS[schema_type]['manifest']
+    )
 
-    builder = loader.get_builder(framework_slug, 'edit_submission').filter({'lot': lot_slug})
+    builder = loader.get_builder(framework_slug, MANIFESTS[schema_type]['manifest']).filter({'lot': lot_slug})
     return {q['id']: q for q in sum((s.questions for s in builder.sections), [])}
 
 
@@ -37,7 +59,7 @@ def drop_non_schema_questions(questions):
 
 def empty_schema(schema_name):
     return {
-        "title": "{} Service Schema".format(schema_name),
+        "title": "{} Schema".format(schema_name),
         "$schema": "http://json-schema.org/schema#",
         "type": "object",
         "additionalProperties": False,
@@ -355,8 +377,8 @@ def add_multiquestion_dependencies(schema, questions):
         schema['dependencies'] = dependencies
 
 
-def generate_schema(path, schema_name, framework_slug, lot_slug):
-    questions = load_questions(framework_slug, lot_slug)
+def generate_schema(path, schema_type, schema_name, framework_slug, lot_slug):
+    questions = load_questions(schema_type, framework_slug, lot_slug)
     drop_non_schema_questions(questions)
     schema = empty_schema(schema_name)
 
@@ -364,5 +386,5 @@ def generate_schema(path, schema_name, framework_slug, lot_slug):
     add_multiquestion_anyof(schema, questions)
     add_multiquestion_dependencies(schema, questions)
 
-    with open(os.path.join(path, 'services-{}-{}.json'.format(framework_slug, lot_slug)), 'w') as f:
+    with open(os.path.join(path, '{}-{}-{}.json'.format(schema_type, framework_slug, lot_slug)), 'w') as f:
         json.dump(schema, f, sort_keys=True, indent=2, separators=(',', ': '))

--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -33,7 +33,11 @@ SCHEMAS = {
     ],
     'briefs': [
         ('Digital Outcomes and Specialists Digital outcomes Brief',
-         'digital-outcomes-and-specialists', 'digital-outcomes')
+         'digital-outcomes-and-specialists', 'digital-outcomes'),
+        ('Digital Outcomes and Specialists Digital specialists Brief',
+         'digital-outcomes-and-specialists', 'digital-specialists'),
+        ('Digital Outcomes and Specialists User research participants Brief',
+         'digital-outcomes-and-specialists', 'user-research-participants')
     ]
 }
 

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -5,7 +5,8 @@ Usage:
     generate-schemas.py --output-path=<output_path>
 
 """
-
+import sys
+sys.path.insert(0, '.')
 
 from docopt import docopt
 from schema_generator import generate_schema, SCHEMAS

--- a/scripts/generate-schemas.py
+++ b/scripts/generate-schemas.py
@@ -13,5 +13,6 @@ from schema_generator import generate_schema, SCHEMAS
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)
-    for schema in SCHEMAS:
-        generate_schema(arguments['--output-path'], *schema)
+    for schema_type in SCHEMAS:
+        for schema in SCHEMAS[schema_type]:
+            generate_schema(arguments['--output-path'], schema_type, *schema)

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -369,3 +369,19 @@ def test_generate_dos_schema_opens_files(opened_files, tmpdir):
                                   x.endswith("manifests/edit_submission.yml")) and
                               not x.endswith("lot.yml")])
     assert dos_expected_files == dos_opened_files
+
+
+def test_generate_dos_brief_opens_files(opened_files, tmpdir):
+    dos_schemas = [x for x in SCHEMAS['briefs'] if x[1] == "digital-outcomes-and-specialists"]
+    test_directory = str(tmpdir.mkdir("briefs"))
+
+    for schema in dos_schemas:
+        generate_schema(test_directory, 'briefs', *schema)
+    dos_path = "./frameworks/digital-outcomes-and-specialists"
+    dos_opened_files = set(x for x in opened_files
+                           if x.startswith(dos_path) and os.path.isfile(x))
+    dos_expected_files = set([x for x in recursive_file_list(dos_path)
+                              if ("questions/briefs" in x or
+                                  x.endswith("manifests/edit_brief.yml")) and
+                              not x.endswith("lot.yml")])
+    assert dos_expected_files == dos_opened_files

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -1,6 +1,5 @@
 import re
 from math import isnan
-from glob import glob
 import os
 
 try:

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -52,7 +52,7 @@ def recursive_file_list(dirname):
 
 
 def test_drop_non_schema_questions():
-    questions = load_questions('g-cloud-7', 'scs')
+    questions = load_questions('services', 'g-cloud-7', 'scs')
     # lotName is in G-Cloud 7
     assert 'lotName' in questions.keys()
     drop_non_schema_questions(questions)
@@ -339,11 +339,11 @@ def test_generate_g_cloud_schema_opens_files(opened_files, tmpdir):
     The assumption is that if there are files which aren't opened,
     either they are unnecessary or something has gone profoundly wrong.
     """
-    g_cloud_schemas = [x for x in SCHEMAS if x[1] == "g-cloud-7"]
+    g_cloud_schemas = [x for x in SCHEMAS['services'] if x[1] == "g-cloud-7"]
     test_directory = str(tmpdir.mkdir("schemas"))
 
     for schema in g_cloud_schemas:
-        generate_schema(test_directory, *schema)
+        generate_schema(test_directory, 'services', *schema)
     g_cloud_path = "./frameworks/g-cloud-7"
     g_cloud_opened_files = set(x for x in opened_files
                                if x.startswith(g_cloud_path) and
@@ -356,12 +356,11 @@ def test_generate_g_cloud_schema_opens_files(opened_files, tmpdir):
 
 
 def test_generate_dos_schema_opens_files(opened_files, tmpdir):
-    dos_schemas = [x for x in SCHEMAS
-                   if x[1] == "digital-outcomes-and-specialists"]
+    dos_schemas = [x for x in SCHEMAS['services'] if x[1] == "digital-outcomes-and-specialists"]
     test_directory = str(tmpdir.mkdir("schemas"))
 
     for schema in dos_schemas:
-        generate_schema(test_directory, *schema)
+        generate_schema(test_directory, 'services', *schema)
     dos_path = "./frameworks/digital-outcomes-and-specialists"
     dos_opened_files = set(x for x in opened_files
                            if x.startswith(dos_path) and os.path.isfile(x))


### PR DESCRIPTION
This pull request sets up the back-end scaffolding needed in order to build a brief-creation form. 

Questions aren't finalised, but they are:
- based on those [in the prototype](http://dm-prototype.herokuapp.com/)
- all different field types: 
 - `list`, `checkboxes`, `radios`, `text`, `textbox_large`
- different for different lots
- essential / optional

Changed some of the top-level schema-generation functions (to look for brief questions, and to appropriately name schemas generated for briefs) but nothing to do with the the actual generation logic.  
Therefore, JSON schemas generated for briefs are identical to what their equivalent service schemas would look like.

Means I didn't hardly do much additional testing and nothing to do with the ContentLoader needs changing.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/111518510)