### PR TITLE
Accessibility questions must be answered 'Yes'

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsOutcomes.yml
@@ -3,6 +3,8 @@ question: Will you design and build accessible applications that meet the 2018 a
 hint:
   Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
 type: boolean
+required_value: true
+
 depends:
   - "on": "lot"
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/accessibleApplicationsSpecialists.yml
@@ -2,12 +2,13 @@ question: Designing and building accessible applications
 question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
 hint:
   Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
 
 depends:
   - "on": lot
     being:
       - digital-specialists
-type: boolean
 
 validations:
   - name: answer_required

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/bespokeSystemInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/bespokeSystemInformation.yml
@@ -1,6 +1,8 @@
 name: Share systems information
 question: Will you share bespoke system information from the service you’re working on, eg software performance data, to help the government continuously improve its services?
 type: boolean
+required_value: true
+
 depends:
   - "on": "lot"
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataProtocols.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataProtocols.yml
@@ -1,6 +1,8 @@
 name: Standard data protocols
 question: Will you use standard, accessible data protocols to ensure interoperability across government services?
 type: boolean
+required_value: true
+
 depends:
   - "on": "lot"
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/helpGovernmentImproveServices.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/helpGovernmentImproveServices.yml
@@ -1,6 +1,8 @@
 name: Share non-personal data
 question: Will you share non-personal user and service data to help the government continuously improve its services?
 type: boolean
+required_value: true
+
 depends:
   - "on": "lot"
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/openStandardsPrinciples.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/openStandardsPrinciples.yml
@@ -4,6 +4,8 @@ question: |
 
   This includes publishing any software you build for the government under the appropriate open source licence.
 type: boolean
+required_value: true
+
 depends:
   - "on": "lot"
     being:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "15.4.2",
+  "version": "15.4.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/kTVN6PlQ/532-clone-dos4-content

Adds validation for the mandatory questions on the DOS4 services, including the new accessibility questions. 

This means that the supplier must answer 'Yes' in order to proceed with adding the service (early feedback!) rather than waiting for us to run the pass/fail validation after applications have closed (when it's a bit late for them to do anything about it). 

I will re-generate the API schemas once this gets a thumbs-up.
