### PR TITLE
Fix pass/fail for employer insurance question

### DIFF
--- a/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
+++ b/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
@@ -13,4 +13,5 @@ options:
 assessment:
   passIfIn:
     - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million."
+    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
     - "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.3.1",
+  "version": "15.3.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/1YUXLv7P/473-remove-unnecessary-clause-from-declaration-question

This will allow any suppliers who have already answered the question with the old text value to still pass the framework validation. We can remove this for DOS4.