### PR TITLE
Fix DOS3 status search filters

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-3/manifests/briefs_search_filters.yml
+++ b/frameworks/digital-outcomes-and-specialists-3/manifests/briefs_search_filters.yml
@@ -1,7 +1,7 @@
 -
   name: Status
   questions:
-    - status
+    - statusOpenClosed
 -
   name: Location
   slug: location

--- a/frameworks/digital-outcomes-and-specialists-3/questions/briefs/status.yml
+++ b/frameworks/digital-outcomes-and-specialists-3/questions/briefs/status.yml
@@ -1,9 +1,0 @@
-name: Status
-id: status
-question: status
-type: radios
-options:
-  -
-    label: open
-    value: live
-  - label: closed

--- a/frameworks/digital-outcomes-and-specialists-3/questions/briefs/statusOpenClosed.yml
+++ b/frameworks/digital-outcomes-and-specialists-3/questions/briefs/statusOpenClosed.yml
@@ -1,0 +1,7 @@
+name: Status
+id: statusOpenClosed
+question: statusOpenClosed
+type: radios
+options:
+  - label: open
+  - label: closed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "13.6.1",
+  "version": "13.6.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
The way the open/closed filters was changed for DOS2 back in March, [see here](https://github.com/alphagov/digitalmarketplace-frameworks/commit/93a66aa7db3b522ac24d5ebecc9fee01708d698b). The change wasn't applied to DOS3 however, which causes weirdness on the search page. 

This catches DOS3 up.

There will be a PR on the buyer frontend once this is merged to pull these changes in.