### PR TITLE
G11 content fixes

### DIFF
--- a/frameworks/g-cloud-11/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-11/messages/homepage-sidebar.yml
@@ -8,7 +8,7 @@ open:
   heading: 'G&#x2011;Cloud&nbsp;11 is open for applications'
   messages:
     - 'You need an account to apply.'
-    - 'The application deadline is 5pm&nbsp;BST, Monday 13 May 2019.'
+    - 'The application deadline is 5pm&nbsp;BST, Wednesday 15 May 2019.'
 
 pending:
   heading: 'G&#x2011;Cloud&nbsp;11 is closed for applications'

--- a/frameworks/g-cloud-11/questions/declaration/canProvideFromDayOne.yml
+++ b/frameworks/g-cloud-11/questions/declaration/canProvideFromDayOne.yml
@@ -2,7 +2,7 @@ name: Providing services straight away
 question: >
   If your application is successful, can you provide all the services you’re submitting to G-Cloud&nbsp;11 from the first day you’re awarded a place on the framework?
 type: boolean
-hint: You must be ready to provide the services you’re submitting from May 2525.
+hint: You must be ready to provide the services you’re submitting from July 2019.
 assessment:
   passIfIn:
     - True

--- a/frameworks/g-cloud-11/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/g-cloud-11/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -2,7 +2,7 @@ name: Modern slavery reporting requirements
 question: Does your organisation comply with the annual reporting requirements of section 54 of The Modern Slavery Act (2015)?
 
 hint: >
-  You must publish a slavery and human trafficking statement to comply with the act. Read the Home Office guidance for information about [how to write a statement and what information it must include](/government/publications/transparency-in-supply-chains-a-practical-guide).
+  You must publish a slavery and human trafficking statement to comply with the act. Read the Home Office guidance for information about <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">how to write a statement and what information it must include (link opens in a new tab)</a>.
 
 hidden: true
 type: boolean

--- a/frameworks/g-cloud-11/questions/declaration/modernSlaveryStatementOptional.yml
+++ b/frameworks/g-cloud-11/questions/declaration/modernSlaveryStatementOptional.yml
@@ -2,7 +2,7 @@ name: Modern slavery statement optional
 question: >
   You don’t need to publish a slavery and human trafficking statement to meet the modern slavery requirements for G-Cloud 11.
 question_advice: >
-  You can choose to upload a statement. Read the Home Office guidance for information about [how to write a statement and what information it must include](/government/publications/transparency-in-supply-chains-a-practical-guide).
+  You can choose to upload a statement. Read the Home Office guidance for information about <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">how to write a statement and what information it must include (link opens in a new tab)</a>.
 hint: >
   Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
 

--- a/frameworks/g-cloud-11/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/g-cloud-11/questions/declaration/understandHowToAskQuestions.yml
@@ -2,7 +2,7 @@ name: Asking questions
 question: >
   Do you understand that you can ask ‘clarification’ questions on the <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-11/updates" target="_blank" rel="noopener noreferrer">G-Cloud&nbsp;11 updates page (link opens in a new tab)</a> in your Digital Marketplace account?
 hint: >
-  You can ask clarification questions about G-Cloud&nbsp;11 until 5pm BST 30 April 2019. All questions and answers will be posted regularly on the G-Cloud 11 updates page. You will be notified by email when new clarification questions and answers are available.
+  You can ask clarification questions about G-Cloud&nbsp;11 until 5pm BST 8 May 2019. All questions and answers will be posted regularly on the G-Cloud 11 updates page. You will be notified by email when new clarification questions and answers are available.
 
 type: boolean
 assessment:

--- a/frameworks/g-cloud-11/questions/services/managementAccessAuthentication.yml
+++ b/frameworks/g-cloud-11/questions/services/managementAccessAuthentication.yml
@@ -8,7 +8,7 @@ depends:
       - cloud-software
 followup:
   managementAccessAuthenticationDescription:
-    - true
+    - other
 
 type: checkboxes
 options:

--- a/frameworks/g-cloud-11/questions/services/publicSectorNetworksTypes.yml
+++ b/frameworks/g-cloud-11/questions/services/publicSectorNetworksTypes.yml
@@ -8,7 +8,7 @@ depends:
       - cloud-software
 followup:
   publicSectorNetworksOther:
-    - true
+    - other
 
 type: checkboxes
 options:

--- a/frameworks/g-cloud-11/questions/services/serviceInterfaceAccessibility.yml
+++ b/frameworks/g-cloud-11/questions/services/serviceInterfaceAccessibility.yml
@@ -8,6 +8,7 @@ depends:
 followup:
   serviceInterfaceAccessibilityDescription:
     - none
+hidden: true
 
 type: radios
 options:

--- a/frameworks/g-cloud-11/questions/services/serviceInterfaceTesting.yml
+++ b/frameworks/g-cloud-11/questions/services/serviceInterfaceTesting.yml
@@ -5,6 +5,8 @@ depends:
     being:
       - cloud-software
 
+hidden: true
+
 type: textbox_large
 max_length_in_words: 200
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/5CzbmwiW/407-bug-fixes-for-the-supplier-declaration-journey

Fixes following QA:
- some followup questions were not hidden/shown
- ModernSlavery guidance links needed fixing and opening in a new tab
- Revised application dates (still awaiting final-final-final confirmation, obviously)

These changes will require the API validation schemas to be regenerated - PR incoming for that.