### PR TITLE
Elasticsearch mappings and transformation generation

### DIFF
--- a/frameworks/g-cloud-9/search_mapping.json
+++ b/frameworks/g-cloud-9/search_mapping.json
@@ -1,0 +1,123 @@
+{
+  "mappings": {
+    "services": {
+      "_meta": {
+      },
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "lot": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "frameworkName": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "serviceName": {
+          "type": "string"
+        },
+        "serviceSummary": {
+          "term_vector" : "with_positions_offsets",
+          "type": "string"
+        },
+        "serviceBenefits": {
+          "type": "string"
+        },
+        "serviceFeatures": {
+          "type": "string"
+        },
+        "supplierName": {
+          "type": "string"
+        },
+        "serviceTypes": {
+          "type": "string"
+        },
+        "filter_lot": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "filter_serviceTypes": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "filter_freeOption": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_trialOption": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_minimumContractPeriod": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "filter_supportForThirdParties": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_selfServiceProvisioning": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_datacentresEUCode": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_datacentreTier": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "filter_dataBackupRecovery": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_dataExtractionRemoval": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_networksConnected": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "filter_apiAccess": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_openStandardsSupported": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_openSource": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_persistentStorage": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_guaranteedResources": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+        "filter_elasticCloud": {
+          "type": "boolean",
+          "index": "not_analyzed"
+        },
+
+        "serviceCategories": {
+          "type": "string"
+        },
+        "filter_serviceCategories": {
+          "type": "string",
+          "index": "not_analyzed"
+        }
+
+      }
+    }
+  }
+}

--- a/schema_generator/search.py
+++ b/schema_generator/search.py
@@ -1,0 +1,78 @@
+from __future__ import print_function
+
+import os.path
+import sys
+import json
+from collections import defaultdict, OrderedDict
+
+from dmcontent import ContentLoader, utils
+
+
+_base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _get_questions_by_type(framework_slug, question_types):
+    loader = ContentLoader(_base_dir)
+    loader.load_manifest(
+        framework_slug,
+        'services',
+        'search_filters'
+    )
+
+    manifest = loader.get_manifest(framework_slug, 'search_filters')
+    return (q for q in sum((s.questions for s in manifest.sections), []) if q.type in question_types)
+
+
+def _checkbox_tree_transformation_generator(checkbox_tree_question):
+    def update_ancestors_dict(options, leaf_values_dict, parents):
+        for option in options:
+            children = option.get('options', [])
+            if not children:
+                if parents:
+                    leaf_values_dict[parents].append(utils.get_option_value(option))
+            else:
+                update_ancestors_dict(children, leaf_values_dict, parents.union([utils.get_option_value(option)]))
+
+    leaf_values_by_ancestor_set = defaultdict(list)
+    # list of child-values preserves order from the source yaml, for the benefit of git history in output file
+
+    update_ancestors_dict(checkbox_tree_question.options, leaf_values_by_ancestor_set, parents=frozenset())
+
+    return [
+        OrderedDict((
+            ('field', checkbox_tree_question.id),
+            ('any_of', child_values),
+            ('append_value', sorted(ancestor_values)),
+        )) for ancestor_values, child_values in leaf_values_by_ancestor_set.items()
+        ]
+
+
+transformation_generators = {
+    'checkbox_tree': _checkbox_tree_transformation_generator
+}
+
+
+def get_transformations(framework_slug):
+    for question in _get_questions_by_type(framework_slug, transformation_generators.keys()):
+        for transformer in transformation_generators[question.type](question):
+            yield transformer
+
+
+def generate_search_mapping(framework_slug, file_handle, mapping_type, extra_meta={}):
+    with open(os.path.join(_base_dir, 'frameworks', framework_slug, 'search_mapping.json'), 'r') as h_template:
+        mapping_json = json.load(h_template, object_pairs_hook=OrderedDict)  # preserve template order for git history
+
+    mapping_json['mappings'][mapping_type]['_meta'].update(extra_meta)
+    mapping_json['mappings'][mapping_type]['_meta']['transformations'] = list(get_transformations(framework_slug))
+
+    json.dump(mapping_json, file_handle, indent=2, separators=(',', ': '))
+    print('', file=file_handle)
+
+
+def generate_config(framework_slug, extra_meta, output_dir=None):
+    mapping_type_name = 'services'
+    if output_dir:
+        with open(os.path.join(output_dir, 'services.json'), 'w') as h_services_mapping:
+            generate_search_mapping(framework_slug, h_services_mapping, mapping_type_name, extra_meta)
+    else:
+        generate_search_mapping(framework_slug, sys.stdout, mapping_type_name, extra_meta)

