### PR TITLE
Revert G11 declaration "employers liability" question changes

### DIFF
--- a/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
+++ b/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
@@ -13,5 +13,4 @@ options:
 assessment:
   passIfIn:
     - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million."
-    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
     - "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."

--- a/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
+++ b/frameworks/g-cloud-11/questions/declaration/employersInsurance.yml
@@ -7,10 +7,10 @@ hint: >
   members. You must answer ‘Yes’ or ‘Not applicable’ to be eligible for consideration for the G-Cloud&nbsp;11 framework.
 type: radios
 options:
-  - label: "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million."
+  - label: "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
   - label: "No - your organisation does not have, and will not have in place, employer’s liability insurance of at least £5 million before the framework is awarded."
   - label: "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."
 assessment:
   passIfIn:
-    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million."
+    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
     - "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.3.2",
+  "version": "15.3.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
These are proving to be too problematic, and it's something we probably shouldn't push out during an application phase. It would also result in us forever having slightly complicated dirty data for G11 declarations.