### PR TITLE
Change "to an" to "for this"

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_brief_response.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_brief_response.yml
@@ -1,5 +1,5 @@
 -
-  name: Apply to an opportunity
+  name: Apply for this opportunity
   editable: True
   description: |
     Buyers will use the information suppliers provide here to create a shortlist.


### PR DESCRIPTION
This is a fallback title no one should ever actually see, but it's still worth keeping it consistent from the way we talk about applying to opportunities in the buyer app.