### PR TITLE
Update G-Cloud-10 dates

### DIFF
--- a/frameworks/g-cloud-10/messages/dates.yml
+++ b/frameworks/g-cloud-10/messages/dates.yml
@@ -1,9 +1,9 @@
-clarifications_close_date: '5pm BST, 32 March 2525'
+clarifications_close_date: '5pm BST, Wednesday 9 May 2018'
 
-clarifications_publish_date: '5pm BST, 33 March 2525'
+clarifications_publish_date: '5pm BST, Wednesday 16 May 2018'
 
-framework_close_date: '5pm BST, 34 March 2525'
+framework_close_date: '5pm BST, Wednesday 23 May 2018'
 
-intention_to_award_date: '35 March 2525'
+intention_to_award_date: 'Monday 18 June 2018'
 
-framework_live_date: "36 March 2525"
+framework_live_date: "Monday 2 July 2018"

--- a/frameworks/g-cloud-10/questions/declaration/MI.yml
+++ b/frameworks/g-cloud-10/questions/declaration/MI.yml
@@ -1,7 +1,7 @@
 name: Providing management information (MI)
 question: >
   Do you confirm that you’re prepared to provide all the monthly G-Cloud&nbsp;10-related management information (MI)
-  to CCS as outlined in the <a href="/suppliers/frameworks/g-cloud-10" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
+  to CCS as outlined in the <a href="/suppliers/frameworks/g-cloud-10#guidance" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/g-cloud-10/questions/declaration/servicesHaveOrSupport.yml
+++ b/frameworks/g-cloud-10/questions/declaration/servicesHaveOrSupport.yml
@@ -5,7 +5,7 @@ question: >
     - on-demand self-service. Your cloud services must be automatically available without needing interaction between the supplier and the buyer, for example server time or network storage. (Lot 1 - cloud hosting and lot 2 - cloud software.)
     - broad network access. Your cloud services must be easily accessible over the network and across a wide range of platforms, for example mobile phones, tablets, laptops and workstations. (Lot 1 - cloud hosting and lot 2 - cloud software.)
     - measured service. Your resource use must be monitored, controlled and reported to the buyer, for example storage, processing, bandwidth and number of active user accounts. (Lot 1 - cloud hosting and lot 2 - cloud software.)
-    - the delivery of cloud services. Your service must enable the delivery of cloud services. Your service complies with the definition of cloud support in the <a href="/suppliers/frameworks/g-cloud-10" target="_blank" rel="noopener noreferrer">framework agreement (link opens in a new tab)</a> (Lot 3 - cloud support.)
+    - the delivery of cloud services. Your service must enable the delivery of cloud services. Your service complies with the definition of cloud support in the <a href="/suppliers/frameworks/g-cloud-10#legal-documents" target="_blank" rel="noopener noreferrer">framework agreement (link opens in a new tab)</a> (Lot 3 - cloud support.)
 
 type: boolean
 assessment:

--- a/frameworks/g-cloud-10/questions/declaration/termsAndConditions.yml
+++ b/frameworks/g-cloud-10/questions/declaration/termsAndConditions.yml
@@ -1,6 +1,6 @@
 name: Terms and conditions
 question: >
-  Do you accept the terms and conditions in the <a href="/suppliers/frameworks/g-cloud-10" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (link opens in a new tab)</a>?
+  Do you accept the terms and conditions in the <a href="/suppliers/frameworks/g-cloud-10#legal-documents" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/g-cloud-10/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/g-cloud-10/questions/declaration/termsOfParticipation.yml
@@ -1,6 +1,6 @@
 name: Invitation to apply
 question: >
-  Do you agree to comply with the terms of the <a href="/suppliers/frameworks/g-cloud-10" target="_blank" rel="noopener noreferrer">G-Cloud&nbsp;10 ‘invitation to apply’ (link opens in a new tab)</a>?
+  Do you agree to comply with the terms of the <a href="/suppliers/frameworks/g-cloud-10#guidance" target="_blank" rel="noopener noreferrer">G-Cloud&nbsp;10 ‘invitation to apply’ (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.5.2",
+  "version": "11.5.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
 ## Summary
We need to have the correct dates stored in our frameworks repository
for G-Cloud 10 stages. These are sourced from
https://www.gov.uk/guidance/what-to-do-and-when-for-g-cloud-10

Also add anchors to links to the G-Cloud 10 framework dashboard documents.