### PR TITLE
Updated mapping generator 

### DIFF
--- a/schema_generator/search.py
+++ b/schema_generator/search.py
@@ -39,12 +39,14 @@ def _checkbox_tree_transformation_generator(checkbox_tree_question):
     update_ancestors_dict(checkbox_tree_question.options, leaf_values_by_ancestor_set, parents=frozenset())
 
     return [
-        OrderedDict((
-            ('field', checkbox_tree_question.id),
-            ('any_of', child_values),
-            ('append_value', sorted(ancestor_values)),
-        )) for ancestor_values, child_values in leaf_values_by_ancestor_set.items()
-        ]
+        {
+            'append_conditionally': OrderedDict((
+                ('field', checkbox_tree_question.id),
+                ('any_of', child_values),
+                ('append_value', sorted(ancestor_values)),
+            ))
+        } for ancestor_values, child_values in leaf_values_by_ancestor_set.items()
+    ]
 
 
 TRANSFORMATION_GENERATORS = {

--- a/tests/test_generate_search_config.py
+++ b/tests/test_generate_search_config.py
@@ -26,18 +26,22 @@ def test_checkbox_tree_transformation_generator():
     }
     result = _checkbox_tree_transformation_generator(Hierarchy(question))
 
-    assert OrderedDict((
-        ('field', 'someQuestion'),
-        ('any_of', [
-            'sub cat 1.1', 'sc1-2'
-        ]),
-        ('append_value', ['cat 1'])
-    )) in result
+    assert {
+        'append_conditionally': OrderedDict((
+            ('field', 'someQuestion'),
+            ('any_of', [
+                'sub cat 1.1', 'sc1-2'
+            ]),
+            ('append_value', ['cat 1'])
+        ))
+    } in result
 
-    assert OrderedDict((
-        ('field', 'someQuestion'),
-        ('any_of', [
-            'sub cat 2.1', 'sub cat 2.2'
-        ]),
-        ('append_value', ['cat 2'])
-    )) in result
+    assert {
+        'append_conditionally': OrderedDict((
+            ('field', 'someQuestion'),
+            ('any_of', [
+                'sub cat 2.1', 'sub cat 2.2'
+            ]),
+            ('append_value', ['cat 2'])
+        ))
+    } in result


### PR DESCRIPTION
 mapping generator with new more forward-compatible syntax.
 - the syntax is now more consistent with Elasticsearch's "ingest node
   processor" feature.

https://trello.com/c/etYh34Zs/341-fixing-software-parent-categories