### PR TITLE
Fix PlanningService G-Cloud search mapping

### DIFF
--- a/frameworks/g-cloud-11/questions/services/serviceCategoriesSupport.yml
+++ b/frameworks/g-cloud-11/questions/services/serviceCategoriesSupport.yml
@@ -12,7 +12,7 @@ number_of_items: 6
 options:
   - label: Planning
     derived_from:
-      question: setupAndMigrationService
+      question: planningService
       any_of:
         - true
   - label: Setup and migration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.1.2",
+  "version": "16.1.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/li12EojM/62-g-cloud-search-results-mapping-is-mis-categorising-a-filter

Part of the G-Cloud search mapping is generated from the `serviceCategories` question. A typo in this content has led to the `planningService` category being mapped to `setupAndMigrationService` services. 

Tested by running `./scripts/generate-search-config.py g-cloud-11 services`, which generates the correct mapping. This will be committed to the Search API in a separate PR (incoming!).  