### PR TITLE
Don't copy questions that depend on changed questions

### DIFF
--- a/frameworks/g-cloud-10/metadata/copy_services.yml
+++ b/frameworks/g-cloud-10/metadata/copy_services.yml
@@ -24,7 +24,6 @@ questions_to_copy:
   - backupScheduling
   - backupWhatData
   - boardLevelServiceSecurity
-  - browsersAccess
   - cloudDeploymentModel
   - commandLineInterface
   - commandLineOS
@@ -121,7 +120,6 @@ questions_to_copy:
   - securityGovernanceApproach
   - securityGovernanceStandards
   - securityGovernanceStandardsOther
-  - securityTestingCCP
   - serviceAddOnDetails
   - serviceAddOnType
   - serviceBenefits

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.5.4",
+  "version": "11.5.5",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
`browserAccess` needs to not be copied as it's follow up question,
`browsersSupported` is not. If the supplier had answered 'yes' to the
`browerAccess` boolean, validation expects to an answer for
`browsersSupported`. Without it, the service is in an invalid state.

Similarly, `securityTestingCCP` needs to not be copied, as it is a
follow up to `securityTestingWhat` which we no longer copy. Having and
answer for `securityTestingCCP` but not `securityTestingWhat` leaves the
service in an invalid state.

These invalid states make editing the new draft service throw 400's.
I've checked the questions that have changed and can't find any other
dependant questions that need changing.