### PR TITLE
Helper script for cloning framework content from a previous iteration

### DIFF
--- a/script_helpers/clone_helpers.py
+++ b/script_helpers/clone_helpers.py
@@ -36,7 +36,13 @@ class FrameworkContentCloner:
     def __init__(self, framework_family, iteration_number, launch_year):
         self._launch_year = launch_year
         self._new_fw_slug = f"{framework_family}-{iteration_number}"
-        self._previous_fw_slug = f"{framework_family}-{iteration_number - 1}"
+        if iteration_number == 2:
+            # Handle first iterations without numeric suffix (e.g. DOS 2 -> DOS)
+            self._previous_fw_slug = f"{framework_family}"
+        elif iteration_number < 2:
+            raise ValueError("Can't clone a framework on its first iteration")
+        else:
+            self._previous_fw_slug = f"{framework_family}-{iteration_number - 1}"
         self._following_fw_slug = f"{framework_family}-{iteration_number + 1}"
 
         self._previous_name = get_fw_name_from_slug(self._previous_fw_slug)

--- a/script_helpers/clone_helpers.py
+++ b/script_helpers/clone_helpers.py
@@ -1,3 +1,21 @@
+import os
+import sys
+import shutil
+import yaml
+
+
+METADATA_FILES = {
+    'copy_services': 'copy_services.yml',
+    'following_framework': 'following_framework.yml',
+    'bad_words': 'service_questions_to_scan_for_bad_words.yml'
+}
+
+DATES_FILES = {
+    'application_deadline': 'messages/homepage-sidebar.yml',
+    'clarification_deadline': 'questions/declaration/understandHowToAskQuestions.yml',
+    'go_live': 'questions/declaration/canProvideFromDayOne.yml'
+}
+
 
 def get_fw_name_from_slug(fw_slug):
     # Hack for G-Cloud which helpfully contains a dash
@@ -11,3 +29,124 @@ def get_nbsp_fw_name_from_slug(fw_slug):
     name = get_fw_name_from_slug(fw_slug)
     last_space_position = name.rindex(" ")
     return name[:last_space_position] + "&nbsp;" + name[(last_space_position + 1):]
