### PR TITLE
[#132662099] Use raw unicode not HTML escapes

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-2/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/manifests/declaration.yml
@@ -3,7 +3,7 @@
   editable: True
   description: >
     You must make this declaration to apply to Digital Outcomes and
-    Specialists&nbsp;2. You can come back and change your answers at any time before
+    Specialists 2. You can come back and change your answers at any time before
     5pm, 6 December 2016.
 
 
@@ -130,7 +130,7 @@
   name: About you
   editable: True
   description: >
-    The Crown Commercial Service will use the information you provide under 'About you' to process your application and manage your participation in the Digital Outcomes and Specialists&nbsp;2 framework.
+    The Crown Commercial Service will use the information you provide under 'About you' to process your application and manage your participation in the Digital Outcomes and Specialists 2 framework.
   questions:
     - primaryContact
     - primaryContactEmail

--- a/frameworks/digital-outcomes-and-specialists-2/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/manifests/edit_brief.yml
@@ -65,12 +65,12 @@
     There are 3 stages to finding the supplier that best meets your needs.
 
     ##1\. View suppliers who applied
-    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+    When suppliers apply, they declare which of your essential and nice‑to‑have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
 
-    - have the least nice&#8209;to&#8209;have skills and experience
+    - have the least nice‑to‑have skills and experience
     - can’t start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many suppliers.
@@ -100,12 +100,12 @@
     There are 3 stages to finding the specialist that best meets your needs.
 
     ##1\. View specialists who applied
-    When specialists apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Specialists who don’t meet your essential skills and experience are excluded.
+    When specialists apply, they declare which of your essential and nice‑to‑have skills and experience they have. Specialists who don’t meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible specialists, you can exclude the specialists who:
 
-    - have the least nice&#8209;to&#8209;have skills and experience
+    - have the least nice‑to‑have skills and experience
     - can’t start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many specialists.
@@ -131,12 +131,12 @@
     There are 3 stages to finding the supplier that best meets your needs.
 
     ##1\. View suppliers who applied
-    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+    When suppliers apply, they declare which of your essential and nice‑to‑have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
 
-    - have the least nice&#8209;to&#8209;have skills and experience
+    - have the least nice‑to‑have skills and experience
     - can’t start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many suppliers.

--- a/frameworks/digital-outcomes-and-specialists-2/messages/homepage-sidebar.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/messages/homepage-sidebar.yml
@@ -1,16 +1,16 @@
 coming:
-  heading: 'Digital Outcomes and Specialists&nbsp;2 coming soon'
+  heading: 'Digital Outcomes and Specialists 2 coming soon'
   messages:
     - 'Provide digital outcomes and specialists, and user research studios and participants.'
     - 'You need an account to receive notifications about when you can apply.'
 
 open:
-  heading: 'Digital Outcomes and Specialists&nbsp;2 is open for applications'
+  heading: 'Digital Outcomes and Specialists 2 is open for applications'
   messages:
     - 'You need an account to apply.'
-    - 'The application deadline is 5pm&nbsp;GMT, 6 December 2016.'
+    - 'The application deadline is 5pm GMT, 6 December 2016.'
 
 pending:
-  heading: 'Digital Outcomes and Specialists&nbsp;2 is closed for applications'
+  heading: 'Digital Outcomes and Specialists 2 is closed for applications'
   messages:
     - 'Applications are being reviewed.'

--- a/frameworks/digital-outcomes-and-specialists-2/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/briefs/endUsers.yml
@@ -3,11 +3,11 @@ question: Who the users are and what they need to do
 question_advice: |
   You should use this format:
 
-  As a&hellip; (who is the user?)
+  As a… (who is the user?)
 
-  I need to&hellip; (what does the user want to do?)
+  I need to… (what does the user want to do?)
 
-  So that&hellip; (why does the user want to do this?)
+  So that… (why does the user want to do this?)
 
   eg As a carer, I need to know if I can get Carer’s Allowance, so that I know if I should apply for it or not.
 type: textbox_large

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/MI.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/MI.yml
@@ -1,2 +1,2 @@
-question: "Do you confirm that you’re prepared to provide all Digital Outcomes and Specialists&nbsp;2-related management information (MI) to CCS as outlined in the [framework agreement (ZIP, 3.2MB)](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?"
+question: "Do you confirm that you’re prepared to provide all Digital Outcomes and Specialists 2-related management information (MI) to CCS as outlined in the [framework agreement (ZIP, 3.2MB)](/suppliers/frameworks/digital-outcomes-and-specialists/files/digital-outcomes-and-specialists-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/accuratelyDescribed.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/accuratelyDescribed.yml
@@ -1,2 +1,2 @@
-question: Do you confirm that all the service descriptions you’re submitting for Digital Outcomes and Specialists&nbsp;2 on the Digital Marketplace will be accurate and true representations?
+question: Do you confirm that all the service descriptions you’re submitting for Digital Outcomes and Specialists 2 on the Digital Marketplace will be accurate and true representations?
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/canProvideFromDayOne.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/canProvideFromDayOne.yml
@@ -1,4 +1,4 @@
 question: >
-  If your application is successful, can you provide all the services you're submitting to Digital Outcomes and Specialists&nbsp;2 from the first day you're awarded a place on the framework?
+  If your application is successful, can you provide all the services you're submitting to Digital Outcomes and Specialists 2 from the first day you're awarded a place on the framework?
 type: boolean
 hint: You must be ready to provide the services you're submitting from February 2016.

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/contactEmailContractNotice.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/contactEmailContractNotice.yml
@@ -1,3 +1,3 @@
-question: If your Digital Outcomes and Specialists&nbsp;2 application is successful, what contact email should appear on the contract notice?
+question: If your Digital Outcomes and Specialists 2 application is successful, what contact email should appear on the contract notice?
 type: text
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/contactNameContractNotice.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/contactNameContractNotice.yml
@@ -1,3 +1,3 @@
-question: If your Digital Outcomes and Specialists&nbsp;2 application is successful, what contact name should appear on the contract notice?
+question: If your Digital Outcomes and Specialists 2 application is successful, what contact name should appear on the contract notice?
 type: text
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/dunsNumber.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/dunsNumber.yml
@@ -1,6 +1,6 @@
 question: What is your organisation’s DUNS number?
 type: text
-hint: The trading organisation applying to sell services through Digital Outcomes and Specialists&nbsp;2 must have its own 9-digit DUNS number. [Find out how to get a DUNS number.](http://www.dnb.co.uk/dandb-duns-number)
+hint: The trading organisation applying to sell services through Digital Outcomes and Specialists 2 must have its own 9-digit DUNS number. [Find out how to get a DUNS number.](http://www.dnb.co.uk/dandb-duns-number)
 
 validations:
   -

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/employersInsurance.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/employersInsurance.yml
@@ -3,7 +3,7 @@ question: >
   will it have prior to framework award, employer’s liability insurance of at least
   £5 million?
 hint:  Employer’s liability insurance is a legal requirement except for businesses
-  employing only the owner or close family members. You must answer 'Yes' or 'Not applicable' to be eligible for consideration for the Digital Outcomes and Specialists&nbsp;2 framework.
+  employing only the owner or close family members. You must answer 'Yes' or 'Not applicable' to be eligible for consideration for the Digital Outcomes and Specialists 2 framework.
 type: radios
 options:
   -

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/nameOfOrganisation.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/nameOfOrganisation.yml
@@ -1,3 +1,3 @@
-question: What is the full name of the organisation applying to the Digital Outcomes and Specialists&nbsp;2 framework agreement?
+question: What is the full name of the organisation applying to the Digital Outcomes and Specialists 2 framework agreement?
 type: text
 hint: For a group of economic operators, this will be the name of the lead organisation (or the separate entity such as a special purpose vehicle if you have already created one). If you’re submitting a response on behalf of another organisation, use their company name and details, not yours.

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/proofOfClaims.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/proofOfClaims.yml
@@ -1,2 +1,2 @@
-question: Are you prepared to provide proof of any claims made about the services you're submitting to Digital Outcomes and Specialists&nbsp;2?
+question: Are you prepared to provide proof of any claims made about the services you're submitting to Digital Outcomes and Specialists 2?
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/readUnderstoodGuidance.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/readUnderstoodGuidance.yml
@@ -1,2 +1,2 @@
-question: Have you read and understood the guidance on [how to apply](https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide) to Digital Outcomes and Specialists&nbsp;2 using the Digital Marketplace?
+question: Have you read and understood the guidance on [how to apply](https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide) to Digital Outcomes and Specialists 2 using the Digital Marketplace?
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/skillsAndResources.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/skillsAndResources.yml
@@ -1,2 +1,2 @@
-question: Does your organisation have the skills and resources to provide the services you're submitting for Digital Outcomes and Specialists&nbsp;2?
+question: Does your organisation have the skills and resources to provide the services you're submitting for Digital Outcomes and Specialists 2?
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/subcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/subcontracting.yml
@@ -1,4 +1,4 @@
-question: "Please confirm whether you will provide Digital Outcomes and Specialists&nbsp;2 services:"
+question: "Please confirm whether you will provide Digital Outcomes and Specialists 2 services:"
 type: radios
 options:
   - label: yourself without the use of third parties (subcontractors)
@@ -6,4 +6,4 @@ options:
   - label: as a prime contractor, using third parties (subcontractors) to provide all services
   - label: as part of a consortium or special purpose vehicle, using members only to provide all services
   - label: as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
-hint: Only include subcontractors whose products or services will be integral to the Digital Outcomes and Specialists&nbsp;2 services that you intend to provide.
+hint: Only include subcontractors whose products or services will be integral to the Digital Outcomes and Specialists 2 services that you intend to provide.

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/termsOfParticipation.yml
@@ -1,2 +1,2 @@
-question: "Do you agree to comply with the terms of the [Digital Outcomes and Specialists&nbsp;2 invitation to apply for a place on the framework)](/suppliers/frameworks/digital-outcomes-and-specialists-2/)?"
+question: "Do you agree to comply with the terms of the [Digital Outcomes and Specialists 2 invitation to apply for a place on the framework)](/suppliers/frameworks/digital-outcomes-and-specialists-2/)?"
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/understandHowToAskQuestions.yml
@@ -1,2 +1,2 @@
-question: Do you understand that you must log in to your Digital Marketplace supplier account to ask questions about the Digital Outcomes and Specialists&nbsp;2 application process?
+question: Do you understand that you must log in to your Digital Marketplace supplier account to ask questions about the Digital Outcomes and Specialists 2 application process?
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists-2/questions/declaration/understandTool.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/questions/declaration/understandTool.yml
@@ -1,2 +1,2 @@
-question: Do you understand that you must complete both the supplier declaration and add at least one service before your application to Digital Outcomes and Specialists&nbsp;2 can be considered?
+question: Do you understand that you must complete both the supplier declaration and add at least one service before your application to Digital Outcomes and Specialists 2 can be considered?
 type: boolean

--- a/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists/manifests/edit_brief.yml
@@ -65,12 +65,12 @@
     There are 3 stages to finding the supplier that best meets your needs.
 
     ##1\. View suppliers who applied
-    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+    When suppliers apply, they declare which of your essential and nice‑to‑have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
 
-    - have the least nice&#8209;to&#8209;have skills and experience
+    - have the least nice‑to‑have skills and experience
     - can’t start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many suppliers.
@@ -100,12 +100,12 @@
     There are 3 stages to finding the specialist that best meets your needs.
 
     ##1\. View specialists who applied
-    When specialists apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Specialists who don’t meet your essential skills and experience are excluded.
+    When specialists apply, they declare which of your essential and nice‑to‑have skills and experience they have. Specialists who don’t meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible specialists, you can exclude the specialists who:
 
-    - have the least nice&#8209;to&#8209;have skills and experience
+    - have the least nice‑to‑have skills and experience
     - can’t start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many specialists.
@@ -131,12 +131,12 @@
     There are 3 stages to finding the supplier that best meets your needs.
 
     ##1\. View suppliers who applied
-    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+    When suppliers apply, they declare which of your essential and nice‑to‑have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
 
-    - have the least nice&#8209;to&#8209;have skills and experience
+    - have the least nice‑to‑have skills and experience
     - can’t start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many suppliers.

--- a/frameworks/digital-outcomes-and-specialists/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists/questions/briefs/endUsers.yml
@@ -3,11 +3,11 @@ question: Who the users are and what they need to do
 question_advice: |
   You should use this format:
   
-  As a&hellip; (who is the user?)
+  As a… (who is the user?)
   
-  I need to&hellip; (what does the user want to do?)
+  I need to… (what does the user want to do?)
   
-  So that&hellip; (why does the user want to do this?)
+  So that… (why does the user want to do this?)
   
   eg As a carer, I need to know if I can get Carer’s Allowance, so that I know if I should apply for it or not.
 type: textbox_large

--- a/frameworks/g-cloud-6/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-6/questions/services/serviceDefinitionDocumentURL.yml
@@ -1,5 +1,5 @@
 question: 'Service definition document'
-hint: 'Please upload your service definition. Refer to the G-Cloud 7 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+hint: 'Please upload your service definition. Refer to the G‑Cloud 7 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 depends:
   -
     "on": lot

--- a/frameworks/g-cloud-7/manifests/declaration.yml
+++ b/frameworks/g-cloud-7/manifests/declaration.yml
@@ -1,5 +1,5 @@
 -
-  name: G-Cloud 7 essentials
+  name: G‑Cloud 7 essentials
   editable: True
   questions:
     - PR1

--- a/frameworks/g-cloud-7/manifests/declaration.yml
+++ b/frameworks/g-cloud-7/manifests/declaration.yml
@@ -1,5 +1,6 @@
 -
   name: G‑Cloud 7 essentials
+  slug: g-cloud-7-essentials
   editable: True
   questions:
     - PR1

--- a/frameworks/g-cloud-7/questions/declaration/PR3.yml
+++ b/frameworks/g-cloud-7/questions/declaration/PR3.yml
@@ -1,2 +1,2 @@
-question: Do you understand that you must complete both the supplier declaration and at least one service before your application to G-Cloud 7 can be considered?
+question: Do you understand that you must complete both the supplier declaration and at least one service before your application to G‑Cloud 7 can be considered?
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/PR4.yml
+++ b/frameworks/g-cloud-7/questions/declaration/PR4.yml
@@ -1,3 +1,3 @@
-question: Do you understand that you must log in to your Digital Marketplace supplier account to ask questions about the G-Cloud 7 application process?
+question: Do you understand that you must log in to your Digital Marketplace supplier account to ask questions about the G‑Cloud 7 application process?
 hint: All communication with the Crown Commercial Service (CCS) about this bid should take place through the Digital Marketplace. All answers will be published on the Digital Marketplace.
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/PR5.yml
+++ b/frameworks/g-cloud-7/questions/declaration/PR5.yml
@@ -1,2 +1,2 @@
-question: Have you read and understood [the guidance](/g-cloud/suppliers-guide) on how to apply to G-Cloud 7 using your supplier account on the Digital Marketplace?
+question: Have you read and understood [the guidance](/g-cloud/suppliers-guide) on how to apply to G‑Cloud 7 using your supplier account on the Digital Marketplace?
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/SQ1-1a.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQ1-1a.yml
@@ -1,4 +1,4 @@
-question: What is the full name of the organisation applying to the G-Cloud 7 framework?
+question: What is the full name of the organisation applying to the G‑Cloud 7 framework?
 hint: For a group of economic operators, this will be the name of the lead organisation. If you're submitting a response on behalf of another organisation, use their company name and details, not yours.
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/declaration/SQ1-1n.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQ1-1n.yml
@@ -1,3 +1,3 @@
-question: If your G-Cloud 7 application is successful, what is the contact name that should appear on the contract notice?
+question: If your G‑Cloud 7 application is successful, what is the contact name that should appear on the contract notice?
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.
 type: text

--- a/frameworks/g-cloud-7/questions/declaration/SQ1-1o.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQ1-1o.yml
@@ -1,4 +1,4 @@
-question: If your G-Cloud 7 application is successful, what is the contact email that should be included on the contract notice?
+question: If your G‑Cloud 7 application is successful, what is the contact email that should be included on the contract notice?
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.
 type: text
 validations:

--- a/frameworks/g-cloud-7/questions/declaration/SQA3.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQA3.yml
@@ -1,2 +1,2 @@
-question: Do you confirm that your organisation has the skills and resources to deliver and support the cloud-based services that you're submitting for G-Cloud 7?
+question: Do you confirm that your organisation has the skills and resources to deliver and support the cloud-based services that you're submitting for G‑Cloud 7?
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/SQA4.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQA4.yml
@@ -1,2 +1,2 @@
-question: Do you confirm that all the services you are submitting for G-Cloud 7 will be accurately described?
+question: Do you confirm that all the services you are submitting for G‑Cloud 7 will be accurately described?
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/SQA5.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQA5.yml
@@ -1,2 +1,2 @@
-question: Do you confirm that you are prepared to provide proof of any claims made about the services you're submitting to G-Cloud 7?
+question: Do you confirm that you are prepared to provide proof of any claims made about the services you're submitting to G‑Cloud 7?
 type: boolean

--- a/frameworks/g-cloud-7/questions/declaration/SQE2a.yml
+++ b/frameworks/g-cloud-7/questions/declaration/SQE2a.yml
@@ -1,5 +1,5 @@
 question: 'Please confirm whether you will provide G-Cloud services:'
-hint: 'Choose all that apply. You should only consider subcontractors whose products or services will be integral to the G-Cloud 7 services that you intend to provide.'
+hint: 'Choose all that apply. You should only consider subcontractors whose products or services will be integral to the G‑Cloud 7 services that you intend to provide.'
 type: checkboxes
 options:
   -

--- a/frameworks/g-cloud-7/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-7/questions/services/serviceDefinitionDocumentURL.yml
@@ -1,5 +1,5 @@
 question: 'Service definition document'
-hint: 'Please upload your service definition. Refer to the G-Cloud 7 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+hint: 'Please upload your service definition. Refer to the G‑Cloud 7 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 depends:
   -
     "on": lot

--- a/frameworks/g-cloud-8/manifests/declaration.yml
+++ b/frameworks/g-cloud-8/manifests/declaration.yml
@@ -2,7 +2,7 @@
   name: Essentials
   editable: True
   description: |
-    You must make this declaration to apply to G-Cloud 8. You can come back and change your answers at any time before
+    You must make this declaration to apply to G‑Cloud 8. You can come back and change your answers at any time before
     5pm BST, 23 June 2016.
     
     You must be able to truthfully answer ‘yes’ to every question under ‘Essentials’
@@ -88,7 +88,7 @@
   editable: True
   description: |
     The Crown Commercial Service will use the information you provide under ‘About you’ to process your application 
-    and manage your participation in the G-Cloud 8 framework.
+    and manage your participation in the G‑Cloud 8 framework.
     
     You can answer ‘yes’ or ‘no’ to questions [[cyberEssentials]] and [[cyberEssentialsPlus]].
   questions:    

--- a/frameworks/g-cloud-8/messages/contract_variation_1.yml
+++ b/frameworks/g-cloud-8/messages/contract_variation_1.yml
@@ -3,7 +3,7 @@ variation_description_not_in_place: |
     contract (reference: RM1557viii-15-07-2016).
     The changes make it easier for suppliers to work with government and are listed here.
     
-    These minor changes were agreed while G-Cloud 8 was open for applications.
+    These minor changes were agreed while G‑Cloud 8 was open for applications.
     The changes were not included in the final documents that were signed on behalf of [[SUPPLIER_NAME]].
 
 variation_not_yet_agreed_extra: |

--- a/frameworks/g-cloud-8/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-8/messages/homepage-sidebar.yml
@@ -1,5 +1,5 @@
 coming:
-  heading: 'G-Cloud 8 coming soon'
+  heading: 'G‑Cloud 8 coming soon'
   messages:
     - 'Provide cloud software and support to the public sector.'
     - 'You need an account to receive notifications about when you can apply.'
@@ -11,7 +11,7 @@ pending:
     - 'G‑Cloud 8 services will be available from 1 August 2016.'
 
 open:
-  heading: 'G-Cloud 8 is open for applications'
+  heading: 'G‑Cloud 8 is open for applications'
   messages:
     - 'Provide cloud software and support to the public sector.'
     - 'You need an account to apply.'

--- a/frameworks/g-cloud-8/questions/declaration/MI.yml
+++ b/frameworks/g-cloud-8/questions/declaration/MI.yml
@@ -1,2 +1,2 @@
-question: "Do you confirm that you’re prepared to provide all G-Cloud 8-related management information (MI) to CCS as outlined in the [framework agreement (ZIP, 2.4MB)](/suppliers/frameworks/g-cloud-8/files/g-cloud-8-supplier-pack.zip)?"
+question: "Do you confirm that you’re prepared to provide all G‑Cloud 8-related management information (MI) to CCS as outlined in the [framework agreement (ZIP, 2.4MB)](/suppliers/frameworks/g-cloud-8/files/g-cloud-8-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/accuratelyDescribed.yml
+++ b/frameworks/g-cloud-8/questions/declaration/accuratelyDescribed.yml
@@ -1,2 +1,2 @@
-question: Do you confirm that all the services you’re submitting for G-Cloud 8 on the Digital Marketplace will be accurately described?
+question: Do you confirm that all the services you’re submitting for G‑Cloud 8 on the Digital Marketplace will be accurately described?
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/contactEmailContractNotice.yml
+++ b/frameworks/g-cloud-8/questions/declaration/contactEmailContractNotice.yml
@@ -1,4 +1,4 @@
-question: If your G-Cloud 8 application is successful, what contact email should appear on the contract notice?
+question: If your G‑Cloud 8 application is successful, what contact email should appear on the contract notice?
 type: text
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.
 validations:

--- a/frameworks/g-cloud-8/questions/declaration/contactNameContractNotice.yml
+++ b/frameworks/g-cloud-8/questions/declaration/contactNameContractNotice.yml
@@ -1,3 +1,3 @@
-question: If your G-Cloud 8 application is successful, what contact name should appear on the contract notice?
+question: If your G‑Cloud 8 application is successful, what contact name should appear on the contract notice?
 type: text
 hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.

--- a/frameworks/g-cloud-8/questions/declaration/dunsNumber.yml
+++ b/frameworks/g-cloud-8/questions/declaration/dunsNumber.yml
@@ -1,6 +1,6 @@
 question: What is your organisation’s DUNS number?
 type: text
-hint: The trading organisation applying to sell services through G-Cloud 8 must have its own 9-digit DUNS number. [Find out how to get a DUNS number.](http://www.dnb.co.uk/dandb-duns-number)
+hint: The trading organisation applying to sell services through G‑Cloud 8 must have its own 9-digit DUNS number. [Find out how to get a DUNS number.](http://www.dnb.co.uk/dandb-duns-number)
 
 validations:
   -

--- a/frameworks/g-cloud-8/questions/declaration/nameOfOrganisation.yml
+++ b/frameworks/g-cloud-8/questions/declaration/nameOfOrganisation.yml
@@ -1,5 +1,5 @@
 
-question: What is the full name of the organisation applying to the G-Cloud 8 framework agreement?
+question: What is the full name of the organisation applying to the G‑Cloud 8 framework agreement?
 type: text
 hint: For a group of economic operators, this will be the name of the lead organisation (or the separate entity such as a special purpose vehicle if you have already created one). If you’re submitting a response on behalf of another organisation, use their company name and details, not yours.
 validations:

--- a/frameworks/g-cloud-8/questions/declaration/proofOfClaims.yml
+++ b/frameworks/g-cloud-8/questions/declaration/proofOfClaims.yml
@@ -1,2 +1,2 @@
-question: Are you prepared to provide proof of any claims made about the services you’re submitting to G-Cloud 8?
+question: Are you prepared to provide proof of any claims made about the services you’re submitting to G‑Cloud 8?
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/readUnderstoodGuidance.yml
+++ b/frameworks/g-cloud-8/questions/declaration/readUnderstoodGuidance.yml
@@ -1,2 +1,2 @@
-question: Have you read and understood the guidance on [how to apply](https://www.gov.uk/guidance/g-cloud-suppliers-guide) to G-Cloud 8 using the Digital Marketplace?
+question: Have you read and understood the guidance on [how to apply](https://www.gov.uk/guidance/g-cloud-suppliers-guide) to G‑Cloud 8 using the Digital Marketplace?
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/servicesHaveOrSupport.yml
+++ b/frameworks/g-cloud-8/questions/declaration/servicesHaveOrSupport.yml
@@ -1,5 +1,5 @@
 question: |
-  Depending on the lots you’re submitting services to, do you confirm that the services you are submitting to G-Cloud 8 have or support:
+  Depending on the lots you’re submitting services to, do you confirm that the services you are submitting to G‑Cloud 8 have or support:
   
   - on-demand self-service. Your cloud services, eg server time or network storage, must be automatically available without interaction between the supplier and the buyer. (Lots 1, 2, 3.)
   - broad network access. Your cloud services must be easily accessible over the network and across a wide range of platforms (eg mobile phones, tablets, laptops and workstations) and a mix of applications that are both thin (the bulk of data processing occurs on the server) and thick (most processing occurs on the local platform). (Lots 1, 2, 3.)

--- a/frameworks/g-cloud-8/questions/declaration/skillsAndResources.yml
+++ b/frameworks/g-cloud-8/questions/declaration/skillsAndResources.yml
@@ -1,2 +1,2 @@
-question: Does your organisation have the skills and resources to provide the services you’re submitting for G-Cloud 8?
+question: Does your organisation have the skills and resources to provide the services you’re submitting for G‑Cloud 8?
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/subcontracting.yml
+++ b/frameworks/g-cloud-8/questions/declaration/subcontracting.yml
@@ -1,4 +1,4 @@
-question: "Please confirm whether you will provide G-Cloud 8 services:"
+question: "Please confirm whether you will provide G‑Cloud 8 services:"
 type: checkboxes
 options:
   - label: yourself without the use of third parties (subcontractors)
@@ -6,5 +6,5 @@ options:
   - label: as a prime contractor, using third parties (subcontractors) to provide all services
   - label: as part of a consortium or special purpose vehicle, using members only to provide all services
   - label: as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
-hint: Choose all that apply. Only include subcontractors whose products or services will be integral to the G-Cloud 8 
+hint: Choose all that apply. Only include subcontractors whose products or services will be integral to the G‑Cloud 8 
       services that you intend to provide.

--- a/frameworks/g-cloud-8/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/g-cloud-8/questions/declaration/termsOfParticipation.yml
@@ -1,2 +1,2 @@
-question: "Do you agree to comply with the terms of the [G-Cloud 8 Invitation to Tender (ZIP, 2.4MB)](/suppliers/frameworks/g-cloud-8/files/g-cloud-8-supplier-pack.zip)?"
+question: "Do you agree to comply with the terms of the [G‑Cloud 8 Invitation to Tender (ZIP, 2.4MB)](/suppliers/frameworks/g-cloud-8/files/g-cloud-8-supplier-pack.zip)?"
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/g-cloud-8/questions/declaration/understandHowToAskQuestions.yml
@@ -1,2 +1,2 @@
-question: Do you understand that you must log in to your Digital Marketplace supplier account to ask questions about the G-Cloud 8 application process?
+question: Do you understand that you must log in to your Digital Marketplace supplier account to ask questions about the G‑Cloud 8 application process?
 type: boolean

--- a/frameworks/g-cloud-8/questions/declaration/understandTool.yml
+++ b/frameworks/g-cloud-8/questions/declaration/understandTool.yml
@@ -1,2 +1,2 @@
-question: Do you understand that you must complete the supplier declaration and mark at least one service complete before your application to G-Cloud 8 can be considered?
+question: Do you understand that you must complete the supplier declaration and mark at least one service complete before your application to G‑Cloud 8 can be considered?
 type: boolean

--- a/frameworks/g-cloud-8/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-8/questions/services/serviceDefinitionDocumentURL.yml
@@ -1,5 +1,5 @@
 question: 'Service definition document'
-hint: 'Please upload your service definition. Refer to the G-Cloud 8 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
+hint: 'Please upload your service definition. Refer to the G‑Cloud 8 guidance for more information on what to include. This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)'
 depends:
   -
     "on": lot

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docopt==0.4.0
-git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@18.0.0#egg=digitalmarketplace-utils==18.0.0
+git+https://github.com/madzak/python-json-logger.git@v0.1.5#egg=python-json-logger==v0.1.5
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0

--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -1,7 +1,7 @@
 import os
 import re
 import json
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 
 
 MANIFESTS = {

--- a/schemas/manifests.json
+++ b/schemas/manifests.json
@@ -8,6 +8,9 @@
       "name": {
         "type": "string"
       },
+      "slug": {
+        "type": "string"
+      },
       "summary_page_description": {
         "type": "string"
       },

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -9,7 +9,7 @@ except ImportError:
 
 import mock
 import pytest
-from dmutils.content_loader import ContentQuestion
+from dmcontent.content_loader import ContentQuestion
 from hypothesis.settings import Settings
 from hypothesis import given, assume, strategies as st
 from schema_generator import text_property, uri_property, parse_question_limits, \


### PR DESCRIPTION
First part of a fix for this bug: https://www.pivotaltracker.com/story/show/132662099

**This is up for discussion... is it the way to go?**

I've tested pulling this content into both buyer and supplier apps and removing some relevant `|safe` filters and everything looks good still as far as I can see - non-breaking spaces and hyphens don't break and horizontal ellipsis looks right on the page.

PROS:
- We will be able to get rid of some of the `|safe` from our Jinja templates (both toolkit and apps)

CONS: 
- It isn't at all obvious to people editing the content which characters are "special", and people adding new content might not remember or even know how to add the "special" characters. 
