### PR TITLE
Remove Yarn in favour of npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+# Node stuff
+node_modules
+
+# Python stuff
 __pycache__
 *.pyc
 .hypothesis/eval_source
 venv*
-local.nix
 .cache
+
+# Nix stuff
+local.nix

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version false

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,0 @@
-version-git-tag false
-

--- a/README.md
+++ b/README.md
@@ -170,16 +170,16 @@ Development
 -----------
 
 A local checkout of the frameworks repo can be shared with locally-running services (i.e. frontend applications)
-as follows, assuming you have a system-wide install of yarn available:
+as follows:
 
-- from this repo, run `yarn link`
-- from each app, run `yarn link digitalmarketplace-frameworks`
+- from this repo, run `npm link`
+- from each app, run `npm link digitalmarketplace-frameworks`
 
 Your frontend apps will then be using your local copy of the framework data rather than the version specified
 in their `package.json` - for example, whenever you:
 
  - rebuild the app's `content` directory by running `make frontend_build`; or
- - run `yarn run frontend-build:watch` to automatically rebuild the framework content whenever a framework YML file
+ - run `npm run frontend-build:watch` to automatically rebuild the framework content whenever a framework YML file
    changes.
 
 Don't forget that you may also need to generate schemas into the API's `json_schema` directory using the
@@ -210,8 +210,8 @@ Releases of this project follow [semantic versioning](http://semver.org/), ie
 > - PATCH version when you make backwards-compatible bug fixes.
 
 To make a new version:
-- run `yarn version` to update the version number;
-- (note that yarn has been configured **not** to create a new tag when you run this command - see `.yarnrc`)
+- run `npm version` to update the version number;
+- (note that npm has been configured **not** to create a new tag when you run this command - see `.npmrc`)
 - if you are making a major change, also update the change log;
 - commit `package.json` and `CHANGELOG.md` if appropriate - for a small PR, this could be in the same commit as other
   changes you are making; for a larger PR you might want a separate commit with a message that summarises the entire PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "digitalmarketplace-frameworks",
+  "version": "16.1.3",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
We do not need to depend on Yarn as npm is Nodes default package manager and we use npm to install yarn. npm does everything yarn does now.

This commit mainly updates the manual but it also replaces `.yarnrc` with `.npmrc`.

Trello ticket: https://trello.com/c/RrpjQDJi/278-replace-yarn-with-npm