+
+
+class FrameworkContentCloner:
+
+    def __init__(self, framework_family, iteration_number, launch_year):
+        self._launch_year = launch_year
+        self._new_fw_slug = f"{framework_family}-{iteration_number}"
+        self._previous_fw_slug = f"{framework_family}-{iteration_number - 1}"
+        self._following_fw_slug = f"{framework_family}-{iteration_number + 1}"
+
+        self._previous_name = get_fw_name_from_slug(self._previous_fw_slug)
+        self._new_name = get_fw_name_from_slug(self._new_fw_slug)
+        self._previous_nbsp_name = get_nbsp_fw_name_from_slug(self._previous_fw_slug)
+        # Hack for G-Cloud (or should we say, 'G&#x2011;Cloud')
+        self._escaped_previous_nbsp_name = get_nbsp_fw_name_from_slug(self._previous_fw_slug).replace("-", "&#x2011;")
+        self._new_nbsp_name = get_nbsp_fw_name_from_slug(self._new_fw_slug)
+
+    def copy_fw_folder(self):
+        previous_fw_folder = os.path.join("frameworks", self._previous_fw_slug)
+        if not os.path.exists(previous_fw_folder):
+            sys.exit(f"No previous framework for iteration {self._previous_fw_slug}")
+
+        print(f"Copying all files from {self._previous_fw_slug} to {self._new_fw_slug}")
+        try:
+            shutil.copytree(previous_fw_folder, os.path.join("frameworks", self._new_fw_slug))
+        except FileExistsError:
+            print("Skipping - folder already exists")
+
+    def _replace_framework_in_content(self, current_content, root, file):
+        updated_content = None
+        if self._previous_name in current_content:
+            updated_content = current_content.replace(self._previous_name, self._new_name)
+            print(f"Replacing framework name in {root}/{file}")
+            # Keep the changes for the next replacement
+            current_content = updated_content
+        if self._previous_nbsp_name in current_content:
+            updated_content = current_content.replace(self._previous_nbsp_name, self._new_nbsp_name)
+            print(f"Replacing framework name (with nbsp) in {root}/{file}")
+            # Keep the changes for the next replacement
+            current_content = updated_content
+        if self._escaped_previous_nbsp_name in current_content:
+            # Hack for G-Cloud which has additional (unnecessary) escaping in some files
+            updated_content = current_content.replace(self._escaped_previous_nbsp_name, self._new_nbsp_name)
+            print(f"Replacing escaped framework name (with nbsp) in {root}/{file}")
+            # Keep the changes for the next replacement
+            current_content = updated_content
+        if self._previous_fw_slug in current_content:
+            updated_content = current_content.replace(self._previous_fw_slug, self._new_fw_slug)
+            print(f"Replacing framework slug in {root}/{file}")
+
+        # If we return updated_content = None, we know that no changes have been made
+        return updated_content
+
+    def replace_hardcoded_framework_name_and_slug(self):
+        new_fw_root = os.path.join('frameworks', self._new_fw_slug)
+        for root, dirs, files in os.walk(new_fw_root, topdown=True):
+            if 'metadata' in root:
+                # Metadata is updated separately
+                continue
+            for file in files:
+                with open(os.path.join(root, file), 'r') as f:
+                    current_content = f.read()
+                    updated_content = self._replace_framework_in_content(current_content, root, file)
+                # Only write if there's been a change
+                if updated_content:
+                    with open(os.path.join(root, file), 'w') as f:
+                        f.write(updated_content)
+
+    def update_metadata(self):
+        print("Setting metadata")
+        # Set copy_services.yml content
+        copy_services_file = os.path.join(
+            "frameworks", self._new_fw_slug, 'metadata', METADATA_FILES['copy_services']
+        )
+        with open(copy_services_file) as f:
+            content = yaml.safe_load(f)
+            # TODO: preserve ordering
+            new_content = {
+                'source_framework': self._previous_fw_slug,
+                'questions_to_copy': content['questions_to_copy']
+            }
+
+        with open(copy_services_file, 'w') as f:
+            print(f"Writing content to {copy_services_file}")
+            yaml.dump(new_content, f)
+
+        # Set following_framework.yml content
+        following_fw_file = os.path.join(
+            "frameworks", self._new_fw_slug, 'metadata', METADATA_FILES['following_framework']
+        )
+        with open(following_fw_file) as f:
+            content = yaml.safe_load(f)
+            new_content = {
+                'framework': {
+                    'slug': self._following_fw_slug,
+                    'name': get_fw_name_from_slug(self._following_fw_slug),
+                    'coming': str(int(content['framework']['coming']) + 1)
+                }
+            }
+        with open(following_fw_file, 'w') as f:
+            print(f"Writing content to {following_fw_file}")
+            yaml.dump(new_content, f)
+
+    def update_dates(self):
+        print("Setting important dates to 2525")
+        for key, file_path in DATES_FILES.items():
+            full_file_path = os.path.join("frameworks", self._new_fw_slug, file_path)
+
+            with open(full_file_path, 'r') as f:
+                current_content = f.read()
+                updated_content = current_content.replace(str(self._launch_year - 1), '2525')
+
+            with open(full_file_path, 'w') as f:
+                print(f"Writing content to {file_path}")
+                f.write(updated_content)
+
+    def clone(self):
+        self.copy_fw_folder()
+        self.replace_hardcoded_framework_name_and_slug()
+        self.update_metadata()
+        self.update_dates()

--- a/script_helpers/clone_helpers.py
+++ b/script_helpers/clone_helpers.py
@@ -63,27 +63,27 @@ class FrameworkContentCloner:
         except FileExistsError:
             print("Skipping - folder already exists")
 
-    def _replace_framework_in_content(self, current_content, root, file):
+    def _replace_framework_in_content(self, current_content, root, filename):
         updated_content = None
         if self._previous_name in current_content:
             updated_content = current_content.replace(self._previous_name, self._new_name)
-            print(f"Replacing framework name in {root}/{file}")
+            print(f"Replacing framework name in {root}/{filename}")
             # Keep the changes for the next replacement
             current_content = updated_content
         if self._previous_nbsp_name in current_content:
             updated_content = current_content.replace(self._previous_nbsp_name, self._new_nbsp_name)
-            print(f"Replacing framework name (with nbsp) in {root}/{file}")
+            print(f"Replacing framework name (with nbsp) in {root}/{filename}")
             # Keep the changes for the next replacement
             current_content = updated_content
         if self._escaped_previous_nbsp_name in current_content:
             # Hack for G-Cloud which has additional (unnecessary) escaping in some files
             updated_content = current_content.replace(self._escaped_previous_nbsp_name, self._new_nbsp_name)
