### PR TITLE
Make tests better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL := /bin/bash
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
+
+virtualenv:
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+
+requirements_for_test: virtualenv requirements_for_test.txt
+	${VIRTUALENV_ROOT}/bin/pip install -r requirements_for_test.txt
+
+test: show_environment test_pep8 test_python
+
+test_pep8: virtualenv
+	${VIRTUALENV_ROOT}/bin/pep8 .
+
+test_python: virtualenv
+	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
+
+show_environment:
+	@echo "Environment variables in use:"
+	@env | grep DM_ || true
+
+.PHONY: virtualenv requirements_for_test test_pep8 test_python show_environment

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Running the tests
 The tests check that the YAML files are valid and that they match a schema.
 
 Setup a VirtualEnv
-`mkvirtualenv`
+`make virtualenv`
 
 Install dependencies
-`pip install -r requirements_for_test.txt`
+`make requirements_for_test`
 
 Run the tests
-`py.test`
+`make test`
 
 Versioning
 ----------

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+pep8==1.5.7
 hypothesis==1.18.1
 jsonschema==2.3.0
 mock==1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 120

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -337,6 +337,7 @@ def test_percentage_property_limits(max_value, min_value, integer_only):
     }}
     assert actual == expected
 
+
 def test_multiquestion():
     question = {}
     question['questions'] = []


### PR DESCRIPTION
A PEP8 error with a file from this repo was breaking the tests on the buyer app.

This adds PEP8 checking here to ensure this won't happen again and wraps it in a `Makefile` to make it consistent with the other apps.