### PR TITLE
Hack a number type for forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Question keys
     * `being` a list of acceptable values for the key. If service data key value matches one of the values in the `being` the
        question is kept, otherwise the question is removed from the section for the given service
 * `limits` a dictionary of validation/type requirements to limit the possible question values. Available fields:
+    * `type` string, the only recognised value is `number`, indicating that a `type: text` field should be given a numeric type in the generated schema
     * `min_value` integer, sets the minimum value for percentage questions
     * `max_value` integer, sets the maximum value for percentage questions
     * `integer_only` boolean, when `true` makes the percentage question accept only integer values instead of numbers

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/numberOfSuppliersOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/numberOfSuppliersOutcomes.yml
@@ -12,6 +12,7 @@ hint: "Minimum 3"
 type: text
 smaller: true
 limits:
+  type: number
   min_value: 3
   integer_only: true
 

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/numberOfSuppliersParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/numberOfSuppliersParticipants.yml
@@ -12,6 +12,7 @@ hint: "Minimum 3"
 type: text
 smaller: true
 limits:
+  type: number
   min_value: 3
   integer_only: true
 

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/numberOfSuppliersSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/numberOfSuppliersSpecialists.yml
@@ -12,6 +12,7 @@ hint: "Minimum 3"
 type: text
 smaller: true
 limits:
+  type: number
   min_value: 3
   integer_only: true
 

--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -89,16 +89,28 @@ def empty_schema(schema_name):
 
 
 def text_property(question):
-    data = {
-        "type": "string",
-        "minLength": 0 if question.get('optional') else 1,
-    }
 
-    format_limit = question.get('limits', {}).get('format')
-    if format_limit:
-        data['format'] = format_limit
+    limits = question.get('limits', {})
+    if limits.get('type') == 'number':
+        data =  {
+            "minimum": limits.get('min_value') or 0,
+            "type": "integer" if limits.get('integer_only') else "number"
+        }
+        if limits.get('max_value') is not None:
+            data["maximum"] = limits['max_value']
+            data["exclusiveMaximum"] = not limits.get('integer_only'),
 
-    data.update(parse_question_limits(question))
+    else:
+        data = {
+            "type": "string",
+            "minLength": 0 if question.get('optional') else 1,
+        }
+
+        format_limit = question.get('limits', {}).get('format')
+        if format_limit:
+            data['format'] = format_limit
+
+        data.update(parse_question_limits(question))
 
     return {question['id']: data}
 

--- a/schemas/questions.json
+++ b/schemas/questions.json
@@ -189,6 +189,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "type": {"type": "string"},
         "format": {"type": "string"},
         "max_value": {"type": "number"},
         "min_value": {"type": "number"},


### PR DESCRIPTION
We don't have a number type but `numberOfSuppliers` needs to be validated as a number 3 or more.  This allows the text type to be a numeric type in the generated schemas by adding `type: number` to the limits.