-            print(f"Replacing escaped framework name (with nbsp) in {root}/{file}")
+            print(f"Replacing escaped framework name (with nbsp) in {root}/{filename}")
             # Keep the changes for the next replacement
             current_content = updated_content
         if self._previous_fw_slug in current_content:
             updated_content = current_content.replace(self._previous_fw_slug, self._new_fw_slug)
-            print(f"Replacing framework slug in {root}/{file}")
+            print(f"Replacing framework slug in {root}/{filename}")
 
         # If we return updated_content = None, we know that no changes have been made
         return updated_content
@@ -94,13 +94,13 @@ class FrameworkContentCloner:
             if 'metadata' in root:
                 # Metadata is updated separately
                 continue
-            for file in files:
-                with open(os.path.join(root, file), 'r') as f:
+            for filename in files:
+                with open(os.path.join(root, filename), 'r') as f:
                     current_content = f.read()
-                    updated_content = self._replace_framework_in_content(current_content, root, file)
+                    updated_content = self._replace_framework_in_content(current_content, root, filename)
                 # Only write if there's been a change
                 if updated_content:
-                    with open(os.path.join(root, file), 'w') as f:
+                    with open(os.path.join(root, filename), 'w') as f:
                         f.write(updated_content)
 
     def update_metadata(self):

--- a/script_helpers/clone_helpers.py
+++ b/script_helpers/clone_helpers.py
@@ -1,0 +1,13 @@
+
+def get_fw_name_from_slug(fw_slug):
+    # Hack for G-Cloud which helpfully contains a dash
+    # Hack for Digital Outcomes and Specialists which contains a lower-case 'and'
+    return fw_slug.replace('-', ' ').replace('g cloud', 'G-Cloud').title().replace('And', 'and')
+
+
+def get_nbsp_fw_name_from_slug(fw_slug):
+    # Some places use G-Cloud&bsp;11 for non-breaking spaces
+    # Get the last space and 'replace' it
+    name = get_fw_name_from_slug(fw_slug)
+    last_space_position = name.rindex(" ")
+    return name[:last_space_position] + "&nbsp;" + name[(last_space_position + 1):]

