### PR TITLE
Remove unnecessary clause from G11 declaration question

### DIFF
--- a/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
+++ b/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
@@ -7,10 +7,10 @@ hint: >
   members. You must answer ‘Yes’ or ‘Not applicable’ to be eligible for consideration for the G-Cloud&nbsp;11 framework.
 type: radios
 options:
-  - label: "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
+  - label: "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million."
   - label: "No - your organisation does not have, and will not have in place, employer’s liability insurance of at least £5 million before the framework is awarded."
   - label: "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."
 assessment:
   passIfIn:
-    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
+    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million."
     - "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.3.0",
+  "version": "15.3.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/1YUXLv7P/473-remove-unnecessary-clause-from-declaration-question

CCS and the G11 team agree that the following answer needs to be changed:

`Yes - your organisation has, or will have in place, employer’s liability insurance of at least $5 million and you will provide certification before the framework is awarded.`

To:

`Yes - your organisation has, or will have in place, employer’s liability insurance of at least $5 million`

The suppliers don't need to provide certification (CCS don't ask for it, and no-one provided it for G10!). Removing the clause should not cause a disadvantage to any suppliers.