### PR TITLE
Use option value in JSON schemas if available

### DIFF
--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -100,14 +100,20 @@ def checkbox_property(question):
         "minItems": 0 if question.get('optional') else 1,
         "maxItems": len(question['options']),
         "items": {
-            "enum": [option['label'] for option in question['options']]
+            "enum": [
+                option.get('value', option['label'])
+                for option in question['options']
+            ]
         }
     }}
 
 
 def radios_property(question):
     return {question['id']: {
-        "enum": [option['label'] for option in question['options']]
+        "enum": [
+            option.get('value', option['label'])
+            for option in question['options']
+        ]
     }}
 
 


### PR DESCRIPTION
When defining checkboxes or radio sets a value can be provided to each option as well as a label. If provided this is used as the value attribute of the option. This change updates the JSON schemas to use that value rather than the label if the value has been provided.

Props to @allait for showing me how to hypothesis.