### PR TITLE
Add following_framework metatdata for DOS3

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-3/metadata/following_framework.yml
+++ b/frameworks/digital-outcomes-and-specialists-3/metadata/following_framework.yml
@@ -1,0 +1,4 @@
+framework:
+  slug: digital-outcomes-and-specialists-4
+  name: Digital Outcomes and Specialists 4
+  coming: '2019'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "13.5.0",
+  "version": "13.6.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schemas/metadata.json
+++ b/schemas/metadata.json
@@ -23,10 +23,19 @@
     },
     "following-framework": {
       "properties": {
-        "slug": {"type": "string"}
+        "slug": {"type": "string"},
+        "framework": {
+          "type": "object",
+          "properties": {
+            "slug": {"type": "string"},
+            "name": {"type": "string"},
+            "coming": {"type": "string"}
+          }
+        }
       },
-      "required": [
-        "slug"
+      "oneOf": [
+        {"required": ["slug"]},
+        {"required": ["framework"]}
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
For [this trello ticket](https://trello.com/c/Msvn4HAz).

We're introducing a custom error page for suppliers for when
applications close and they try to follow a link that is no longer
available. Editing a service for example.

Previously they've been served a generic error page which is unhelpful.
Now they'll get an error page with more information, and some brief
details about when the next framework is expected. That's what this
content is for.