### PR TITLE
Update other manifests with service changes

### DIFF
--- a/frameworks/g-cloud-11/manifests/display_service.yml
+++ b/frameworks/g-cloud-11/manifests/display_service.yml
@@ -261,6 +261,7 @@
 - name: Energy efficiency
   questions:
     - energyEfficientDatacentres
+    - energyEfficientDatacentresDescription
 
 - name: Pricing
   questions:

--- a/frameworks/g-cloud-11/manifests/edit_service_as_admin.yml
+++ b/frameworks/g-cloud-11/manifests/edit_service_as_admin.yml
@@ -210,7 +210,7 @@
 - name: Energy efficiency
   editable: true
   questions:
-    - energyEfficientDatacentres
+    - multiqEnergyEfficiency
 
 - name: Pricing
   editable: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
While doing the manual spaniel I remembered that other manifests use service questions too, and we renamed one of the questions (`energyEfficientDatacentres` became `multiqEnergyEfficiency`) and added a new one (`energyEfficientDatacentresDescription `).

These manifests are used in the Admin and Buyer FEs.