### PR TITLE
Remove buyers' guide links from the messages schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Records breaking changes from major version bumps
 
+## 13.0.0
+
+Removed buyers guide links from the frameworks, as they are no longer framework-specific. The guide is tied
+to the direct award process as implemented for any G-Cloud-like framework on the Digital Marketplace.
+
 ## 12.0.0
 
 All the `messages/dates.yml` files for frameworks have been removed. These dates are now stored directly on the

--- a/frameworks/g-cloud-10/messages/urls.yml
+++ b/frameworks/g-cloud-10/messages/urls.yml
@@ -9,5 +9,3 @@ call_off_contract_url: "https://www.gov.uk/government/publications/g-cloud-10-ca
 customer_benefits_record_form_url: "http://ccs-agreements.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Benefits%20Record_4.docx"
 
 customer_benefits_record_form_email: "gcloud-benefits@crowncommercial.gov.uk"
-
-buyers_guide_compare_services_url: "https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-compare-services"

--- a/frameworks/g-cloud-9/messages/urls.yml
+++ b/frameworks/g-cloud-9/messages/urls.yml
@@ -9,5 +9,3 @@ call_off_contract_url: "https://www.gov.uk/government/publications/g-cloud-9-cal
 customer_benefits_record_form_url: "http://ccs-agreements.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Benefits%20Record_4.docx"
 
 customer_benefits_record_form_email: "gcloud-benefits@crowncommercial.gov.uk"
-
-buyers_guide_compare_services_url: "https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-compare-services"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "12.4.0",
+  "version": "13.0.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schemas/messages.json
+++ b/schemas/messages.json
@@ -41,8 +41,7 @@
         "framework_agreement_pdf_url": {"type": "string"},
         "supplier_guide_url": {"type": "string"},
         "customer_benefits_record_form_url": {"type": "string"},
-        "customer_benefits_record_form_email": {"type": "string"},
-        "buyers_guide_compare_services_url": {"type": "string"}
+        "customer_benefits_record_form_email": {"type": "string"}
       },
       "required": [
         "supplier_guide_url"


### PR DESCRIPTION
Links to the buyers guide are no longer required in the frameworks repo, as it makes sense to hard-code these links into our content in our template. The content and the guide are inextricably linked, and are not specific to the framework but relate to the 'Direct Award' buying process.

https://trello.com/c/7wlBbGU0/138-add-step-3-assessing-your-service-and-badges