### PR TITLE
Add dynamic list and followup questions to schema generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ Question keys
     * Permitted values are `after` or `before`
 * `before_summary_value` lists additional values that will be added to the question values on the summary page. Can be used for
   mandatory options or adding additional information to the question (only supported by 'checkboxes' questions at the moment)
-* `required_value` for boolean questions can enforce that the correct response is provided (eg, you must answer this question "Yes") 
+* `required_value` for boolean questions can enforce that the correct response is provided (eg, you must answer this question "Yes")
+* `dynamic_field` defines the field in the filter context that will be used to generate dynamic list questions (eg when passing
+  a brief as filter context setting `dynamic_field` to `brief.niceToHaveRequirements` will generate questions for nice-to-have
+  requirements) (only valid for `dynamic_list` questions)
+* `followup` sets the name of the question that will be required/shown if the current question is answered with "Yes" (only valid
+  for `boolean` questions)
 
 
 Manifest files and section keys

--- a/schema_generator/__init__.py
+++ b/schema_generator/__init__.py
@@ -290,6 +290,48 @@ def multiquestion(question):
     return properties
 
 
+def followup(question):
+    return {
+        'oneOf': [
+            {
+                "properties": {
+                    question['id']: {"enum": [False]},
+                },
+                "required": [question['id']]
+            },
+            {
+                "properties": {
+                    question['id']: {"enum": [True]},
+                    question['followup']: {"type": "string", "minLength": 1}
+                },
+                "required": [question['id'], question['followup']]
+            },
+        ]
+    }
+
+
+def dynamic_list(question):
+    properties = multiquestion(question)
+
+    property_schema = {
+        "type": "array",
+        "minItems": 0,
+        "items": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": properties
+        }
+    }
+
+    for nested_question in question.questions:
+        if nested_question.get('followup'):
+            if 'allOf' not in property_schema['items']:
+                property_schema['items']['allOf'] = []
+            property_schema['items']['allOf'].append(followup(nested_question))
+
+    return {question['id']: property_schema}
+
+
 QUESTION_TYPES = {
     'text': text_property,
     'upload': uri_property,
@@ -301,7 +343,8 @@ QUESTION_TYPES = {
     'boolean_list': boolean_list_property,
     'pricing': pricing_property,
     'number': number_property,
-    'multiquestion': multiquestion
+    'multiquestion': multiquestion,
+    'dynamic_list': dynamic_list,
 }
 
 

--- a/schemas/questions.json
+++ b/schemas/questions.json
@@ -33,6 +33,16 @@
       "properties": {
         "type": {"enum": ["boolean"]}
       }
+    },
+    "dynamic_field": {
+      "properties": {
+        "type": {"enum": ["dynamic_list"]}
+      }
+    },
+    "followup": {
+      "properties": {
+        "type": {"enum": ["boolean"]}
+      }
     }
   },
   "properties": {
@@ -42,7 +52,7 @@
     "type": {
       "enum": [
         "boolean", "text", "radios", "list", "boolean_list", "checkboxes", "service_id",
-        "pricing", "upload", "number", "textbox_large", "multiquestion", "email"
+        "pricing", "upload", "number", "textbox_large", "multiquestion", "dynamic_list", "email"
       ]
     },
     "question_advice": {
@@ -238,6 +248,12 @@
     "before_summary_value": {
       "type": "array",
       "items": {"type": "string"}
+    },
+    "followup": {
+      "type": "string"
+    },
+    "dynamic_field": {
+      "type": "string"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Generates an array property for the dynamic list field and sets the items schema to match nested question fields.

Followup questions generate a subschema to validate that if a question was answered with 'Yes' then the followup question has to be answered too.

Schema generation supports multiple followup relationships within one group of dynamic_list nested questions, but it's likely that API error reporting will require some changes if this ever becomes a feature we need.