### PR TITLE
Remove deprecated field `include_in_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Records breaking changes from major version bumps
 
+## 15.0.0
+
+Removed the `include_in_all` parameter from the `serviceIdHash` field in the
+search mappings, as `_all` has been deprecated in Elasticsearch 5.6 and will be
+removed in Elasticsearch 6. Consumers of the Elasticsearch search mappings will
+now need to ensure that searches do not include the `serviceIdHash` field to
+remain compliant.
+
 ## 14.0.0
 
 Updated the `generate-validation-schemas` and `generate-assessment-schemas` scripts. These scripts now reflect the fact

--- a/frameworks/g-cloud-10/search_mappings/services.json
+++ b/frameworks/g-cloud-10/search_mappings/services.json
@@ -69,8 +69,7 @@
           "type": "keyword"
         },
         "sortonly_serviceIdHash": {
-          "type": "keyword",
-          "include_in_all": false
+          "type": "keyword"
         },
         "dmagg_lot": {
           "type": "keyword"

--- a/frameworks/g-cloud-11/search_mappings/services.json
+++ b/frameworks/g-cloud-11/search_mappings/services.json
@@ -69,8 +69,7 @@
           "type": "keyword"
         },
         "sortonly_serviceIdHash": {
-          "type": "keyword",
-          "include_in_all": false
+          "type": "keyword"
         },
         "dmagg_lot": {
           "type": "keyword"

--- a/frameworks/g-cloud-9/search_mappings/services.json
+++ b/frameworks/g-cloud-9/search_mappings/services.json
@@ -69,8 +69,7 @@
           "type": "keyword"
         },
         "sortonly_serviceIdHash": {
-          "type": "keyword",
-          "include_in_all": false
+          "type": "keyword"
         },
         "dmagg_lot": {
           "type": "keyword"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "14.0.1",
+  "version": "15.0.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Ticket: https://trello.com/c/uTA0PcGF

`include_in_all` is deprecated in Elasticsearch 5.6 and has been [removed][1] in Elasticsearch 6.0.

We were using `include_in_all: false` for the serviceIdHash as we didn't want people to be able to search by ID hash, but this option is now no longer available.

I'm currently looking into whether this will actually affect our search; I'm not sure if we ever search `_all` directly or indirectly. If we do we may have to decide whether we care about the hash being searchable because as far as I know there is no easy way to replicate the `include_in_all: false` behaviour in Elasticsearch 6.

[1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html#_the_literal_include_in_all_literal_mapping_parameter_is_now_disallowed