### PR TITLE
Revert "Add more cyber security accreditations"

### DIFF
--- a/frameworks/g-cloud-10/questions/services/securityTesting.yml
+++ b/frameworks/g-cloud-10/questions/services/securityTesting.yml
@@ -3,6 +3,13 @@ question: Do you provide security testing?
 question_advice: |
   Security testing services include penetration testing, IT Health Checks and risk analysis.
 
+  Don’t submit your services to G-Cloud if they’ve been assured by these National Cyber Security Centre (NCSC) schemes:
+
+    - Cyber Security Consultancy
+    - Penetration Testing (CHECK)
+    - Cyber Incident Response (CIR)
+    - Tailored Assurance Service
+
 depends:
   - "on": lot
     being:

--- a/frameworks/g-cloud-10/questions/services/securityTestingAccreditations.yml
+++ b/frameworks/g-cloud-10/questions/services/securityTestingAccreditations.yml
@@ -12,10 +12,6 @@ followup:
 
 type: checkboxes
 options:
-  - label: CHECK
-    value: check
-  - label: NCSC Certified Cyber Security Consultancy
-    value: cyber-security-consultancy
   - label: Tigerscheme
     value: tigerscheme
   - label: CREST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.2.0",
+  "version": "11.3.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-frameworks#505

Correct changes are in https://github.com/alphagov/digitalmarketplace-frameworks/pull/511