### PR TITLE
Change from flake8-putty to per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,13 +1,11 @@
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
 # D203: 1 blank line required before class docstring
-# F401: 'identifier' imported but unused
 # E402: module level import not at top of file
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 12
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    scripts/ : +E402
+per-file-ignores =
+    scripts/* : E402

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 hypothesis==1.18.1
 jsonschema==2.3.0
 mock==2.0.0


### PR DESCRIPTION
This allows us to upgrade to flake8==3.5.0 which brings with it support
for Python 3 features such as f-strings and type annotations.

Flake8 report:
```
/Users/samuelwilliams/git/digitalmarketplace-frameworks/venv/bin/flake8 .
./schema_generator/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
./scripts/generate-assessment-schema.py:11:1: E402 module level import not at top of file
./scripts/generate-assessment-schema.py:13:1: E402 module level import not at top of file
./scripts/generate-assessment-schema.py:14:1: E402 module level import not at top of file
./scripts/generate-search-config.py:31:1: E402 module level import not at top of file
./scripts/generate-search-config.py:32:1: E402 module level import not at top of file
./scripts/generate-search-config.py:34:1: E402 module level import not at top of file
./scripts/generate-search-config.py:35:1: E402 module level import not at top of file
./scripts/generate-validation-schemas.py:12:1: E402 module level import not at top of file
./scripts/generate-validation-schemas.py:13:1: E402 module level import not at top of file
./tests/__init__.py:0:1: X100 Superfluous per-file-ignores for F401
make: *** [test-flake8] Error 1
```