### PR TITLE
Remove requirement on virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 requirements-dev: virtualenv requirements-dev.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements-dev.txt

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ in (with args; {
     name = "digitalmarketplace-frameworks-env";
     shortName = "dm-fwks";
     buildInputs = [
-      pythonPackages.virtualenv
+      pythonPackages.python
       pkgs.libffi
       pkgs.libyaml
       # pip requires git to fetch some of its dependencies
@@ -37,7 +37,7 @@ in (with args; {
       export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
 
       if [ ! -e $VIRTUALENV_ROOT ]; then
-        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+        ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
       make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}


### PR DESCRIPTION
Python36 includes the venv module which means we no longer need virtualenv to be installed on the development system