### PR TITLE
Add file type and size to ZIP file download links

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/declaration/MI.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/declaration/MI.yml
@@ -1,2 +1,2 @@
-question: Do you confirm that you’re prepared to provide all Digital Outcomes and Specialists-related management information (MI) to CCS as outlined in the [framework agreement](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?
+question: "Do you confirm that you’re prepared to provide all Digital Outcomes and Specialists-related management information (MI) to CCS as outlined in the [framework agreement (ZIP, 3.2MB)](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists/questions/declaration/termsAndConditions.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/declaration/termsAndConditions.yml
@@ -1,2 +1,2 @@
-question: Do you accept the terms and conditions in the [framework agreement and call-off contract documents](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?
+question: "Do you accept the terms and conditions in the [framework agreement and call-off contract documents (ZIP, 3.2MB)](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/declaration/termsOfParticipation.yml
@@ -1,2 +1,2 @@
-question: Do you agree to comply with the terms of the [Digital Outcomes and Specialists Invitation to Tender](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?
+question: "Do you agree to comply with the terms of the [Digital Outcomes and Specialists Invitation to Tender (ZIP, 3.2MB)](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/AQA3.yml
+++ b/frameworks/g-cloud-7/questions/declaration/AQA3.yml
@@ -1,3 +1,3 @@
-question: Do you confirm that you're prepared to provide all G-Cloud-related management information (MI) to CCS using the template in Attachment 7 of [the supplier pack](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?
+question: "Do you confirm that you're prepared to provide all G-Cloud-related management information (MI) to CCS using the template in Attachment 7 of [the supplier pack (ZIP, 4.3MB)](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?"
 hint: CCS use MI to calculate any savings made by public sector organisations.
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/PR1.yml
+++ b/frameworks/g-cloud-7/questions/declaration/PR1.yml
@@ -1,2 +1,2 @@
-question: Do you accept the terms of participation as described in Attachment 4 of [the supplier pack](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?
+question: "Do you accept the terms of participation as described in Attachment 4 of [the supplier pack (ZIP, 4.3MB)](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/PR2.yml
+++ b/frameworks/g-cloud-7/questions/declaration/PR2.yml
@@ -1,2 +1,2 @@
-question: Do you accept the framework terms and conditions as set out in the Attachment 3 Framework Agreement and Call-Off Contract documents in [the supplier pack](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?
+question: "Do you accept the framework terms and conditions as set out in the Attachment 3 Framework Agreement and Call-Off Contract documents in [the supplier pack (ZIP, 4.3MB)](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/SQC2.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQC2.yml
@@ -1,2 +1,2 @@
-question: Do you accept the declaration of compliance as described in Attachment 5 of [the supplier pack](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?
+question: "Do you accept the declaration of compliance as described in Attachment 5 of [the supplier pack (ZIP, 4.3MB)](/suppliers/frameworks/g-cloud-7/g-cloud-7-supplier-pack.zip)?"
 type: boolean


### PR DESCRIPTION
An [earlier commit](https://github.com/alphagov/digitalmarketplace-frameworks/commit/2c747d2133ac1f7fbec34028805f1ea79802f3c4) added file type and size information to PDF download links.

This adds similar link text for the ZIP file downloads that I missed in the earlier commit.

As per @tombye's comment: 
 "If we're linking to a document, it should include the file type and size as on www.gov.uk.

An example of what I mean at the bottom of: https://www.gov.uk/green-deal-energy-saving-measures/improvements-and-benefits-to-your-home"