### PR TITLE
Update digitalmarketplace-content-loader from 4.6.0 to 5.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.4.0
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.6.0#egg=digitalmarketplace-content-loader==4.6.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.8.0#egg=digitalmarketplace-utils==36.8.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@46.2.0#egg=digitalmarketplace-utils==46.2.0


### PR DESCRIPTION
This is only really used for testing, but it's good to keep it up-to-date.

I also had to bump dmutils, as it's a requirement of dmcontent.