### PR TITLE
Add manifest for briefs page

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/display_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/display_brief.yml
@@ -1,0 +1,37 @@
+-
+  name: Overview 
+  questions:
+    - startDate
+    - contractLength
+    - location
+    - outcome
+-
+  name: About the work
+  questions:
+    - backgroundInformation
+    - endUsers
+    - userNeeds
+    - phase
+    - workingArrangements
+    - location
+    - importantDates
+    - successCriteria
+-
+  name: Skills and experience
+  questions:
+    - essentialRequirements
+    - niceToHaveRequirements
+-
+  name: Type of specialist required
+  questions:
+    - specialistRole
+-
+  name: Evaluation
+  questions:
+    - evaluationType
+-
+  name: Additional information
+  questions:
+    - expectedOutcomes
+    - currentTechnologies
+    - additionalTerms


### PR DESCRIPTION
Adds a first-draft of the manifest for the `/digital-outcomes-and-specialists/opportunities/<id>` page.

Is a first draft of the page proposed in the prototype: http://dm-prototype.herokuapp.com/page/requirement/template-brief?key=outcomes.0.