### PR TITLE
Removes Cloudformation from API automation tools

### DIFF
--- a/frameworks/g-cloud-9/questions/services/APIAutomationTools.yml
+++ b/frameworks/g-cloud-9/questions/services/APIAutomationTools.yml
@@ -16,8 +16,6 @@ options:
     value: ansible
   - label: Chef
     value: chef
-  - label: CloudFormation
-    value: cloudformation
   - label: OpenStack
     value: openstack
   - label: SaltStack

--- a/frameworks/g-cloud-9/questions/services/installation.yml
+++ b/frameworks/g-cloud-9/questions/services/installation.yml
@@ -1,5 +1,5 @@
 name: Installation
-question: Does the service need to be installed?
+question: Is there an application that users install to use your service?
 
 depends:
   - "on": lot


### PR DESCRIPTION
Removes Cloudformation from API automation tools specific to a single supplier, suppliers can still add their own 'others'.