### PR TITLE
Fix duplicate brief location options

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/location.yml
@@ -2,19 +2,19 @@ name: Location
 question: Where is the work to be carried out?
 type: radios
 options:
+  - label: "Offsite"
   - label: "Scotland"
   - label: "North East England"
   - label: "North West England"
   - label: "Yorkshire and the Humber"
   - label: "East Midlands"
-  - label: "East Midlands"
+  - label: "West Midlands"
   - label: "East of England"
   - label: "Wales"
   - label: "London"
   - label: "South East England"
-  - label: "South East England"
+  - label: "South West England"
   - label: "Northern Ireland"
-  - label: "Offsite"
 depends:
   - "on": "lot"
     being:


### PR DESCRIPTION
Matching location options generate an invalid schema, since we set
`uniqueItems` on the checkboxes property.

Copying the location list from service questions.