### PR TITLE
Update anchor for reporting question

### DIFF
--- a/frameworks/g-cloud-10/questions/declaration/MI.yml
+++ b/frameworks/g-cloud-10/questions/declaration/MI.yml
@@ -1,7 +1,7 @@
 name: Providing management information (MI)
 question: >
   Do you confirm that you’re prepared to provide all the monthly G-Cloud&nbsp;10-related management information (MI)
-  to CCS as outlined in the <a href="/suppliers/frameworks/g-cloud-10#guidance" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
+  to CCS as outlined in the <a href="/suppliers/frameworks/g-cloud-10#reporting" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.5.5",
+  "version": "11.5.6",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
 ## Summary
Reporting template link should use the #reporting anchor on the
framework dashboard. Bump version to 11.5.6