### PR TITLE
Update content for `become a supplier` messages

### DIFF
--- a/frameworks/g-cloud-10/messages/become-a-supplier.yml
+++ b/frameworks/g-cloud-10/messages/become-a-supplier.yml
@@ -4,8 +4,8 @@ coming: |
     You will be able to apply to sell:
     <ul class="list-bullet">
       <li>cloud hosting</li>
-      <li>software</li>
-      <li>technical support</li>
+      <li>cloud software</li>
+      <li>cloud support</li>
     </ul>
   </div>
 
@@ -15,8 +15,8 @@ open: |
     You can apply to sell:
     <ul class="list-bullet">
       <li>cloud hosting</li>
-      <li>software</li>
-      <li>technical support</li>
+      <li>cloud software</li>
+      <li>cloud support</li>
     </ul>
   </div>
 
@@ -26,8 +26,8 @@ pending: &can_not_apply |
     You will be able to apply to sell:
     <ul class="list-bullet">
       <li>cloud hosting</li>
-      <li>software</li>
-      <li>technical support</li>
+      <li>cloud software</li>
+      <li>cloud support</li>
     </ul>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
For this trello ticket: [https://trello.com/c/7P1cRFqt](https://trello.com/c/7P1cRFqt)
There will be a corresponding PR on the supplier frontend to pull these changes in once merged.

The content on the `become a supplier` page is wrong, and needs updating.

At the time of writing G-Cloud 10 is `pending` and so the changes to
`coming` and `open` will never be seen. I'm updating them too for
consistency and in case this file is copied to a new
iteration of the framework in future.