### PR TITLE
Update questions to copy

### DIFF
--- a/frameworks/g-cloud-10/metadata/copy_services.yml
+++ b/frameworks/g-cloud-10/metadata/copy_services.yml
@@ -44,8 +44,7 @@ questions_to_copy:
   - dataProtectionWithinNetwork
   - dataProtectionWithinNetworkOther
   - dataSanitisation
-  - dataSanitisationTypeHosting
-  - dataSanitisationTypeSoftware
+  - dataSanitisationType
   - dataStorageAndProcessing
   - dataStorageAndProcessingLocations
   - dataStorageAndProcessingUserControl
@@ -80,13 +79,11 @@ questions_to_copy:
   - lotName
   - managementAccessAuthentication
   - managementAccessAuthenticationDescription
-  - metricsHosting
-  - metricsHostingHow
-  - metricsHostingWhat
-  - metricsHostingWhatOther
-  - metricsSoftware
-  - metricsSoftwareDescription
-  - metricsSoftwareHow
+  - metrics
+  - metricsHow
+  - metricsWhat
+  - metricsWhatOther
+  - metricsDescription
   - mobile
   - mobileDifferences
   - ongoingSupport
@@ -102,7 +99,10 @@ questions_to_copy:
   - planningServiceCompatibility
   - planningServiceCompatibilityList
   - planningServiceDescription
-  - price
+  - priceInterval
+  - priceMax
+  - priceMin
+  - priceUnit
   - protectionOfDataAtRest
   - protectionOfDataAtRestOther
   - protectiveMonitoringApproach
@@ -124,16 +124,11 @@ questions_to_copy:
   - securityTestingCCP
   - serviceAddOnDetails
   - serviceAddOnType
-  - serviceBenefitsHostingAndSoftware
-  - serviceBenefitsSupport
-  - serviceCategoriesHosting
-  - serviceCategoriesSoftware
-  - serviceCategoriesSupport
-  - serviceConstraintsHostingAndSoftware
-  - serviceConstraintsSupport
+  - serviceBenefits
+  - serviceCategories
+  - serviceConstraints
   - serviceDescription
-  - serviceFeaturesHostingAndSoftware
-  - serviceFeaturesSupport
+  - serviceFeatures
   - serviceInterfaceAccessibility
   - serviceInterfaceAccessibilityDescription
   - serviceInterfaceTesting
@@ -169,9 +164,8 @@ questions_to_copy:
   - usageNotifications
   - usageNotificationsHow
   - userAuthenticationDescription
-  - userAuthenticationHosting
+  - userAuthentication
   - userAuthenticationNeeded
-  - userAuthenticationSoftware
   - virtualisation
   - virtualisationImplementedBy
   - virtualisationSeparation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.5.1",
+  "version": "11.5.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
 ## Summary
Some questions specify an ID to use in place of the filename. We had
incorrectly stored the filename in all instances rather than the ID,
where it was given. This corrects that so the data is correctly copied
across for all questions that are equivalent.

Bumps version to 11.5.2