### PR TITLE
Fix missing EOF newline in generated schemas

### DIFF
--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -392,3 +392,4 @@ def generate_schema(path, schema_type, schema_name, framework_slug, lot_slug):
 
     with open(os.path.join(path, '{}-{}-{}.json'.format(schema_type, framework_slug, lot_slug)), 'w') as f:
         json.dump(schema, f, sort_keys=True, indent=2, separators=(',', ': '))
+        f.write('\n')


### PR DESCRIPTION
When script was rewritten to use schema_generator the call to add a
trailing newline to generated files was lost, which means rerunning
the script creates schema diff without EOF newline.

Restoring the write to keep the trailing newline in all generated
schemas.