### PR TITLE
Hardcode unordered list in declaration description

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/manifests/declaration.yml
@@ -28,8 +28,10 @@
 
     It’s unlikely your application will be accepted if you:
 
-      - don’t agree (answer ‘no’) to the terms given in questions [[termsOfParticipation]], [[termsAndConditions]], [[canProvideFromDayOne]], [[evidence]], [[10WorkingDays]] and [[MI]]
-      - answer ‘yes’ to say you've been involved in the misconduct listed in question [[unfairCompetition]]
+    <ul class="list-bullet">
+    <li>don’t agree (answer ‘no’) to the terms given in questions [[termsOfParticipation]], [[termsAndConditions]], [[canProvideFromDayOne]], [[evidence]], [[10WorkingDays]] and [[MI]]</li>
+    <li>answer ‘yes’ to say you've been involved in the misconduct listed in question [[unfairCompetition]]</li>
+    </ul>
 
   questions:
     - termsOfParticipation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.5",
+  "version": "16.0.6",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/BZ1PRdXo/567-update-text-what-it-means-to-be-on-digital-outcomes-and-specialists-4

![supplier-fe-unordered-list](https://user-images.githubusercontent.com/3492540/60093348-16a39b00-9741-11e9-845e-d2d2770a39f4.png)

Testing revealed that the supplier FE's CSS sets unordered lists to `list-style: none` in declaration section descriptions. So we have to hardcode some HTML into the description to explicitly include `class="list-bullet"`. We do this in a few places throughout the frameworks repo - I remember discussion about improving this a couple of years ago, but we haven't found a better solution so far.

(Skipping v16.0.5 with the hope that https://github.com/alphagov/digitalmarketplace-frameworks/pull/581 will get merged first) 