### PR TITLE
Software accessibility question had wrong dependency set-up

### DIFF
--- a/frameworks/g-cloud-9/questions/services/serviceInterfaceAccessibility.yml
+++ b/frameworks/g-cloud-9/questions/services/serviceInterfaceAccessibility.yml
@@ -7,7 +7,7 @@ depends:
       - cloud-software
 followup:
   serviceInterfaceAccessibilityDescription:
-    - true
+    - none
 
 type: radios
 options:

--- a/frameworks/g-cloud-9/questions/services/serviceInterfaceAccessibilityDescription.yml
+++ b/frameworks/g-cloud-9/questions/services/serviceInterfaceAccessibilityDescription.yml
@@ -4,7 +4,7 @@ question_advice: >
   Include details of what users can and can’t do.
   <a href="http://mandate376.standards.eu/standard/technical-requirements/#9" target="_blank" rel="noopener noreferrer">EN 301 549 9: Web (new tab)</a> includes the features and
   constraints you should describe.
-
+hidden: true
 depends:
   - "on": lot
     being:

--- a/frameworks/g-cloud-9/questions/services/serviceInterfaceTesting.yml
+++ b/frameworks/g-cloud-9/questions/services/serviceInterfaceTesting.yml
@@ -1,7 +1,5 @@
 name: Service interface testing
 question: Describe any interface testing you’ve done with users of assistive technology.
-
-hidden: true
 depends:
   - "on": lot
     being:


### PR DESCRIPTION
 - now the 'testing' question will only appear if the service does not
   meet an accessibility standard, as intended.