### PR TITLE
Bump version to 16.1.2

### DIFF
--- a/frameworks/g-cloud-11/messages/urls.yml
+++ b/frameworks/g-cloud-11/messages/urls.yml
@@ -6,6 +6,6 @@ supplier_guide_url: "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-
 
 call_off_contract_url: "https://www.gov.uk/government/publications/g-cloud-11-call-off-contract"
 
-customer_benefits_record_form_url: "http://ccs-agreements.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Benefits%20Record_4.docx"
+customer_benefits_record_form_url: "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.11-Customer-benefits-record-v3.docx"
 
 customer_benefits_record_form_email: "gcloud-benefits@crowncommercial.gov.uk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.1.1",
+  "version": "16.1.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/J16FwsPb/939-customer-benefits-records-form-link

To replace the broken link in the G-Cloud saved search page (section 5 here https://www.digitalmarketplace.service.gov.uk/buyers/direct-award/g-cloud/start).