### PR TITLE
Add more cyber security accreditations

### DIFF
--- a/frameworks/g-cloud-10/questions/services/securityTesting.yml
+++ b/frameworks/g-cloud-10/questions/services/securityTesting.yml
@@ -3,13 +3,6 @@ question: Do you provide security testing?
 question_advice: |
   Security testing services include penetration testing, IT Health Checks and risk analysis.
 
-  Don’t submit your services to G-Cloud if they’ve been assured by these National Cyber Security Centre (NCSC) schemes:
-
-    - Cyber Security Consultancy
-    - Penetration Testing (CHECK)
-    - Cyber Incident Response (CIR)
-    - Tailored Assurance Service
-
 depends:
   - "on": lot
     being:

--- a/frameworks/g-cloud-10/questions/services/securityTestingAccreditations.yml
+++ b/frameworks/g-cloud-10/questions/services/securityTestingAccreditations.yml
@@ -12,6 +12,10 @@ followup:
 
 type: checkboxes
 options:
+  - label: CHECK
+    value: check
+  - label: NCSC Certified Cyber Security Consultancy
+    value: cyber-security-consultancy
   - label: Tigerscheme
     value: tigerscheme
   - label: CREST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
For this ticket: https://trello.com/c/Khm9AS0X/68-re-add-cyber-for-g-cloud-10

Suppliers with some specific security accreditations were barred from supplying through G-Cloud and instead directed to the "Cyber framework" instead.  But for G-Cloud 10 they will be allowed.

So we have been told to "re-add cyber" for G-Cloud 10.  

No-one really knows what this means, so I've had a go at figuring it out here.

Trawling the history of this repo I found two security-related questions that were deleted mid way during development of G-Cloud 9.  They look like this:
![screen shot 2018-03-09 at 16 17 41](https://user-images.githubusercontent.com/6525554/37218890-b2fc6db2-23b9-11e8-88bb-57ae6a9d4465.png)

Looking at the way the security questions ended up for G-Cloud 9 launch it looks to me like these questions are unnecessary as full questions, and the same information can be collected from suppliers with the addition of two checkboxes to the list of accreditations that security services can have.

So I've done that, and removed the text telling suppliers with security accreditations that they can't apply to G-Cloud, because now they can.

## Existing security testing page - 🚫NO CYBER🚫 

![screen shot 2018-03-09 at 17 22 18](https://user-images.githubusercontent.com/6525554/37220422-86756c26-23be-11e8-9595-f665051f008a.png)

## Proposed new security testing question page - :ok: CYBER :ok: 

![screen shot 2018-03-09 at 17 10 00](https://user-images.githubusercontent.com/6525554/37219906-d01e3580-23bc-11e8-8454-375fe5742817.png)
