### PR TITLE
G11 lot validation schema config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "13.7.0",
+  "version": "13.7.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -64,6 +64,9 @@ SCHEMAS = {
         ('G-Cloud 10 Cloud Hosting Product', 'g-cloud-10', 'cloud-hosting'),
         ('G-Cloud 10 Cloud Software Product', 'g-cloud-10', 'cloud-software'),
         ('G-Cloud 10 Cloud Support Product', 'g-cloud-10', 'cloud-support'),
+        ('G-Cloud 11 Cloud Hosting Product', 'g-cloud-11', 'cloud-hosting'),
+        ('G-Cloud 11 Cloud Software Product', 'g-cloud-11', 'cloud-software'),
+        ('G-Cloud 11 Cloud Support Product', 'g-cloud-11', 'cloud-support'),
     ],
     'briefs': [
         ('Digital Outcomes and Specialists Digital outcomes Brief',


### PR DESCRIPTION
Forgot to add this config in when copying the G11 content.

It's used in `scripts/generate-validation-schemas.py`, which have already been run to generate schemas for the API (https://github.com/alphagov/digitalmarketplace-api/pull/861).