### PR TITLE
Enable Travis checks for Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install -r requirements-dev.txt
 script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 flake8==3.7.7
-hypothesis==1.18.1
+hypothesis==4.48.0
 jsonschema==3.0.0
 mock==2.0.0
-pytest==3.2.5
+pytest==4.6.3
 PyYAML==5.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 -r requirements.txt
-flake8==3.5.0
-flake8-per-file-ignores==0.4.0
+flake8==3.7.7
 hypothesis==1.18.1
 jsonschema==3.0.0
 mock==2.0.0
 pytest==3.2.5
-PyYAML==3.11
+PyYAML==5.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.4.0
-git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.2.0#egg=digitalmarketplace-utils==46.2.0
+git+https://github.com/madzak/python-json-logger.git@v0.1.11#egg=python-json-logger==v0.1.11
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.1.0#egg=digitalmarketplace-utils==50.1.0

--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -3,7 +3,6 @@ import re
 import json
 from dmcontent import ContentLoader
 
-
 MANIFESTS = {
     'services': {
         'question_set': 'services',
@@ -23,7 +22,6 @@ MANIFESTS = {
     },
 }
 
-
 LEGACY_GCLOUD_LOTS = [
     ('scs', 'SCS'), ('iaas', 'IaaS'), ('paas', 'PaaS'), ('saas', 'SaaS')
 ]
@@ -38,7 +36,6 @@ DOS_LOTS = [
     ('user-research-participants', 'User research participants'),
     ('user-research-studios', 'User research studios')
 ]
-
 
 FRAMEWORKS_AND_LOTS = {
     "g-cloud": [
@@ -547,7 +544,7 @@ def parse_question_limits(question, for_items=False):
     limits = {}
     word_length_validator = next(
         iter(filter(None, (
-            re.match('under_(\d+)_words', validator['name'])
+            re.match(r'under_(\d+)_words', validator['name'])
             for validator in question.get('validations', [])
         ))),
         None
@@ -561,8 +558,9 @@ def parse_question_limits(question, for_items=False):
         None
     )
 
-    char_length = question.get('max_length') or (char_length_validator and
-                                                 char_length_validator.group(1).replace(',', ''))
+    char_length = question.get('max_length') or (
+        char_length_validator and char_length_validator.group(1).replace(',', '')
+    )
     word_length = question.get('max_length_in_words') or (word_length_validator and word_length_validator.group(1))
 
     if char_length:

--- a/tests/test_generate_validation_schema.py
+++ b/tests/test_generate_validation_schema.py
@@ -10,7 +10,7 @@ except ImportError:
 import mock
 import pytest
 from dmcontent import ContentQuestion
-from hypothesis import given, assume, strategies as st
+from hypothesis import settings, given, assume, HealthCheck, strategies as st
 from schema_generator.validation import (
     SCHEMAS,
     boolean_list_property,
@@ -233,6 +233,7 @@ def test_checkbox_property(id, options):
                for option in options if 'value' not in option)
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(st.text(), nested_checkboxes_list(), st.integers())
 def test_checkbox_tree_property(id, options, number_of_items):
     assume(len(id) > 0)

--- a/tests/test_generate_validation_schema.py
+++ b/tests/test_generate_validation_schema.py
@@ -611,13 +611,17 @@ def test_generate_g_cloud_schema_opens_files(opened_files, tmpdir):
     for schema in g_cloud_schemas:
         generate_schema_todir(test_directory, 'services', *schema)
     g_cloud_path = "./frameworks/g-cloud-7"
-    g_cloud_opened_files = set(x for x in opened_files
-                               if x.startswith(g_cloud_path) and
-                               os.path.isfile(x))
-    g_cloud_expected_files = set([x for x in recursive_file_list(g_cloud_path)
-                                  if ("questions/services" in x or
-                                      x.endswith("manifests/edit_submission.yml")) and
-                                  not x.endswith("lot.yml") and not x.endswith("id.yml")])
+    g_cloud_opened_files = set(
+        x for x in opened_files if x.startswith(g_cloud_path) and os.path.isfile(x)
+    )
+    g_cloud_expected_files = set(
+        [
+            x for x in recursive_file_list(g_cloud_path)
+            if ("questions/services" in x or x.endswith("manifests/edit_submission.yml"))
+            and not x.endswith("lot.yml")
+            and not x.endswith("id.yml")
+        ]
+    )
     assert g_cloud_expected_files == g_cloud_opened_files
 
 
@@ -630,10 +634,13 @@ def test_generate_dos_schema_opens_files(opened_files, tmpdir):
     dos_path = "./frameworks/digital-outcomes-and-specialists"
     dos_opened_files = set(x for x in opened_files
                            if x.startswith(dos_path) and os.path.isfile(x))
-    dos_expected_files = set([x for x in recursive_file_list(dos_path)
-                              if ("questions/services" in x or
-                                  x.endswith("manifests/edit_submission.yml")) and
-                              not x.endswith("lot.yml")])
+    dos_expected_files = set(
+        [
+            x for x in recursive_file_list(dos_path)
+            if ("questions/services" in x or x.endswith("manifests/edit_submission.yml"))
+            and not x.endswith("lot.yml")
+        ]
+    )
     assert dos_expected_files == dos_opened_files
 
 

--- a/tests/test_generate_validation_schema.py
+++ b/tests/test_generate_validation_schema.py
@@ -90,12 +90,12 @@ def nested_checkboxes(draw, options_list_strategy=None,
 
 def nested_checkboxes_list():
     def create_options_with_children(list_strategy):
-        return st.lists(nested_checkboxes(options_list_strategy=list_strategy))
+        return st.lists(nested_checkboxes(options_list_strategy=list_strategy), max_size=25)
 
     return st.recursive(
         st.lists(nested_checkboxes()),
         create_options_with_children,
-        max_leaves=15
+        max_leaves=10
     )
 
 

--- a/tests/test_generate_validation_schema.py
+++ b/tests/test_generate_validation_schema.py
@@ -10,7 +10,6 @@ except ImportError:
 import mock
 import pytest
 from dmcontent import ContentQuestion
-from hypothesis.settings import Settings
 from hypothesis import given, assume, strategies as st
 from schema_generator.validation import (
     SCHEMAS,
@@ -32,8 +31,6 @@ from schema_generator.validation import (
     text_property,
     uri_property,
 )
-
-Settings.default.database = None
 
 
 @pytest.fixture()


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Enabled Travis checks for 3.7 and 3.8
- Bumps content loader, utils and python-json-logger
- Updated PyYaml and flake8 (some minor whitespace fixes needed)

Also had to bump one of our test utils, `hypothesis` (and `pytest`). We were three major version bumps behind, and there were a lot of breaking changes. However our test data generation for this repo is pretty simple, so it worked with a few tweaks. For one test I did have to bump down the max size and suppress a warning about it being too slow to get it to work on all three Python versions, but I don't think that's a huge problem (happy to be convinced otherwise).