### PR TITLE
Update G-Cloud 10 lot descriptions

### DIFF
--- a/frameworks/g-cloud-10/messages/advice.yml
+++ b/frameworks/g-cloud-10/messages/advice.yml
@@ -8,15 +8,11 @@ use_of_service_data: >
 
 lots:
   - slug: cloud-hosting
-    body: >
-      Find cloud platform or infrastructure services to help you:
-
-        - deploy, manage and run software
-        - provision and use processing, storage or networking resources
+    body: Platform or infrastructure services for running software, networking, or processing and storing data.
     advice: eg content delivery networks or load balancing services
   - slug: cloud-software
-    body: Find software applications that are accessed over the internet and hosted in the cloud.
+    body: Applications that are accessed over the internet and hosted in the cloud.
     advice: eg accounting tools or customer service management software
   - slug: cloud-support
-    body: Find cloud support services to help you set up and maintain your cloud software or hosting services.
+    body: Services to help you set up and maintain your cloud software or hosting services.
     advice: eg migration services or ongoing support


### PR DESCRIPTION
@karlchillmaid has tightened up the direct award lot descriptions as part of restructuring the lot selection page for direct award searches.

The changes in full can also be seen [here][doc].

[doc]: https://docs.google.com/document/d/1A42AurJ4bqDsGjOXJOfI5110W-n8j5hj0c7SJEYFIdI/edit?ts=5b3e3b7e