### PR TITLE
Don't markdown dates

### DIFF
--- a/frameworks/digital-outcomes-and-specialists/messages/dates.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/dates.yml
@@ -1,14 +1,9 @@
-clarifications_close_date: |
-  5pm GMT, 6 January 2016
+clarifications_close_date: '5pm GMT, 6 January 2016'
 
-  *[GMT]: Greenwich Mean Time
-clarifications_publish_date: |
-  5pm GMT, 13 January 2016
+clarifications_publish_date: '5pm GMT, 13 January 2016'
 
-  *[GMT]: Greenwich Mean Time
-framework_close_date: |
-  3pm GMT, 19 January 2016
+framework_close_date: '3pm GMT, 19 January 2016'
 
-  *[GMT]: Greenwich Mean Time
 intention_to_award_date: '18 February 2016'
+
 framework_live_date: ""

--- a/frameworks/g-cloud-7/messages/dates.yml
+++ b/frameworks/g-cloud-7/messages/dates.yml
@@ -1,14 +1,9 @@
-clarifications_close_date: |
-  5pm BST, 22 September 2015
+clarifications_close_date: '5pm BST, 22 September 2015'
 
-  *[BST]: British Summer Time
-clarifications_publish_date: |
-  5pm BST, 29 September 2015
+clarifications_publish_date: '5pm BST, 29 September 2015'
 
-  *[BST]: British Summer Time
-framework_close_date: |
-  3pm BST, 6 October 2015
+framework_close_date: '3pm BST, 6 October 2015'
 
-  *[BST]: British Summer Time
 intention_to_award_date: '9 November 2015'
+
 framework_live_date: '23 November 2015'

--- a/frameworks/g-cloud-8/messages/dates.yml
+++ b/frameworks/g-cloud-8/messages/dates.yml
@@ -1,14 +1,9 @@
-clarifications_close_date: |
-  5pm BST, 7 June 2016
+clarifications_close_date: '5pm BST, 7 June 2016'
 
-  *[BST]: British Summer Time
-clarifications_publish_date: |
-  5pm BST, 14 June 2016
+clarifications_publish_date: '5pm BST, 14 June 2016'
 
-  *[BST]: British Summer Time
-framework_close_date: |
-  5pm BST, 21 June 2016
+framework_close_date: '5pm BST, 21 June 2016'
 
-  *[BST]: British Summer Time
 intention_to_award_date: '18 July 2016'
+
 framework_live_date: '1 August 2016'


### PR DESCRIPTION
Required to fix:
 - https://www.pivotaltracker.com/story/show/119086793
 - https://www.pivotaltracker.com/story/show/119075005

The markdown filter wraps values in `<p>` tags but we generally want to use dates inline and the `<p>` breaks the page layouts in the frontend.  So we're not going to use markdown for date strings.