### PR TITLE
Fix DOS4 legal document links

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/MI.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/MI.yml
@@ -1,7 +1,7 @@
 name: Providing management information (MI)
 question: >
   Do you confirm that you’re prepared to provide all the monthly Digital Outcomes and Specialists&nbsp;4-related management information (MI)
-  to CCS as outlined in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-4" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
+  to CCS as outlined in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-4#reporting" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/termsAndConditions.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/termsAndConditions.yml
@@ -1,6 +1,6 @@
 name: Terms and conditions
 question: >
-  Do you accept the terms and conditions in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-4" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (link opens in a new tab)</a>?
+  Do you accept the terms and conditions in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-4#legal-documents" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/termsOfParticipation.yml
@@ -1,6 +1,6 @@
 name: Invitation to apply
 question: >
-  Do you agree to comply with the terms of the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-4" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists&nbsp;4 ‘invitation to apply’ (link opens in a new tab)</a>?
+  Do you agree to comply with the terms of the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-4#legal-documents" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists&nbsp;4 ‘invitation to apply’ (link opens in a new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
These got missed off for some reason. The bookmarks jump to the legal docs section of the supplier's application dashboard.