### PR TITLE
Remove customer benefits record email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Records breaking changes from major version bumps
 
+## 17.0.0
+
+Removes the customer benefits record email from G-Cloud 11 manifest, as this is no longer used by CCS. This was only
+used in the G-Cloud Direct Award flow in the Buyer Frontend.
+
 ## 16.0.0
 
 Removes the Documents section from the `display_service` G-Cloud 10 and G-Cloud 11 manifests. This will be replaced

--- a/frameworks/g-cloud-11/messages/urls.yml
+++ b/frameworks/g-cloud-11/messages/urls.yml
@@ -7,5 +7,3 @@ supplier_guide_url: "https://www.gov.uk/guidance/g-cloud-suppliers-guide#how-to-
 call_off_contract_url: "https://www.gov.uk/government/publications/g-cloud-11-call-off-contract"
 
 customer_benefits_record_form_url: "https://forms.gle/ir3a77A5knkUuiJ38"
-
-customer_benefits_record_form_email: "gcloud-benefits@crowncommercial.gov.uk"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.4.0",
+  "version": "17.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "16.4.0",
+  "version": "17.0.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Ticket: https://trello.com/c/nY41xU2U/105-modify-copy-and-change-url-for-customer-benefits-record-form

CCS no longer use this email address (customer benefit records are now submitted via Google Form, see #595), so we can remove this metadata from the G-Cloud framework.