### PR TITLE
Add 'serviceDescription' to search mapping

### DIFF
--- a/frameworks/g-cloud-9/search_mapping.json
+++ b/frameworks/g-cloud-9/search_mapping.json
@@ -24,6 +24,10 @@
           "term_vector" : "with_positions_offsets",
           "type": "string"
         },
+        "serviceDescription": {
+          "term_vector" : "with_positions_offsets",
+          "type": "string"
+        },
         "serviceBenefits": {
           "type": "string"
         },


### PR DESCRIPTION
## Summary
As above... Add the 'serviceDescription' field to the search mapping to enable indexing of said field in ES.