### PR TITLE
Exclude managementAccessDescription from copy_services

### DIFF
--- a/frameworks/g-cloud-11/metadata/copy_services.yml
+++ b/frameworks/g-cloud-11/metadata/copy_services.yml
@@ -67,8 +67,6 @@ questions_to_copy:
   - installationCompatibleOperatingSystems
   - lot
   - lotName
-  - managementAccessAuthentication
-  - managementAccessAuthenticationDescription
   - metrics
   - metricsHow
   - metricsWhat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.0.4",
+  "version": "15.0.5",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/2IUa5FqD/676-launchcloud-error-with-g-cloud-11-application-process

We updated a dependency question to be triggered on a response value of `other` rather than `true`. Where users had copied their answers **and** previously responded `true`, validation was failing every time they tried to save their application because the dependent questions was triggering but contained no answer. This offers a fix for future users by not including responses to this question when they copy their previous declaration.