### PR TITLE
Set title as the first question needed for creating a brief

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
@@ -1,4 +1,10 @@
 -
+  name: Title
+  editable: True
+  step: 1
+  questions:
+    - title
+-
   name: Specialist role
   editable: True
   step: 1
@@ -11,12 +17,6 @@
   questions:
     - locationOutcomesSpecialists
     - locationParticipants
--
-  name: Title
-  editable: True
-  step: 1
-  questions:
-    - title
 -
   name: Description of work
   editable: True


### PR DESCRIPTION
Previously, our assumption had been that titles were of lesser importance/value than actually picking a location or role (arguably, it gets the buyer thinking of the important thing about their brief sooner), but now we don't know if that's a real thing.
@ralph-hawkins isn't here and the prototype starts with selecting a title, so let's do that.