### PR TITLE
Validation keys need to match allowed word counts

### DIFF
--- a/frameworks/g-cloud-9/questions/services/accessRestrictionsManagementAndSupport.yml
+++ b/frameworks/g-cloud-9/questions/services/accessRestrictionsManagementAndSupport.yml
@@ -13,7 +13,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/approachToResilience.yml
+++ b/frameworks/g-cloud-9/questions/services/approachToResilience.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your description must be no more than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/backupControls.yml
+++ b/frameworks/g-cloud-9/questions/services/backupControls.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/configurationAndChangeManagementProcesses.yml
+++ b/frameworks/g-cloud-9/questions/services/configurationAndChangeManagementProcesses.yml
@@ -20,7 +20,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/dataExportHow.yml
+++ b/frameworks/g-cloud-9/questions/services/dataExportHow.yml
@@ -12,7 +12,7 @@ validations:
     name: answer_required
     message: "You must answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/dataSanitisationApproach.yml
+++ b/frameworks/g-cloud-9/questions/services/dataSanitisationApproach.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/endOfContractDataExtraction.yml
+++ b/frameworks/g-cloud-9/questions/services/endOfContractDataExtraction.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/gettingStarted.yml
+++ b/frameworks/g-cloud-9/questions/services/gettingStarted.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/guaranteedAvailability.yml
+++ b/frameworks/g-cloud-9/questions/services/guaranteedAvailability.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/howSharedInfrastructureIsKeptSeparate.yml
+++ b/frameworks/g-cloud-9/questions/services/howSharedInfrastructureIsKeptSeparate.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/incidentManagementApproach.yml
+++ b/frameworks/g-cloud-9/questions/services/incidentManagementApproach.yml
@@ -21,7 +21,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/informationSecurityPoliciesAndProcesses.yml
+++ b/frameworks/g-cloud-9/questions/services/informationSecurityPoliciesAndProcesses.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/metricsTypes.yml
+++ b/frameworks/g-cloud-9/questions/services/metricsTypes.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/outageReporting.yml
+++ b/frameworks/g-cloud-9/questions/services/outageReporting.yml
@@ -21,7 +21,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/placeholderStandardsAndCertifications.yml
+++ b/frameworks/g-cloud-9/questions/services/placeholderStandardsAndCertifications.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/resellerRelationship.yml
+++ b/frameworks/g-cloud-9/questions/services/resellerRelationship.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/scalingApproach.yml
+++ b/frameworks/g-cloud-9/questions/services/scalingApproach.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this questions."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/scalingPricingStructure.yml
+++ b/frameworks/g-cloud-9/questions/services/scalingPricingStructure.yml
@@ -14,7 +14,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/securityGovernanceApproach.yml
+++ b/frameworks/g-cloud-9/questions/services/securityGovernanceApproach.yml
@@ -15,7 +15,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/supportLevels.yml
+++ b/frameworks/g-cloud-9/questions/services/supportLevels.yml
@@ -21,7 +21,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/supportResponseTimes.yml
+++ b/frameworks/g-cloud-9/questions/services/supportResponseTimes.yml
@@ -16,7 +16,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/usingTheAPI.yml
+++ b/frameworks/g-cloud-9/questions/services/usingTheAPI.yml
@@ -21,7 +21,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/usingTheCommandLineInterface.yml
+++ b/frameworks/g-cloud-9/questions/services/usingTheCommandLineInterface.yml
@@ -20,7 +20,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/usingTheWebInterface.yml
+++ b/frameworks/g-cloud-9/questions/services/usingTheWebInterface.yml
@@ -20,7 +20,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit

--- a/frameworks/g-cloud-9/questions/services/virtualisationTechnologiesUsed.yml
+++ b/frameworks/g-cloud-9/questions/services/virtualisationTechnologiesUsed.yml
@@ -19,9 +19,6 @@ validations:
     name: under_10_words
     message: "Each virtualisation technology must be no more than 10 words."
   -
-    name: under_20_words
-    message: "API type must be no more than 20 words."
-  -
     name: max_items_limit
     message: "You must have 10 or fewer virtualisation technology."
   -

--- a/frameworks/g-cloud-9/questions/services/vulnerabilityManagementApproach.yml
+++ b/frameworks/g-cloud-9/questions/services/vulnerabilityManagementApproach.yml
@@ -21,7 +21,7 @@ validations:
     name: answer_required
     message: "You need to answer this question."
   -
-    name: under_200_words
+    name: under_50_words
     message: "Your answer must be no longer than 50 words."
   -
     name: under_character_limit


### PR DESCRIPTION
e.g. if it's a 50 word limit then the key should be `under_50_words`.

Not planning to bump the version here as lots more changes coming soon, I know.

But validation won't work as expected for these questions in Preview right now.