### PR TITLE
[WIP] Fix reuse service answers bug

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/metadata/copy_services.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/metadata/copy_services.yml
@@ -3,8 +3,6 @@ questions_to_copy:
   - agileCoachLocations
   - agileCoachPriceMax
   - agileCoachPriceMin
-  - anonymousRecruitment
-  - bespokeSystemInformation
   - businessAnalystLocations
   - businessAnalystPriceMax
   - businessAnalystPriceMin
@@ -14,7 +12,6 @@ questions_to_copy:
   - contentDesignerLocations
   - contentDesignerPriceMax
   - contentDesignerPriceMin
-  - dataProtocols
   - dataArchitectLocations
   - dataArchitectPriceMax
   - dataArchitectPriceMin
@@ -34,7 +31,6 @@ questions_to_copy:
   - developerLocations
   - developerPriceMax
   - developerPriceMin
-  - helpGovernmentImproveServices
   - labAccessibility
   - labAddressBuilding
   - labAddressPostcode
@@ -56,8 +52,6 @@ questions_to_copy:
   - labWaitingArea
   - labWiFi
   - locations
-  - manageIncentives
-  - openStandardsPrinciples
   - performanceAnalysisTypes
   - performanceAnalystLocations
   - performanceAnalystPriceMax

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/anonymousRecruitment.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/anonymousRecruitment.yml
@@ -1,6 +1,8 @@
 name: Provide discreet recruitment
 question: Can you, if asked, recruit participants without revealing details of the organisation you’re recruiting for?
 type: boolean
+required_value: true
+
 depends:
   - "on": "lot"
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/manageIncentives.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/manageIncentives.yml
@@ -1,6 +1,7 @@
 name: Manage incentives
 question: Do you agree to manage any incentives to user research participants?
 type: boolean
+required_value: true
 depends:
   - "on": "lot"
     being:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.6",
+  "version": "16.0.7",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/nhi1PRi4/928-i-dont-adhere-to-open-standards-causes-400

Let's avoid copying changed questions from DOS3 by taking those fields out of the `copy_services` metadata.

Also, add validation for essential questions on the User Research Participants lot.

EDIT: this doesn't actually fix it - argh