### PR TITLE
G11 homepage dates

### DIFF
--- a/frameworks/g-cloud-11/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-11/messages/homepage-sidebar.yml
@@ -1,5 +1,5 @@
 coming:
-  heading: 'G&#x2011;Cloud&nbsp;11 is opening in March&nbsp;2525'
+  heading: 'G&#x2011;Cloud&nbsp;11 is opening in March&nbsp;2019'
   messages:
     - 'Provide cloud hosting, software and support.'
     - 'You’ll need to create a supplier account to apply.'
@@ -8,7 +8,7 @@ open:
   heading: 'G&#x2011;Cloud&nbsp;11 is open for applications'
   messages:
     - 'You need an account to apply.'
-    - 'The application deadline is 5pm&nbsp;BST, Thursday 25 April 2525.'
+    - 'The application deadline is 5pm&nbsp;BST, Monday 13 May 2019.'
 
 pending:
   heading: 'G&#x2011;Cloud&nbsp;11 is closed for applications'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "13.7.1",
+  "version": "13.7.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/WnalAx1D/386-set-g11-to-coming-on-staging

Time to put the proper year on the homepage, not 2525.

![g11-opening-march-2019](https://user-images.githubusercontent.com/3492540/53190318-32ffc180-3601-11e9-9a50-7a794d58cc69.png)

Also includes expected application closing date (still awaiting final confirmation).
Will need to be pulled into Buyer FE.