### PR TITLE
Assessment schema can handle multiquestion type declaration questions

### DIFF
--- a/frameworks/g-cloud-11/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/g-cloud-11/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -14,3 +14,4 @@ validations:
 assessment:
   passIfIn:
     - True
+  discretionary: True

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.3.4",
+  "version": "15.3.5",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schema_generator/assessment.py
+++ b/schema_generator/assessment.py
@@ -19,11 +19,14 @@ def generate_schema(framework_slug, question_set, manifest_name):
         manifest_name,
     )
 
-    assessed_questions = tuple(
-        question
-        for question in chain.from_iterable(section.questions for section in manifest.sections)
-        if "passIfIn" in question.get("assessment", {})
-    )
+    assessed_questions = []
+    for question in chain.from_iterable(section.questions for section in manifest.sections):
+        if question.type == 'multiquestion':
+            for nested_question in question.questions:
+                if "passIfIn" in nested_question.get("assessment", {}):
+                    assessed_questions.append(nested_question)
+        elif "passIfIn" in question.get("assessment", {}):
+            assessed_questions.append(question)
 
     discretionary_properties = {
         question.id: _enum_for_question(question)

--- a/tests/test_generate_assessment_schema.py
+++ b/tests/test_generate_assessment_schema.py
@@ -105,3 +105,16 @@ def test_g11_declaration_assessment(declaration_update, use_baseline, should_pas
 
     with (_empty_context_manager() if should_pass else pytest.raises(jsonschema.ValidationError)):
         jsonschema.validate(candidate, schema)
+
+
+@pytest.mark.parametrize('use_baseline', (True, False))
+def test_g11_declaration_assessment_passes_if_answer_missing(use_baseline):
+    schema = generate_schema("g-cloud-11", "declaration", "declaration")
+    if use_baseline:
+        schema = schema["definitions"]["baseline"]
+
+    candidate = _definite_pass_g11_declaration()
+    candidate.pop('modernSlaveryReportingRequirements')
+    candidate['modernSlaveryTurnover'] = False
+
+    jsonschema.validate(candidate, schema)

--- a/tests/test_generate_assessment_schema.py
+++ b/tests/test_generate_assessment_schema.py
@@ -6,14 +6,14 @@ import pytest
 from schema_generator.assessment import generate_schema
 
 
-# we define a basic, assessment-passing, g9 declaration here (though interestingly it doesn't include informational
+# we define a basic, assessment-passing, g11 declaration here (though interestingly it doesn't include informational
 # fields so it wouldn't actually pass the *validation* schema). this could be fleshed out to enable it to be used as a
 # common "example" valid declaration from other apps: having it live here in this repository and regularly checked
 # in these tests ensures that it is always up to date with what is defined in the framework's yaml files... future work
 # to look at.
 
 
-def _definite_pass_g9_declaration():
+def _definite_pass_g11_declaration():
     return {
         # discretionary
         "GAAR": False,
@@ -26,6 +26,7 @@ def _definite_pass_g9_declaration():
         "graveProfessionalMisconduct": False,
         "influencedContractingAuthority": False,
         "misleadingInformation": False,
+        "modernSlaveryReportingRequirements": True,
         "seriousMisrepresentation": False,
         "significantOrPersistentDeficiencies": False,
         "taxEvasion": False,
@@ -50,6 +51,7 @@ def _definite_pass_g9_declaration():
         "fullAccountability": True,
         "helpBuyersComplyTechnologyCodesOfPractice": True,
         "informationChanges": True,
+        "modernSlaveryTurnover": True,
         "offerServicesYourselves": True,
         "organisedCrime": False,
         "proofOfClaims": True,
@@ -86,16 +88,19 @@ def _empty_context_manager():
     # discretionary
     ({"graveProfessionalMisconduct": True}, False, False,),
     ({"graveProfessionalMisconduct": True}, True, True,),
+    # Multiquestion discretionary
+    ({"modernSlaveryReportingRequirements": False}, True, True,),
+    ({"modernSlaveryReportingRequirements": False}, False, False,),
 ))
-def test_g9_declaration_assessment(declaration_update, use_baseline, should_pass):
+def test_g11_declaration_assessment(declaration_update, use_baseline, should_pass):
     # these test(s) are a bit funny in that they all make the same call to the function-under-test and then
     # assert a different thing about the return value, so we could improve on run time if necessary by only performing
     # the call once if necessary...
-    schema = generate_schema("g-cloud-9", "declaration", "declaration")
+    schema = generate_schema("g-cloud-11", "declaration", "declaration")
     if use_baseline:
         schema = schema["definitions"]["baseline"]
 
-    candidate = _definite_pass_g9_declaration()
+    candidate = _definite_pass_g11_declaration()
     candidate.update(declaration_update)
 
     with (_empty_context_manager() if should_pass else pytest.raises(jsonschema.ValidationError)):


### PR DESCRIPTION
Trello: https://trello.com/c/9PHHg4X3/509-generate-g11-declaration-assessment-schema-ko-w-kat

The `modernSlaveryReportingRequirements` question has an associated `mitigatingFactors3` question - it's a discretionary fail if users answer 'False'.

`modernSlaveryReportingRequirements` is also a sub question of `multiqModernSlavery`, a `multiquestion` type - the assessment schema can now handle this when generating the pass/fail schema. It's a fairly crude fix but we are unlikely to have more than one level of nested questions.

Generates this schema: https://github.com/alphagov/digitalmarketplace-scripts/pull/380