### PR TITLE
Update clarification question deadline

### DIFF
--- a/frameworks/g-cloud-11/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/g-cloud-11/questions/declaration/understandHowToAskQuestions.yml
@@ -2,7 +2,7 @@ name: Asking questions
 question: >
   Do you understand that you can ask ‘clarification’ questions on the <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-11/updates" target="_blank" rel="noopener noreferrer">G-Cloud&nbsp;11 updates page (link opens in a new tab)</a> in your Digital Marketplace account?
 hint: >
-  You can ask clarification questions about G-Cloud&nbsp;11 until 5pm BST 8 May 2019. All questions and answers will be posted regularly on the G-Cloud 11 updates page. You will be notified by email when new clarification questions and answers are available.
+  You can ask clarification questions about G-Cloud&nbsp;11 until 5pm BST 30 April 2019. All questions and answers will be posted regularly on the G-Cloud 11 updates page. You will be notified by email when new clarification questions and answers are available.
 
 type: boolean
 assessment:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.0.3",
+  "version": "15.0.4",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/wgdqi2gJ/668-g-11-declarations-questions-update-clarification-deadline

The old date is the clarification question answers publish date, not the deadline for asking.

