### PR TITLE
dos4 brief evaluationType* questions: improve opening text of question_advice

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeOutcomes.yml
@@ -2,7 +2,7 @@ name: Additional assessment methods
 id: evaluationType
 question: How you’ll assess suppliers
 question_advice: |
-  You must ask all suppliers that reach the assessment stage for a written proposal.
+  All suppliers will have to provide a written proposal. However, you can also choose additional ways to assess them, if you want to.
 
   Choose additional ways to assess suppliers.
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeParticipants.yml
@@ -2,7 +2,7 @@ name: Additional assessment methods
 id: evaluationType
 question: How you’ll assess suppliers
 question_advice: |
-  You must ask all suppliers that reach the assessment stage for a written proposal.
+  All suppliers will have to provide a written proposal. However, you can also choose additional ways to assess them, if you want to.
 
   Choose additional ways to assess suppliers.
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeSpecialists.yml
@@ -2,7 +2,7 @@ name: Additional assessment methods
 id: evaluationType
 question: How you’ll assess specialists
 question_advice: |
-  You must ask all specialists that reach the assessment stage for a work history.
+  All suppliers will have to provide a work history. However, you can also choose additional ways to assess them, if you want to.
 
   Choose additional ways to assess specialists.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.1.0",
+  "version": "16.1.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/57tHAqi9

From

![20190722_brief_eval_before](https://user-images.githubusercontent.com/807447/61700289-5e174a00-ad34-11e9-9fd4-9b23222917f8.png)

to

![20190722_brief_eval_after](https://user-images.githubusercontent.com/807447/61700312-6a030c00-ad34-11e9-9240-98aeb9b9483c.png)

It was thought the previous wording could be confusing because it all
appears below the heavy text "Optional".

This changes the wording, I think for the better - others opinions?