--- a/scripts/clone-latest-framework.py
+++ b/scripts/clone-latest-framework.py
@@ -14,7 +14,6 @@ Usage:
 Example:
     ./scripts/clone-latest-framework.py --family=g-cloud --iteration=12 --launch-year=2020
 """
-import os
 import sys
 sys.path.insert(0, '.')
 from docopt import docopt
@@ -22,7 +21,6 @@ from script_helpers.clone_helpers import FrameworkContentCloner
 
 
 if __name__ == '__main__':
-    current_dir = os.path.dirname(__file__)
     arguments = docopt(__doc__)
     framework_family = arguments['--family']
     if framework_family not in ('g-cloud', 'digital-outcomes-and-specialists'):

--- a/scripts/clone-latest-framework.py
+++ b/scripts/clone-latest-framework.py
@@ -27,18 +27,60 @@ METADATA_FILES = {
 
 
 def get_fw_name_from_slug(fw_slug):
-    return fw_slug.replace('-', ' ').title()
+    # Hack for G-Cloud which helpfully contains a dash
+    return fw_slug.replace('-', ' ').replace('g cloud', 'G-Cloud').title()
 
 
-def update_metadata(previous_fw, new_fw, following_fw):
+def get_nbsp_fw_name_from_slug(fw_slug):
+    # Some places use G-Cloud&bsp;11 for non-breaking spaces
+    return get_fw_name_from_slug(fw_slug).replace(" ", "&nbsp;")
+
+
+def replace_framework_in_content(current_content, root, file):
+    updated_content = None
+    if previous_name in current_content:
+        updated_content = current_content.replace(previous_name, new_name)
+        print(f"Replacing framework name in {root}/{file}")
+        # Keep the changes for the next replacement
+        current_content = updated_content
+    if previous_nbsp_name in current_content:
+        updated_content = current_content.replace(previous_nbsp_name, new_nbsp_name)
+        print(f"Replacing framework name (with nbsp) in {root}/{file}")
+        # Keep the changes for the next replacement
+        current_content = updated_content
+    if previous_fw_slug in current_content:
+        updated_content = current_content.replace(previous_fw_slug, new_fw_slug)
+        print(f"Replacing framework slug in {root}/{file}")
+
+    # If we return updated_content = None, we know that no changes have been made
+    return updated_content
+
+
+def replace_hardcoded_framework_name_and_slug():
+    new_fw_root = os.path.join('frameworks', new_fw_slug)
+    for root, dirs, files in os.walk(new_fw_root, topdown=True):
+        if 'metadata' in root:
+            # Metadata is updated separately
+            continue
+        for file in files:
+            with open(os.path.join(root, file), 'r') as f:
+                current_content = f.read()
+                updated_content = replace_framework_in_content(current_content, root, file)
+            # Only write if there's been a change
+            if updated_content:
+                with open(os.path.join(root, file), 'w') as f:
+                    f.write(updated_content)
+
+
+def update_metadata():
     print("Setting metadata")
     # Set copy_services.yml content
-    copy_services_file = os.path.join("frameworks", new_fw, 'metadata', METADATA_FILES['copy_services'])
+    copy_services_file = os.path.join("frameworks", new_fw_slug, 'metadata', METADATA_FILES['copy_services'])
     with open(copy_services_file) as f:
         content = yaml.safe_load(f)
         # TODO: preserve ordering
         new_content = {
-            'source_framework': previous_fw,
+            'source_framework': previous_fw_slug,
             'questions_to_copy': content['questions_to_copy']
         }
 
@@ -46,13 +88,13 @@ def update_metadata(previous_fw, new_fw, following_fw):
         yaml.dump(new_content, f)
 
     # Set following_framework.yml content
-    following_fw_file = os.path.join("frameworks", new_fw, 'metadata', METADATA_FILES['following_framework'])
+    following_fw_file = os.path.join("frameworks", new_fw_slug, 'metadata', METADATA_FILES['following_framework'])
     with open(following_fw_file) as f:
         content = yaml.safe_load(f)
         new_content = {
             'framework': {
-                'slug': following_fw,
-                'name': get_fw_name_from_slug(following_fw),
+                'slug': following_fw_slug,
+                'name': get_fw_name_from_slug(following_fw_slug),
                 'coming': str(int(content['framework']['coming']) + 1)
             }
         }
@@ -60,14 +102,14 @@ def update_metadata(previous_fw, new_fw, following_fw):
         yaml.dump(new_content, f)
 
 
-def copy_fw_folder(previous_fw, new_fw):
-    previous_fw_folder = os.path.join("frameworks", previous_fw)
+def copy_fw_folder():
+    previous_fw_folder = os.path.join("frameworks", previous_fw_slug)
     if not os.path.exists(previous_fw_folder):
-        sys.exit(f"No previous framework for iteration {previous_fw}")
+        sys.exit(f"No previous framework for iteration {previous_fw_slug}")
 
-    print(f"Copying all files from {previous_fw} to {new_fw}")
+    print(f"Copying all files from {previous_fw_slug} to {new_fw_slug}")
     try:
-        shutil.copytree(previous_fw_folder, os.path.join("frameworks", new_fw))
+        shutil.copytree(previous_fw_folder, os.path.join("frameworks", new_fw_slug))
     except FileExistsError:
         print("Skipping - folder exists")
 
@@ -81,9 +123,15 @@ if __name__ == '__main__':
 
     iteration_number = int(arguments['--iteration'])
 
-    new_fw = f"{framework_family}-{iteration_number}"
-    previous_fw = f"{framework_family}-{iteration_number - 1}"
-    following_fw = f"{framework_family}-{iteration_number + 1}"
+    # Set all the strings up front: framework slug, name and non-breaking-space name
+    new_fw_slug = f"{framework_family}-{iteration_number}"
+    previous_fw_slug = f"{framework_family}-{iteration_number - 1}"
+    following_fw_slug = f"{framework_family}-{iteration_number + 1}"
+    previous_name = get_fw_name_from_slug(previous_fw_slug)
+    new_name = get_fw_name_from_slug(new_fw_slug)
+    previous_nbsp_name = get_nbsp_fw_name_from_slug(previous_fw_slug)
+    new_nbsp_name = get_nbsp_fw_name_from_slug(new_fw_slug)
 
-    copy_fw_folder(previous_fw, new_fw)
-    update_metadata(previous_fw, new_fw, following_fw)
+    copy_fw_folder()
+    replace_hardcoded_framework_name_and_slug()
+    update_metadata()

--- a/scripts/clone-latest-framework.py
+++ b/scripts/clone-latest-framework.py
@@ -16,9 +16,11 @@ Example:
 """
 import os
 import sys
