### PR TITLE
Add max word limits to textbox declaration questions

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors.yml
@@ -3,7 +3,15 @@ question: >
   If you responded ‘yes’ to any of the questions [[taxEvasion]] to [[misleadingInformation]], please provide details of
   any mitigating factors that you think should be taken into consideration.
 type: textbox_large
+max_length_in_words: 500
+
 validations:
   - 
     name: answer_required
     message: You need to answer this question because you answered ‘yes’ to one of questions [[taxEvasion]] to [[misleadingInformation]].
+  -
+    name: under_word_limit
+    message: "Your answer must be no more than 500 words."
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 5000 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors2.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors2.yml
@@ -3,7 +3,15 @@ question: >
   If you responded ‘yes’ to either question [[unspentTaxConvictions]] or question [[GAAR]], please provide details of 
   any mitigating factors that you think should be taken into consideration.
 type: textbox_large
+max_length_in_words: 500
+
 validations:
   - 
     name: answer_required
     message: You need to answer this question because you answered ‘yes’ to either [[unspentTaxConvictions]] or [[GAAR]].
+  -
+    name: under_word_limit
+    message: "Your answer must be no more than 500 words."
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 5000 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors3.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors3.yml
@@ -2,9 +2,16 @@ name: Mitigating factors for Modern Slavery reporting requirements
 question: >
   If your organisation does not meet the requirements, please explain why.
 type: textbox_large
+max_length_in_words: 500
 
 hidden: true
 validations:
-  - 
+  -
     name: answer_required
-    message: You need to answer this question
+    message: You need to answer this question because you answered ‘yes’ to question [[modernSlaveryReportingRequirements]].
+  -
+    name: under_word_limit
+    message: "Your answer must be no more than 500 words."
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 5000 characters."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.4",
+  "version": "16.0.5",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schemas/questions.json
+++ b/schemas/questions.json
@@ -163,6 +163,7 @@
               "under_50_words",
               "under_100_words",
               "under_200_words",
+              "under_word_limit",
               "under_character_limit",
               "total_should_be_100"
             ]


### PR DESCRIPTION
https://trello.com/c/Bw46fBz5/559-declaration-questions-for-mitigatingfactors-have-no-maxlengthinwords

Adds maximum word and character limits to DOS4 free text questions. 500 words is the limit agreed by us and CCS (the 5000 character limit follows our convention of having a 10:1 character:word ratio elsewhere).

The validation itself will take place in the Supplier FE (separate PR incoming).