### PR TITLE
Update framework agreement direct pdf link

### DIFF
--- a/frameworks/g-cloud-10/messages/urls.yml
+++ b/frameworks/g-cloud-10/messages/urls.yml
@@ -1,6 +1,6 @@
 framework_agreement_url: "https://www.gov.uk/government/publications/g-cloud-10-framework-agreement"
 
-framework_agreement_pdf_url: "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/612999/g-cloud-10-framework-agreement.pdf"
+framework_agreement_pdf_url: "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/717205/g-cloud_10_framework_agreement.pdf"
 
 supplier_guide_url: "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-apply"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
 ## Summary
We display this link to users during standstill as they need to be able
to view the rest of the framework agreement (we only provide section 1 - 
the 'signature page').