### PR TITLE
DOS4 service questions

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/manifests/declaration.yml
@@ -163,7 +163,7 @@
   name: How you’ll deliver your services
   slug: how-youll-deliver-your-services
   editable: True
-  prefill: True
+  prefill: False
   description: |
     The Crown Commercial Service will use this information to manage your participation in Digital Outcomes and Specialists&nbsp;4.
   questions:

--- a/frameworks/digital-outcomes-and-specialists-4/manifests/edit_submission.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/manifests/edit_submission.yml
@@ -15,6 +15,7 @@
     - bespokeSystemInformation
     - dataProtocols
     - openStandardsPrinciples
+    - accessibleApplicationsOutcomes
 
 - name: User research participants essentials
   editable: True

--- a/frameworks/digital-outcomes-and-specialists-4/metadata/copy_services.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/metadata/copy_services.yml
@@ -15,6 +15,15 @@ questions_to_copy:
   - contentDesignerPriceMax
   - contentDesignerPriceMin
   - dataProtocols
+  - dataArchitectLocations
+  - dataArchitectPriceMax
+  - dataArchitectPriceMin
+  - dataEngineerLocations
+  - dataEngineerPriceMax
+  - dataEngineerPriceMin
+  - dataScientistLocations
+  - dataScientistPriceMax
+  - dataScientistPriceMin
   - deliveryManagerLocations
   - deliveryManagerPriceMax
   - deliveryManagerPriceMin

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsOutcomes.yml
@@ -1,0 +1,13 @@
+name: Designing and building accessible applications
+question: Will you design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsSpecialists.yml
@@ -1,0 +1,14 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: boolean
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/agileCoachLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/agileCoachLocations.yml
@@ -2,6 +2,7 @@ question: Where will your agile coach work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/businessAnalystLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/businessAnalystLocations.yml
@@ -2,6 +2,7 @@ question: Where will your business analyst work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/communicationsManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/communicationsManagerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your communications manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/contentDesigner.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/contentDesigner.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - contentDesignerLocations
   - contentDesignerDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a content designer
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/contentDesignerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/contentDesignerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your content designer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataArchitectLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataArchitectLocations.yml
@@ -2,6 +2,7 @@ question: Where will your data architect work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataEngineerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataEngineerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your data engineer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataScientistLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataScientistLocations.yml
@@ -2,6 +2,7 @@ question: Where will your data scientist work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/deliveryManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/deliveryManagerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your delivery manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/designer.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/designer.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - designerLocations
   - designerDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a designer
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/designerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/designerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your designer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/developer.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/developer.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - developerLocations
   - developerDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a developer
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/developerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/developerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your developer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/outcomesLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/outcomesLocations.yml
@@ -8,6 +8,7 @@ question: |
   You can update the locations where you can provide services when the framework is live.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/performanceAnalystLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/performanceAnalystLocations.yml
@@ -2,6 +2,7 @@ question: Where will your performance analyst work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/portfolioManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/portfolioManagerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your portfolio manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/productManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/productManagerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your product manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/programmeManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/programmeManagerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your programme manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/qualityAssurance.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/qualityAssurance.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - qualityAssuranceLocations
   - qualityAssuranceDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a quality assurance analyst
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/qualityAssuranceLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/qualityAssuranceLocations.yml
@@ -2,6 +2,7 @@ question: Where will your quality assurance analyst work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/securityConsultantLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/securityConsultantLocations.yml
@@ -2,6 +2,7 @@ question: Where will your cyber security consultant work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/serviceManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/serviceManager.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - serviceManagerLocations
   - serviceManagerDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a service manager
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/serviceManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/serviceManagerLocations.yml
@@ -2,6 +2,7 @@ question: Where will your service manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/technicalArchitect.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/technicalArchitect.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - technicalArchitectLocations
   - technicalArchitectDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a technical architect
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/technicalArchitectLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/technicalArchitectLocations.yml
@@ -2,6 +2,7 @@ question: Where will your technical architect work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/userResearcherLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/userResearcherLocations.yml
@@ -2,6 +2,7 @@ question: Where will your user researcher work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/webOperations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/webOperations.yml
@@ -10,6 +10,7 @@ any_of: specialist
 questions:
   - webOperationsLocations
   - webOperationsDayRate
+  - accessibleApplicationsSpecialists
 
 empty_message: You haven’t added a web operations engineer
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/webOperationsLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/webOperationsLocations.yml
@@ -2,6 +2,7 @@ question: Where will your web operations engineer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
     [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot
     being:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.4.0",
+  "version": "15.4.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/kTVN6PlQ/532-clone-dos4-content

Includes the following significant changes:
- adding in an accessibility question for the following specialist roles: content designer, developer, designer, QA, service manager, web operations, tech architect.
- adding in an accessibility question for outcome teams
- adding explanatory hint text to anywhere that specifies 'Offsite' location

Also includes the specialist roles that were added in DOS3 to the `copy_services` metadata. (We'll need to add in the new accessibility questions here when we get round to DOS5!)

Also also: fix for the IR35 question added in the previous PR. We can't prefill that declaration section as there's a new question.