--- a/schema_generator/search.py
+++ b/schema_generator/search.py
@@ -47,14 +47,14 @@ def _checkbox_tree_transformation_generator(checkbox_tree_question):
         ]
 
 
-transformation_generators = {
+TRANSFORMATION_GENERATORS = {
     'checkbox_tree': _checkbox_tree_transformation_generator
 }
 
 
 def get_transformations(framework_slug):
-    for question in _get_questions_by_type(framework_slug, transformation_generators.keys()):
-        for transformer in transformation_generators[question.type](question):
+    for question in _get_questions_by_type(framework_slug, TRANSFORMATION_GENERATORS.keys()):
+        for transformer in TRANSFORMATION_GENERATORS[question.type](question):
             yield transformer
 
 

--- a/scripts/generate-search-config.py
+++ b/scripts/generate-search-config.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""Generate an Elasticsearch mapping using the template stored with the framework.
+
+At the time of writing, most of the search mapping is written by hand, in
+the search_mapping.json template file. This script adds to that template
+and writes it to a services.json file in the directory provided, which
+should be reference the 'mappings' directory in a checkout of the Search API.
+
+To preview the mapping that will be generated, do not specify the output path.
+
+Note that the Search API only supports one mapping at a time, which will be
+used for any index relating to any G-Cloud framework. Therefore, care should
+be taken with the release process to ensure that indexing for the currently-
+live framework continues as expected, especially if the new framework's
+mapping is not backward-compatible with the old one.
+
+
+Usage:
+    generate-validation-schemas.py [--help] <framework_slug> [--output-path=<output_path>]
+
+"""
+import os
+import sys
+base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, base_dir)
+from datetime import datetime
+from collections import OrderedDict
+
+from docopt import docopt
+from schema_generator.search import generate_config
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+    output_dir = arguments.get('--output-path')
+    if output_dir and not os.path.exists(output_dir):
+        sys.exit('Specified output directory does not exist.')
+
+    framework_slug = arguments['<framework_slug>']
+
+    with open(os.path.join(base_dir, 'VERSION.txt'), 'r') as version_handle:
+        extra_meta = OrderedDict((
+            ('version', version_handle.read().strip()),
+            ('generated_from_framework', framework_slug),
+            ('generated_by', os.path.abspath(__file__)),
+            ('generated_time', datetime.utcnow().isoformat()),
+        ))
+
+    generate_config(framework_slug, extra_meta, output_dir)

--- a/tests/test_generate_search_config.py
+++ b/tests/test_generate_search_config.py
@@ -1,0 +1,43 @@
+from collections import OrderedDict
+
+from dmcontent.questions import Hierarchy
+from schema_generator.search import _checkbox_tree_transformation_generator
+
+
+def test_checkbox_tree_transformation_generator():
+    question = {
+        "id": 'someQuestion',
+        "options": [
+            {
+                'label': 'cat 1',
+                'options': [
+                    {'label': 'sub cat 1.1'},
+                    {'label': 'sub cat 1.2', 'value': 'sc1-2'},
+                    ]
+            },
+            {
+                'label': 'cat 2',
+                'options': [
+                    {'label': 'sub cat 2.1'},
+                    {'label': 'sub cat 2.2'}
+                ]
+            }
+        ]
+    }
+    result = _checkbox_tree_transformation_generator(Hierarchy(question))
+
+    assert OrderedDict((
+        ('field', 'someQuestion'),
+        ('any_of', [
+            'sub cat 1.1', 'sc1-2'
+        ]),
+        ('append_value', ['cat 1'])
+    )) in result
+
+    assert OrderedDict((
+        ('field', 'someQuestion'),
+        ('any_of', [
+            'sub cat 2.1', 'sub cat 2.2'
+        ]),
+        ('append_value', ['cat 2'])
+    )) in result


### PR DESCRIPTION
Script to generate Elasticsearch mapping for framework, inc transformations.

 - Most of the mapping comes, unchanged, from a template file which
   has been copied from the Search API i.e. mappings/services.json .
 - The main addition is of a 'transformations' node, which the
   Search API will use to preprocess the incoming service data before
   passing it on to Elasticsearch.
 - The only transformation we add so far is one that indexes parent
   categories relating to select subcategories. This is denormalization
   is done purely in the index.
 - Other meta information is added so that it's clear that the file
   in the Search API is no longer the original, and should not be
   edited by hand.
 - Brings in new version of Content Loader, which now depends on dm-
   utils library.

https://trello.com/c/etYh34Zs/341-fixing-software-parent-categories