### PR TITLE
Enable transformation of radios questions for schema generation

### DIFF
--- a/schema_generator/search.py
+++ b/schema_generator/search.py
@@ -71,7 +71,8 @@ def _derived_options_transformation_generator(checkbox_question):
 
 TRANSFORMATION_GENERATORS = {
     'checkbox_tree': _checkbox_tree_transformation_generator,
-    'checkboxes': _derived_options_transformation_generator
+    'checkboxes': _derived_options_transformation_generator,
+    'radios': _derived_options_transformation_generator
 }
 
 


### PR DESCRIPTION
## Summary
As above. Need to allow `radios` questions to be checked for derived_from transformations when generating search schemas.