### PR TITLE
Change to certification noun

### DIFF
--- a/frameworks/g-cloud-10/questions/services/accreditationsOther.yml
+++ b/frameworks/g-cloud-10/questions/services/accreditationsOther.yml
@@ -1,5 +1,5 @@
-name: Other security accreditations
-question: Do you have any other security accreditations that cover this service?
+name: Other security certifications
+question: Do you have any other security certifications that cover this service?
 
 depends:
   - "on": lot

--- a/frameworks/g-cloud-10/questions/services/accreditationsOtherList.yml
+++ b/frameworks/g-cloud-10/questions/services/accreditationsOtherList.yml
@@ -1,5 +1,5 @@
-name: Any other security accreditations
-question: What other security accreditations do you have?
+name: Any other security certifications
+question: What other security certifications do you have?
 
 hidden: true
 depends:
@@ -8,15 +8,15 @@ depends:
       - cloud-hosting
       - cloud-software
 
-list_item_name: security accreditation
+list_item_name: security certification
 type: list
 
 validations:
   - name: answer_required
     message: You need to answer this question.
   - name: under_10_words
-    message: You can’t write more than 10 words for each security accreditation.
+    message: You can’t write more than 10 words for each security certification.
   - name: max_items_limit
-    message: You must have 10 or fewer security accreditations.
+    message: You must have 10 or fewer security certifications.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each security accreditation.
+    message: You can’t write more than 100 characters for each security certification.

--- a/frameworks/g-cloud-10/questions/services/multiqAccreditationsOther.yml
+++ b/frameworks/g-cloud-10/questions/services/multiqAccreditationsOther.yml
@@ -1,5 +1,5 @@
-name: Other security accreditations
-question: Other security accreditations
+name: Other security certifications
+question: Other security certifications
 
 depends:
   - "on": lot

--- a/frameworks/g-cloud-10/questions/services/securityGovernanceAccreditation.yml
+++ b/frameworks/g-cloud-10/questions/services/securityGovernanceAccreditation.yml
@@ -1,5 +1,5 @@
-name: Security governance accreditation
-question: Is your security governance accredited to a standard?
+name: Security governance certified
+question: Is your security governance certified to a standard?
 
 depends:
   - "on": lot

--- a/frameworks/g-cloud-10/questions/services/securityTestingWhatOther.yml
+++ b/frameworks/g-cloud-10/questions/services/securityTestingWhatOther.yml
@@ -8,12 +8,12 @@ depends:
       - cloud-support
 
 type: list
-list_item_name: kind of security services
+list_item_name: kind of security service
 
 validations:
   - name: under_10_words
-    message: You can’t write more than 10 words for each kind of security services.
+    message: You can’t write more than 10 words for each kind of security service.
   - name: max_items_limit
-    message: You must have 10 or fewer kinds of security services.
+    message: You must have 10 or fewer kinds of security service.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each kind of security services.
+    message: You can’t write more than 100 characters for each kind of security service.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.4.0",
+  "version": "11.4.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
 ## Summary
Change language to consistently use 'certification' rather than
'accreditation' where appropriate (i.e. generally where 'accreditation'
is used as a noun or where we do not need to repeat the same/similar
word close together).