### PR TITLE
Reword declaration section intro

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/manifests/declaration.yml
@@ -22,11 +22,14 @@
   editable: True
   prefill: False
   description: |
-    If you make an application to Digital Outcomes and Specialists&nbsp;4, you’re agreeing to the terms and conditions in the legal documentation.
+    If you make an application to Digital Outcomes and Specialists&nbsp;4, you need to agree to the terms and conditions in the legal documentation.
 
-    You must be able to truthfully answer ‘yes’ to every question on this page for your application to be considered eligible.
+    You also need to confirm that you’re not guilty of misconduct that affects the fairness of the procurement.
 
-    If you can’t answer ‘yes’ to every question on this page, it’s very unlikely that your application will be accepted.
+    It’s unlikely your application will be accepted if you:
+
+      - don’t agree (answer ‘no’) to the terms given in questions [[termsOfParticipation]], [[termsAndConditions]], [[canProvideFromDayOne]], [[evidence]], [[10WorkingDays]] and [[MI]]
+      - answer ‘yes’ to say you've been involved in the misconduct listed in question [[unfairCompetition]]
 
   questions:
     - termsOfParticipation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.3",
+  "version": "16.0.4",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/BZ1PRdXo/567-update-text-what-it-means-to-be-on-digital-outcomes-and-specialists-4

One of the questions now requires the answer to be 'no', so the advice needs to change. Content has been provided by Stefan. The `[[questionName]]` values resolve to the question numbers.