### PR TITLE
Bugfix: modern slavery mitigating factors error message

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors3.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/mitigatingFactors3.yml
@@ -8,7 +8,7 @@ hidden: true
 validations:
   -
     name: answer_required
-    message: You need to answer this question because you answered ‘yes’ to question [[modernSlaveryReportingRequirements]].
+    message: You need to answer this question because you answered ‘no’ to the Reporting Requirements question.
   -
     name: under_word_limit
     message: "Your answer must be no more than 500 words."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.8",
+  "version": "16.0.9",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
![modern-slavery-error-message](https://user-images.githubusercontent.com/3492540/60732170-4290fe80-9f41-11e9-9a6f-810be44b9005.png)

a) the error message shouldn't show the field name in square brackets!
b) I answered 'no', not 'yes'!

The question number doesn't show up unlike for other similar error messages, because this is a nested question and it isn't numbered.