### PR TITLE
Add missing specialist roles to brief

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
@@ -85,6 +85,7 @@ options:
     value: technicalArchitect
     description: >
       Break down complex problems and identify steps towards solutions. Coach individuals and engage with non-technical people at all levels of seniority. Write code as a senior member of the development team.
+  -
     label: User researcher
     value: userResearcher
     description: >

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
@@ -49,6 +49,11 @@ options:
       Build software that supports user needs. Continually improve the service by
       identifying new tools and techniques, removing technical bottlenecks, and adapting and maintaining code.
   -
+    label: Performance analytist
+    value: performance_analytist
+    description: >
+      Specify, collect and present the key performance data and analysis for a service.
+  -
     label: Portfolio manager
     value: portfolioManager
     description: >
@@ -76,6 +81,10 @@ options:
       Develop and deliver an effective user-focused digital service.
       Manage the full product lifecycle, including user research, design, delivery and continuous improvement.
   -
+    label: Technical Architect
+    value: technical_architect
+    description: >
+      Break down complex problems and identify steps towards solutions. Coach individuals and engage with non-technical people at all levels of seniority. Write code as a senior member of the development team.
     label: User researcher
     value: userResearcher
     description: >

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/specialistRole.yml
@@ -49,8 +49,8 @@ options:
       Build software that supports user needs. Continually improve the service by
       identifying new tools and techniques, removing technical bottlenecks, and adapting and maintaining code.
   -
-    label: Performance analytist
-    value: performance_analytist
+    label: Performance analyst
+    value: performanceAnalyst
     description: >
       Specify, collect and present the key performance data and analysis for a service.
   -
@@ -82,7 +82,7 @@ options:
       Manage the full product lifecycle, including user research, design, delivery and continuous improvement.
   -
     label: Technical Architect
-    value: technical_architect
+    value: technicalArchitect
     description: >
       Break down complex problems and identify steps towards solutions. Coach individuals and engage with non-technical people at all levels of seniority. Write code as a senior member of the development team.
     label: User researcher


### PR DESCRIPTION
@pcraig3 noticed the performance analytist and techical architect specialisms are recognised [specialisms a service can provide](https://github.com/alphagov/digitalmarketplace-frameworks/tree/master/frameworks/digital-outcomes-and-specialists/questions/services) but aren't available for briefs.

This adds them.

I've run the [scripts/generate-schemas.py](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/scripts/generate-schemas.py) script to update the schemas.
The updates have been put into this pull request:

https://github.com/alphagov/digitalmarketplace-api/pull/374