### PR TITLE
content update so buyers know when they should hold their q+a session

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/questionAndAnswerSessionDetails.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/questionAndAnswerSessionDetails.yml
@@ -5,7 +5,7 @@ question_advice: |
   You must include:
 
   - the type of session you want to run, eg webinar, phone conference or meeting
-  - the date and time of the session
+  - the date and time of the session (this should happen within 1 week of publishing your requirements)
 
   Depending on the type of session you choose, you could also include:
 


### PR DESCRIPTION
the line 'the date and time of the session' has had '(this should happen within 1 week of publishing your requirements)' added to it.