### PR TITLE
dos4 briefs evaluationType* questions: remove before_summary_value, change content to make it clearer these are additional

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/manifests/edit_brief.yml
@@ -82,6 +82,8 @@
       - evidence of their skills and experience
       - a proposal explaining how they plan to meet your requirements
 
+    All suppliers must provide a written proposal. You can choose additional assessment methods, for example a presentation.
+
     You must tell suppliers how you’ll evaluate and assess them.
 
   questions:
@@ -113,6 +115,8 @@
 
     ##3\. Evaluate your shortlist
     Ask the shortlisted specialists for evidence of their skills and experience.
+
+    All suppliers must provide a written proposal. You can choose additional assessment methods, for example a presentation.
 
     You must tell specialists how you’ll evaluate and assess them.
 
@@ -147,6 +151,8 @@
 
       - evidence of their skills and experience
       - a proposal explaining how they plan to recruit particpants
+
+    All suppliers must provide a written proposal. You can choose additional assessment methods, for example a case study.
 
     You must tell suppliers how you’ll evaluate and assess them.
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeOutcomes.yml
@@ -1,4 +1,4 @@
-name: Assessment methods
+name: Additional assessment methods
 id: evaluationType
 question: How you’ll assess suppliers
 question_advice: |
@@ -11,9 +11,6 @@ question_advice: |
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes
 optional: true
-
-before_summary_value:
-  - "Written proposal"
 
 options:
   - label: "Case study"
@@ -41,4 +38,4 @@ validations:
   -
     name: answer_required
     message: 'You need to answer this question.'
-empty_message: Choose assessment method
+empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeParticipants.yml
@@ -1,4 +1,4 @@
-name: Assessment methods
+name: Additional assessment methods
 id: evaluationType
 question: How you’ll assess suppliers
 question_advice: |
@@ -11,9 +11,6 @@ question_advice: |
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes
 optional: true
-
-before_summary_value:
-  - "Written proposal"
 
 options:
   - label: "Case study"
@@ -38,4 +35,4 @@ validations:
   -
     name: answer_required
     message: 'You need to answer this question.'
-empty_message: Choose assessment method
+empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeSpecialists.yml
@@ -1,4 +1,4 @@
-name: Assessment methods
+name: Additional assessment methods
 id: evaluationType
 question: How you’ll assess specialists
 question_advice: |
@@ -11,9 +11,6 @@ question_advice: |
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes
 optional: true
-
-before_summary_value:
-  - "Work history"
 
 options:
   - label: "Reference"
@@ -42,4 +39,4 @@ validations:
   -
     name: answer_required
     message: 'You need to answer this question.'
-empty_message: Choose assessment method
+empty_message: Choose additional assessment methods

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.0.10",
+  "version": "16.1.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/S1kIwe05

Once brought through to the briefs frontend this goes from looking like

![image](https://user-images.githubusercontent.com/807447/61067633-f1c94c00-a3ff-11e9-942b-7b474dc51b7f.png)

for digital outcomes in the initial state to 

![image](https://user-images.githubusercontent.com/807447/61067706-16bdbf00-a400-11e9-8f44-b36c178f2f3d.png)

with similar changes for digital specialists and UR participants.
