### PR TITLE
Remove `dates.yml` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Records breaking changes from major version bumps
 
+## 12.0.0
+
+All the `messages/dates.yml` files for frameworks have been removed. These dates are now stored directly on the
+`framework` record in the API as datetimestamps. Any frontends that load `dates.yml` files will need to instead
+look for dates in the framework record(s).
+
 ## 11.0.0
 
 Removed the transformation of the status field entirely. The DOS search filters

--- a/frameworks/digital-outcomes-and-specialists-2/messages/dates.yml
+++ b/frameworks/digital-outcomes-and-specialists-2/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm GMT, 1 December 2016'
-
-clarifications_publish_date: '5pm GMT, 7 December 2016'
-
-framework_close_date: '5pm GMT, 14 December 2016'
-
-intention_to_award_date: '16 January 2017'
-
-framework_live_date: "February 2017"

--- a/frameworks/digital-outcomes-and-specialists-3/messages/dates.yml
+++ b/frameworks/digital-outcomes-and-specialists-3/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm GMT, 30 February 2525'
-
-clarifications_publish_date: '5pm GMT, 31 February 2525'
-
-framework_close_date: '5pm GMT, 32 February 2525'
-
-intention_to_award_date: '33 February 2525'
-
-framework_live_date: "February 2525"

--- a/frameworks/digital-outcomes-and-specialists/messages/dates.yml
+++ b/frameworks/digital-outcomes-and-specialists/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm GMT, 6 January 2016'
-
-clarifications_publish_date: '5pm GMT, 13 January 2016'
-
-framework_close_date: '3pm GMT, 19 January 2016'
-
-intention_to_award_date: '18 February 2016'
-
-framework_live_date: ""

--- a/frameworks/g-cloud-10/messages/dates.yml
+++ b/frameworks/g-cloud-10/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm BST, Wednesday 9 May 2018'
-
-clarifications_publish_date: '5pm BST, Wednesday 16 May 2018'
-
-framework_close_date: '5pm BST, Wednesday 23 May 2018'
-
-intention_to_award_date: 'Monday 18 June 2018'
-
-framework_live_date: "Monday 2 July 2018"

--- a/frameworks/g-cloud-6/messages/dates.yml
+++ b/frameworks/g-cloud-6/messages/dates.yml
@@ -1,5 +1,0 @@
-clarifications_close_date: ""
-clarifications_publish_date: ""
-framework_close_date: ""
-intention_to_award_date: ""
-framework_live_date: ""

--- a/frameworks/g-cloud-7/messages/dates.yml
+++ b/frameworks/g-cloud-7/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm BST, 22 September 2015'
-
-clarifications_publish_date: '5pm BST, 29 September 2015'
-
-framework_close_date: '3pm BST, 6 October 2015'
-
-intention_to_award_date: '9 November 2015'
-
-framework_live_date: '23 November 2015'

--- a/frameworks/g-cloud-8/messages/dates.yml
+++ b/frameworks/g-cloud-8/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm BST, 7 June 2016'
-
-clarifications_publish_date: '5pm BST, 14 June 2016'
-
-framework_close_date: '5pm BST, 23 June 2016'
-
-intention_to_award_date: '18 July 2016'
-
-framework_live_date: '1 August 2016'

--- a/frameworks/g-cloud-9/messages/dates.yml
+++ b/frameworks/g-cloud-9/messages/dates.yml
@@ -1,9 +1,0 @@
-clarifications_close_date: '5pm BST, 28 March 2017'
-
-clarifications_publish_date: '5pm BST, 4 April 2017'
-
-framework_close_date: '5pm BST, 11 April 2017'
-
-intention_to_award_date: '18 May 2017'
-
-framework_live_date: "22 May 2017"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "11.5.6",
+  "version": "12.0.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.4.0
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.6.0#egg=digitalmarketplace-content-loader==4.6.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.1.0#egg=digitalmarketplace-utils==25.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.8.0#egg=digitalmarketplace-utils==36.8.0

--- a/schemas/messages.json
+++ b/schemas/messages.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "anyOf": [
-    {"$ref": "#/definitions/dates"},
     {"$ref": "#/definitions/frameworkStates"},
     {"$ref": "#/definitions/urls"},
     {"$ref": "#/definitions/contract_variation"},
@@ -11,20 +10,6 @@
     {"$ref": "#/definitions/descriptions"}
   ],
   "definitions": {
-    "dates": {
-      "properties": {
-        "clarifications_close_date": {"type": "string"},
-        "clarifications_publish_date": {"type": "string"},
-        "framework_close_date": {"type": "string"},
-        "intention_to_award_date": {"type": "string"},
-        "framework_live_date": {"type": "string"}
-      },
-      "required": [
-        "clarifications_close_date", "clarifications_publish_date",
-        "framework_close_date", "intention_to_award_date", "framework_live_date"
-      ],
-      "additionalProperties": false
-    },
     "frameworkStates": {
       "properties": {
         "coming": {


### PR DESCRIPTION
 ## Summary
We are migrating framework lifecycle event dates/times to the API and
storing them in machine format, rather than as strings for humans. This
should decrease any risk of errors creeping in and also bring us back to
a single source of truth.

Frontends that use frameworks will need to stop loading dates from this
frameworks repo and start using dates from the API.

Bump to version 12.0.0