### PR TITLE
Update function and tests for JSON schema V7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 14.0.0
+
+Updated the `generate-validation-schemas` and `generate-assessment-schemas` scripts. These scripts now reflect the fact
+that we use JSON Draft 07 standard. The backwards incompatible change is that `exclusiveMaximum` is now an integer.
+Where we used both `exclusiveMaximum` and `maximum`, I've removed `maximum` in favour of solely using `exclusiveMaximum`
+to reduce the repetition. `maximum` by itself now signifies an inclusive maximum.
+ 
 ## 13.0.0
 
 Removed buyers guide links from the frameworks, as they are no longer framework-specific. The guide is tied

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "13.9.0",
+  "version": "14.0.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 flake8==3.5.0
 flake8-per-file-ignores==0.4.0
 hypothesis==1.18.1
-jsonschema==2.3.0
+jsonschema==3.0.0
 mock==2.0.0
 pytest==3.2.5
 PyYAML==3.11

--- a/schema_generator/assessment.py
+++ b/schema_generator/assessment.py
@@ -35,7 +35,7 @@ def generate_schema(framework_slug, question_set, manifest_name):
     }
 
     return {
-        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$schema": "http://json-schema.org/draft-07/schema#",  # hardcoded to draft 7 because jsonschema > 3 supports it
         "title": "{} Declaration Assessment Schema (Definite Pass Schema)".format(framework_slug),
         "type": "object",
         "allOf": [

--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -167,7 +167,7 @@ def merge_schemas(a, b):
 def empty_schema(schema_name):
     return {
         "title": "{} Schema".format(schema_name),
-        "$schema": "http://json-schema.org/schema#",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": False,
         "properties": {},
@@ -390,12 +390,14 @@ def pricing_property(question):
 
 def number_property(question):
     limits = question.get('limits', {})
-    return {question['id']: {
-        "exclusiveMaximum": not limits.get('integer_only'),
-        "maximum": limits['max_value'] if limits.get('max_value') is not None else 100,
+    output = {question['id']: {
         "minimum": limits.get('min_value') or 0,
         "type": "integer" if limits.get('integer_only') else "number"
     }}
+    inclusive_max = bool(limits.get('integer_only'))
+    maximum = limits['max_value'] if limits.get('max_value') is not None else 100
+    output[question['id']].update({"maximum": maximum} if inclusive_max else {"exclusiveMaximum": maximum})
+    return output
 
 
 def multiquestion(question):

--- a/tests/test_generate_validation_schema.py
+++ b/tests/test_generate_validation_schema.py
@@ -461,8 +461,7 @@ def test_hours_for_price():
 def test_number_property(id):
     actual = number_property({'id': id, 'type': 'number'})
     expected = {id: {
-        "exclusiveMaximum": True,
-        "maximum": 100,
+        "exclusiveMaximum": 100,
         "minimum": 0,
         "type": "number"
     }}
@@ -475,11 +474,10 @@ def test_number_property_limits(max_value, min_value, integer_only):
         'max_value': max_value, 'min_value': min_value, 'integer_only': integer_only
     }})
     expected = {"number-question": {
-        "exclusiveMaximum": False if integer_only else True,
-        "maximum": max_value,
         "minimum": min_value,
         "type": "integer" if integer_only else "number"
     }}
+    expected['number-question'].update({"maximum": max_value} if integer_only else {"exclusiveMaximum": max_value})
     assert actual == expected
 
 


### PR DESCRIPTION
These changes update the number_property method and associated tests. These changes are a part of updating our JSON schema to version 7, which expects exclusiveMaximum to be a number rather than a boolean.

In updating the `number_property` function I found the `not limits.get('integer_only')` pattern confusing, and replaced it with a variable that explains what we're actually checking.