### PR TITLE
Increase word lengths for some buyer questions

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
@@ -7,7 +7,7 @@ question_advice: |
   Include any important dates. You must say if you need the work to be done by a certain date.
   This will help suppliers understand any time constraints.
 type: textbox_large
-max_length_in_words: 100
+max_length_in_words: 200
 depends:
   - "on": "lot"
     being:
@@ -18,5 +18,5 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Your answer must be no more than 200 words.'
 empty_message: Describe why the work is being done

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
@@ -17,6 +17,6 @@ validations:
     name: answer_required
     message: 'You need to answer this question.'
   -
-    name: under_100_words
+    name: under_200_words
     message: 'Your answer must be no more than 200 words.'
 empty_message: Describe why the work is being done

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
@@ -11,7 +11,7 @@ question_advice: |
 
   eg As a carer, I need to know if I can get Carer’s Allowance, so that I know if I should apply for it or not.
 type: textbox_large
-max_length_in_words: 100
+max_length_in_words: 200
 depends:
   - "on": "lot"
     being:
@@ -22,5 +22,5 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Your answer must be no more than 200 words.'
 empty_message: Describe the users and their needs

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
@@ -21,6 +21,6 @@ validations:
     name: answer_required
     message: 'You need to answer this question.'
   -
-    name: under_100_words
+    name: under_200_words
     message: 'Your answer must be no more than 200 words.'
 empty_message: Describe the users and their needs

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
@@ -12,6 +12,6 @@ validations:
     name: answer_required
     message: 'You need to answer this question.'
   -
-    name: under_100_words
+    name: under_200_words
     message: 'Your answer must be no more than 200 words.'
 empty_message: Describe problem

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
@@ -2,7 +2,7 @@ name: Problem to be solved
 question: Problem to be solved
 question_advice: eg patients can’t access their medical records
 type: textbox_large
-max_length_in_words: 100
+max_length_in_words: 200
 depends:
   - "on": "lot"
     being:
@@ -13,5 +13,5 @@ validations:
     message: 'You need to answer this question.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Your answer must be no more than 200 words.'
 empty_message: Describe problem

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.1.3",
+  "version": "16.3.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.2.0",
+  "version": "16.3.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/YELMUI7V/316-buyer-questions-should-have-longer-word-limit

3 buyer questions have been updated:

`Why the work is being done`
`Who the users are and what they need to do`
`Problem to be solved`

Will require a corresponding PR in the API (still in progress) to provide the correct validation (it will return the new error type `under_200_words`).

![word-count-over-200](https://user-images.githubusercontent.com/3492540/65517881-506c7500-dedb-11e9-913f-6a00e56a82de.png)