+sys.path.insert(0, '.')
 import shutil
 import yaml
 from docopt import docopt
+from script_helpers.clone_helpers import get_nbsp_fw_name_from_slug, get_fw_name_from_slug
 
 
 METADATA_FILES = {
@@ -32,20 +34,6 @@ DATES_FILES = {
     'clarification_deadline': 'questions/declaration/understandHowToAskQuestions.yml',
     'go_live': 'questions/declaration/canProvideFromDayOne.yml'
 }
-
-
-def get_fw_name_from_slug(fw_slug):
-    # Hack for G-Cloud which helpfully contains a dash
-    # Hack for Digital Outcomes and Specialists which contains a lower-case 'and'
-    return fw_slug.replace('-', ' ').replace('g cloud', 'G-Cloud').title().replace('And', 'and')
-
-
-def get_nbsp_fw_name_from_slug(fw_slug):
-    # Some places use G-Cloud&bsp;11 for non-breaking spaces
-    # Get the last space and 'replace' it
-    name = get_fw_name_from_slug(fw_slug)
-    last_space_position = name.rindex(" ")
-    return name[:last_space_position] + "&nbsp;" + name[(last_space_position + 1):]
 
 
 def replace_framework_in_content(current_content, root, file):

--- a/scripts/clone-latest-framework.py
+++ b/scripts/clone-latest-framework.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Clone a new framework, based on the latest iteration, into the same level directory.
+
+- Finds the last iteration of the given framework family type
+- Copies all content to a new folder
+- Update metadata
+- Update hardcoded content of framework name in declaration questions 'G-Cloud 11', 'G-Cloud&nsbp;11'
+- Update hardcoded content of framework slug in urls, declaration
+- Set any dates to a point in the far-future e.g. 1 Jan 2525
+
+Usage:
+    clone-latest-framework.py --family=<framework_family> --iteration=<iteration_number>
+
+"""
+import os
+import sys
+import shutil
+from docopt import docopt
+
+
+def main(framework_family, iteration_number):
+    new_fw = f"{framework_family}-{iteration_number}"
+    previous_fw = f"{framework_family}-{iteration_number - 1}"
+    previous_fw_folder = os.path.join("frameworks", previous_fw)
+
+    if not os.path.exists(previous_fw_folder):
+        sys.exit(f"No previous framework for iteration {previous_fw}")
+
+    print(f"Copying all files from {previous_fw} to {new_fw}")
+    try:
+        shutil.copytree(previous_fw_folder, os.path.join("frameworks", new_fw))
+    except FileExistsError:
+        print("Skipping - folder exists")
+
+
+if __name__ == '__main__':
+    current_dir = os.path.dirname(__file__)
+    arguments = docopt(__doc__)
+    framework_family = arguments['--family']
+    if framework_family not in ('g-cloud', 'digital-outcomes-and-specialists'):
+        sys.exit('Invalid framework family - must be g-cloud or digital-outcomes-and-specialists')
+
+    iteration_number = int(arguments['--iteration'])
+    main(framework_family, iteration_number)

--- a/scripts/clone-latest-framework.py
+++ b/scripts/clone-latest-framework.py
@@ -17,122 +17,8 @@ Example:
 import os
 import sys
 sys.path.insert(0, '.')
-import shutil
-import yaml
 from docopt import docopt
-from script_helpers.clone_helpers import get_nbsp_fw_name_from_slug, get_fw_name_from_slug
-
-
-METADATA_FILES = {
-    'copy_services': 'copy_services.yml',
-    'following_framework': 'following_framework.yml',
-    'bad_words': 'service_questions_to_scan_for_bad_words.yml'
-}
-
-DATES_FILES = {
-    'application_deadline': 'messages/homepage-sidebar.yml',
-    'clarification_deadline': 'questions/declaration/understandHowToAskQuestions.yml',
-    'go_live': 'questions/declaration/canProvideFromDayOne.yml'
-}
-
-
-def replace_framework_in_content(current_content, root, file):
-    updated_content = None
-    if previous_name in current_content:
-        updated_content = current_content.replace(previous_name, new_name)
-        print(f"Replacing framework name in {root}/{file}")
-        # Keep the changes for the next replacement
-        current_content = updated_content
-    if previous_nbsp_name in current_content:
-        updated_content = current_content.replace(previous_nbsp_name, new_nbsp_name)
-        print(f"Replacing framework name (with nbsp) in {root}/{file}")
-        # Keep the changes for the next replacement
-        current_content = updated_content
-    if escaped_previous_nbsp_name in current_content:
-        # Hack for G-Cloud which has additional (unnecessary) escaping in some files
-        updated_content = current_content.replace(escaped_previous_nbsp_name, new_nbsp_name)
-        print(f"Replacing escaped framework name (with nbsp) in {root}/{file}")
-        # Keep the changes for the next replacement
-        current_content = updated_content
-    if previous_fw_slug in current_content:
-        updated_content = current_content.replace(previous_fw_slug, new_fw_slug)
-        print(f"Replacing framework slug in {root}/{file}")
-
-    # If we return updated_content = None, we know that no changes have been made
-    return updated_content
-
-
-def replace_hardcoded_framework_name_and_slug():
-    new_fw_root = os.path.join('frameworks', new_fw_slug)
-    for root, dirs, files in os.walk(new_fw_root, topdown=True):
-        if 'metadata' in root:
-            # Metadata is updated separately
-            continue
-        for file in files:
-            with open(os.path.join(root, file), 'r') as f:
-                current_content = f.read()
-                updated_content = replace_framework_in_content(current_content, root, file)
-            # Only write if there's been a change
-            if updated_content:
-                with open(os.path.join(root, file), 'w') as f:
-                    f.write(updated_content)
-
-
-def update_metadata():
-    print("Setting metadata")
-    # Set copy_services.yml content
-    copy_services_file = os.path.join("frameworks", new_fw_slug, 'metadata', METADATA_FILES['copy_services'])
-    with open(copy_services_file) as f:
-        content = yaml.safe_load(f)
-        # TODO: preserve ordering
-        new_content = {
-            'source_framework': previous_fw_slug,
-            'questions_to_copy': content['questions_to_copy']
-        }
-
-    with open(copy_services_file, 'w') as f:
-        print(f"Writing content to {copy_services_file}")
-        yaml.dump(new_content, f)
-
-    # Set following_framework.yml content
-    following_fw_file = os.path.join("frameworks", new_fw_slug, 'metadata', METADATA_FILES['following_framework'])
-    with open(following_fw_file) as f:
-        content = yaml.safe_load(f)
-        new_content = {
-            'framework': {
-                'slug': following_fw_slug,
-                'name': get_fw_name_from_slug(following_fw_slug),
-                'coming': str(int(content['framework']['coming']) + 1)
-            }
-        }
-    with open(following_fw_file, 'w') as f:
-        print(f"Writing content to {following_fw_file}")
-        yaml.dump(new_content, f)
-
-
-def update_dates():
-    print("Setting important dates to 2525")
-    for key, file_path in DATES_FILES.items():
-        full_file_path = os.path.join("frameworks", new_fw_slug, file_path)
-
-        with open(full_file_path, 'r') as f:
-            current_content = f.read()
-            updated_content = current_content.replace(str(launch_year - 1), '2525')
-
-        with open(full_file_path, 'w') as f:
-            print(f"Writing content to {file_path}")
-            f.write(updated_content)
-
-def copy_fw_folder():
-    previous_fw_folder = os.path.join("frameworks", previous_fw_slug)
-    if not os.path.exists(previous_fw_folder):
-        sys.exit(f"No previous framework for iteration {previous_fw_slug}")
-
-    print(f"Copying all files from {previous_fw_slug} to {new_fw_slug}")
-    try:
-        shutil.copytree(previous_fw_folder, os.path.join("frameworks", new_fw_slug))
-    except FileExistsError:
-        print("Skipping - folder exists")
+from script_helpers.clone_helpers import FrameworkContentCloner
 
 
 if __name__ == '__main__':
@@ -145,18 +31,5 @@ if __name__ == '__main__':
     iteration_number = int(arguments['--iteration'])
     launch_year = int(arguments['--launch-year'])
 
-    # Set all the strings up front: framework slug, name and non-breaking-space name
-    new_fw_slug = f"{framework_family}-{iteration_number}"
-    previous_fw_slug = f"{framework_family}-{iteration_number - 1}"
-    following_fw_slug = f"{framework_family}-{iteration_number + 1}"
-    previous_name = get_fw_name_from_slug(previous_fw_slug)
-    new_name = get_fw_name_from_slug(new_fw_slug)
-    previous_nbsp_name = get_nbsp_fw_name_from_slug(previous_fw_slug)
-    # Hack for G-Cloud (or should we say, 'G&#x2011;Cloud')
-    escaped_previous_nbsp_name = get_nbsp_fw_name_from_slug(previous_fw_slug).replace("-", "&#x2011;")
-    new_nbsp_name = get_nbsp_fw_name_from_slug(new_fw_slug)
-
-    copy_fw_folder()
-    replace_hardcoded_framework_name_and_slug()
-    update_metadata()
-    update_dates()
+    cloner = FrameworkContentCloner(framework_family, iteration_number, launch_year)
+    cloner.clone()

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -1,3 +1,4 @@
+import pytest
 from script_helpers.clone_helpers import get_fw_name_from_slug, get_nbsp_fw_name_from_slug, FrameworkContentCloner
 
 
@@ -23,5 +24,16 @@ def test_framework_content_cloner_init():
     assert cloner._previous_nbsp_name == 'G-Cloud&nbsp;11'
     assert cloner._escaped_previous_nbsp_name == 'G&#x2011;Cloud&nbsp;11'
     assert cloner._new_nbsp_name == 'G-Cloud&nbsp;12'
+
+
+def test_framework_content_cloner_init_for_second_iteration():
+    cloner = FrameworkContentCloner('digital-outcomes-and-specialists', 2, 2017)
+    assert cloner._previous_fw_slug == 'digital-outcomes-and-specialists'
+
+
+def test_framework_content_cloner_init_fails_for_first_iteration():
+    with pytest.raises(ValueError) as exc:
+        FrameworkContentCloner('digital-outcomes-and-specialists', 1, 2016)
+    assert str(exc.value) == "Can't clone a framework on its first iteration"
 
 # TODO: add test coverage for file copying/replacement :)

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -1,4 +1,4 @@
-from script_helpers.clone_helpers import get_fw_name_from_slug, get_nbsp_fw_name_from_slug
+from script_helpers.clone_helpers import get_fw_name_from_slug, get_nbsp_fw_name_from_slug, FrameworkContentCloner
 
 
 def test_get_fw_name_from_slug():
@@ -9,3 +9,19 @@ def test_get_fw_name_from_slug():
 def test_get_nbsp_fw_name_from_slug():
     assert get_nbsp_fw_name_from_slug('g-cloud-11') == 'G-Cloud&nbsp;11'
     assert get_nbsp_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists&nbsp;4'
+
+
+def test_framework_content_cloner_init():
+    cloner = FrameworkContentCloner('g-cloud', 12, 2020)
+    assert cloner._launch_year == 2020
+    assert cloner._new_fw_slug == 'g-cloud-12'
+    assert cloner._previous_fw_slug == 'g-cloud-11'
+    assert cloner._following_fw_slug == 'g-cloud-13'
+
+    assert cloner._previous_name == 'G-Cloud 11'
+    assert cloner._new_name == 'G-Cloud 12'
+    assert cloner._previous_nbsp_name == 'G-Cloud&nbsp;11'
+    assert cloner._escaped_previous_nbsp_name == 'G&#x2011;Cloud&nbsp;11'
+    assert cloner._new_nbsp_name == 'G-Cloud&nbsp;12'
+
+# TODO: add test coverage for file copying/replacement :)

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -9,4 +9,3 @@ def test_get_fw_name_from_slug():
 def test_get_nbsp_fw_name_from_slug():
     assert get_nbsp_fw_name_from_slug('g-cloud-11') == 'G-Cloud&nbsp;11'
     assert get_nbsp_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists&nbsp;4'
-

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -1,0 +1,12 @@
+from script_helpers.clone_helpers import get_fw_name_from_slug, get_nbsp_fw_name_from_slug
+
+
+def test_get_fw_name_from_slug():
+    assert get_fw_name_from_slug('g-cloud-11') == 'G-Cloud 11'
+    assert get_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists 4'
+
+
+def test_get_nbsp_fw_name_from_slug():
+    assert get_nbsp_fw_name_from_slug('g-cloud-11') == 'G-Cloud&nbsp;11'
+    assert get_nbsp_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists&nbsp;4'
+


### PR DESCRIPTION
Automates some of the initial steps here: https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/adding-frameworks.html#id2

It's verbose/non-DRY in places, to try and keep visibility of the different files being edited.

Tested with G-Cloud 12 and DOS 5, but not exhaustively.

Scope for more unit tests to be added at a later date 😸 