### PR TITLE
Update G11 closing date

### DIFF
--- a/frameworks/g-cloud-11/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-11/messages/homepage-sidebar.yml
@@ -8,7 +8,7 @@ open:
   heading: 'G&#x2011;Cloud&nbsp;11 is open for applications'
   messages:
     - 'You need an account to apply.'
-    - 'The application deadline is 5pm&nbsp;BST, Wednesday 15 May 2019.'
+    - 'The application deadline is 5pm&nbsp;BST, Wednesday 22 May 2019.'
 
 pending:
   heading: 'G&#x2011;Cloud&nbsp;11 is closed for applications'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.3.3",
+  "version": "15.3.4",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
The G11 application closing date has been extended to 5pm BST 22nd May 2019 (as per email already sent to suppliers). The home page content needs to be updated to reflect this.

Will need to be pulled into the Buyer FE.