### PR TITLE
assessment schema improvements

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -15,3 +15,5 @@ assessment:
   passIfIn:
     - True
   discretionary: True
+  # actually dependent, but it is not the assessment schema's responsibility to enforce that dependency
+  required: False

--- a/frameworks/g-cloud-11/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/g-cloud-11/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -15,3 +15,5 @@ assessment:
   passIfIn:
     - True
   discretionary: True
+  # actually dependent, but it is not the assessment schema's responsibility to enforce that dependency
+  required: False

--- a/frameworks/g-cloud-12/assessment/declaration/extra.schema.json
+++ b/frameworks/g-cloud-12/assessment/declaration/extra.schema.json
@@ -1,0 +1,14 @@
+{
+    "definitions": {
+        "baseline": {
+            "allOf": [
+                {
+                    "anyOf": [
+                        {"properties": {"servicesHaveOrSupportCloudHostingCloudSoftware": {"enum": ["Yes"]}}},
+                        {"properties": {"servicesHaveOrSupportCloudSupport": {"enum": ["Yes"]}}}
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -15,3 +15,5 @@ assessment:
   passIfIn:
     - True
   discretionary: True
+  # actually dependent, but it is not the assessment schema's responsibility to enforce that dependency
+  required: False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 flake8==3.7.7
 hypothesis==4.48.0
 jsonschema==3.0.0
+deepmerge==0.1.0
 mock==2.0.0
 pytest==4.6.3
 PyYAML==5.1.2

--- a/schema_generator/assessment.py
+++ b/schema_generator/assessment.py
@@ -28,14 +28,12 @@ def generate_schema(framework_slug, question_set, manifest_name):
         elif "passIfIn" in question.get("assessment", {}):
             assessed_questions.append(question)
 
-    discretionary_properties = {
-        question.id: _enum_for_question(question)
-        for question in assessed_questions if question["assessment"].get("discretionary")
-    }
-    baseline_properties = {
-        question.id: _enum_for_question(question)
-        for question in assessed_questions if not question["assessment"].get("discretionary")
-    }
+    discretionary_questions = tuple(q for q in assessed_questions if q["assessment"].get("discretionary"))
+    baseline_questions = tuple(q for q in assessed_questions if not q["assessment"].get("discretionary"))
+
+    # we add all assessed_questions as "required" by default, not because it's the assessment schema's job to
+    # enforce that requirement, but it's a stronger guarantee we keep the content, the tests for this function
+    # and the custom validation in the supplier frontend in agreement with each other.
 
     return {
         "$schema": "http://json-schema.org/draft-07/schema#",  # hardcoded to draft 7 because jsonschema > 3 supports it
@@ -43,14 +41,18 @@ def generate_schema(framework_slug, question_set, manifest_name):
         "type": "object",
         "allOf": [
             {"$ref": "#/definitions/baseline"},
-            {"properties": discretionary_properties},
+            {"properties": {q.id: _enum_for_question(q) for q in discretionary_questions}},
         ],
+        "required": sorted(q.id for q in discretionary_questions if q["assessment"].get("required", True)),
         "definitions": {
             "baseline": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "title": "{} Declaration Assessment Schema (Baseline Schema)".format(framework_slug),
                 "type": "object",
-                "properties": baseline_properties,
+                "allOf": [
+                    {"properties": {q.id: _enum_for_question(q) for q in baseline_questions}},
+                ],
+                "required": sorted(q.id for q in baseline_questions if q["assessment"].get("required", True)),
             },
         },
     }

--- a/schemas/questions.json
+++ b/schemas/questions.json
@@ -313,6 +313,9 @@
         },
         "discretionary": {
           "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/tests/test_generate_assessment_schema.py
+++ b/tests/test_generate_assessment_schema.py
@@ -86,34 +86,88 @@ _g11 = ("g-cloud-11", _definite_pass_g11_declaration)
 _g12 = ("g-cloud-12", _definite_pass_g12_declaration)
 
 
-@pytest.mark.parametrize("declaration_update,use_baseline,should_pass", (
+@pytest.mark.parametrize("fw_slug,base_decl_factory,declaration_update,use_baseline,should_pass", (
     # a definite pass
-    ({}, False, True,),
-    ({}, True, True,),
+    _g11 + ({}, False, True,),
+    _g11 + ({}, True, True,),
+    _g12 + ({}, False, True,),
+    _g12 + ({}, True, True,),
     # pass with arbitrary other, hopefully ignored, fields
-    ({"bullockbefriendingBard": "Bous Stephanoumenos"}, False, True,),
-    ({"bullockbefriendingBard": "Bous Stephanoumenos"}, True, True,),
+    _g11 + ({"bullockbefriendingBard": "Bous Stephanoumenos"}, False, True,),
+    _g11 + ({"bullockbefriendingBard": "Bous Stephanoumenos"}, True, True,),
+    _g12 + ({"bullockbefriendingBard": "Bous Stephanoumenos"}, False, True,),
+    _g12 + ({"bullockbefriendingBard": "Bous Stephanoumenos"}, True, True,),
     # definite fails
-    ({"readUnderstoodGuidance": False}, False, False,),
-    ({"readUnderstoodGuidance": False}, True, False,),
-    ({"employersInsurance": "Through metempsychosis"}, False, False,),
-    ({"employersInsurance": "Through metempsychosis"}, True, False,),
+    _g11 + ({"readUnderstoodGuidance": False}, False, False,),
+    _g11 + ({"readUnderstoodGuidance": False}, True, False,),
+    _g11 + ({"employersInsurance": "Through metempsychosis"}, False, False,),
+    _g11 + ({"employersInsurance": "Through metempsychosis"}, True, False,),
+    _g12 + ({"readUnderstoodGuidance": False}, False, False,),
+    _g12 + ({"readUnderstoodGuidance": False}, True, False,),
+    _g12 + ({"employersInsurance": "Through metempsychosis"}, False, False,),
+    _g12 + ({"employersInsurance": "Through metempsychosis"}, True, False,),
     # discretionary
-    ({"graveProfessionalMisconduct": True}, False, False,),
-    ({"graveProfessionalMisconduct": True}, True, True,),
+    _g11 + ({"graveProfessionalMisconduct": True}, False, False,),
+    _g11 + ({"graveProfessionalMisconduct": True}, True, True,),
+    _g12 + ({"graveProfessionalMisconduct": True}, False, False,),
+    _g12 + ({"graveProfessionalMisconduct": True}, True, True,),
     # Multiquestion discretionary
-    ({"modernSlaveryReportingRequirements": False}, True, True,),
-    ({"modernSlaveryReportingRequirements": False}, False, False,),
+    _g11 + ({"modernSlaveryReportingRequirements": False}, True, True,),
+    _g11 + ({"modernSlaveryReportingRequirements": False}, False, False,),
+    _g12 + ({"modernSlaveryReportingRequirements": False}, True, True,),
+    _g12 + ({"modernSlaveryReportingRequirements": False}, False, False,),
+    # "extra" schema json
+    _g12 + ({"servicesHaveOrSupportCloudHostingCloudSoftware": "No"}, True, False,),
+    _g12 + ({"servicesHaveOrSupportCloudHostingCloudSoftware": "No"}, False, False,),
+    _g12 + ({"servicesHaveOrSupportCloudSupport": "No"}, True, False,),
+    _g12 + ({"servicesHaveOrSupportCloudSupport": "No"}, False, False,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "My organisation isn't submitting cloud hosting (lot 1) or cloud software (lot 2) services",  # noqa
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, True, False,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "My organisation isn't submitting cloud hosting (lot 1) or cloud software (lot 2) services",  # noqa
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, False, False,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "My organisation isn't submitting cloud hosting (lot 1) or cloud software (lot 2) services",  # noqa
+    }, True, True,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "My organisation isn't submitting cloud hosting (lot 1) or cloud software (lot 2) services",  # noqa
+    }, False, True,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, True, True,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, False, True,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "No",
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, True, False,),
+    _g12 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "No",
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, False, False,),
+    # ...whereas g11 doesn't have the extra schema to invalidate this candidate
+    _g11 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "My organisation isn't submitting cloud hosting (lot 1) or cloud software (lot 2) services",  # noqa
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, True, True,),
+    _g11 + ({
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "My organisation isn't submitting cloud hosting (lot 1) or cloud software (lot 2) services",  # noqa
+        "servicesHaveOrSupportCloudSupport": "My organisation isn't submitting cloud support (lot 3) services",
+    }, False, True,),
 ))
-def test_g11_declaration_assessment(declaration_update, use_baseline, should_pass):
-    # these test(s) are a bit funny in that they all make the same call to the function-under-test and then
-    # assert a different thing about the return value, so we could improve on run time if necessary by only performing
-    # the call once if necessary...
-    schema = generate_schema("g-cloud-11", "declaration", "declaration")
+def test_g11_declaration_assessment(fw_slug, base_decl_factory, declaration_update, use_baseline, should_pass):
+    # these test(s) are a bit funny in that they all make the same call to the function-under-test (`generate_schema`)
+    # and then assert a different thing about the return value, so we could improve on run time if necessary by only
+    # performing the call once...
+    schema = generate_schema(fw_slug, "declaration", "declaration")
     if use_baseline:
         schema = schema["definitions"]["baseline"]
 
-    candidate = _definite_pass_g11_declaration()
+    candidate = base_decl_factory()
     candidate.update(declaration_update)
 
     with (_empty_context_manager() if should_pass else pytest.raises(jsonschema.ValidationError)):

--- a/tests/test_generate_assessment_schema.py
+++ b/tests/test_generate_assessment_schema.py
@@ -41,6 +41,7 @@ def _definite_pass_g11_declaration():
         "canProvideFromDayOne": True,
         "conspiracy": False,
         "corruptionBribery": False,
+        "dunsNumberCompanyRegistrationNumber": True,
         "employersInsurance": (
             u"Not applicable - your organisation does not need employer\u2019s liability insurance because your "
             u"organisation employs only the owner or close family members."
@@ -58,7 +59,8 @@ def _definite_pass_g11_declaration():
         "publishContracts": True,
         "readUnderstoodGuidance": True,
         "servicesDoNotInclude": True,
-        "servicesHaveOrSupport": True,
+        "servicesHaveOrSupportCloudHostingCloudSoftware": "Yes",
+        "servicesHaveOrSupportCloudSupport": "Yes",
         "termsAndConditions": True,
         "termsOfParticipation": True,
         "terrorism": False,
@@ -68,9 +70,20 @@ def _definite_pass_g11_declaration():
     }
 
 
+def _definite_pass_g12_declaration():
+    g11_decl = _definite_pass_g11_declaration()
+
+    # g12 hasn't (yet?) diverged enough to require a change
+    return g11_decl
+
+
 @contextmanager
 def _empty_context_manager():
     yield
+
+
+_g11 = ("g-cloud-11", _definite_pass_g11_declaration)
+_g12 = ("g-cloud-12", _definite_pass_g12_declaration)
 
 
 @pytest.mark.parametrize("declaration_update,use_baseline,should_pass", (
@@ -107,13 +120,14 @@ def test_g11_declaration_assessment(declaration_update, use_baseline, should_pas
         jsonschema.validate(candidate, schema)
 
 
-@pytest.mark.parametrize('use_baseline', (True, False))
-def test_g11_declaration_assessment_passes_if_answer_missing(use_baseline):
-    schema = generate_schema("g-cloud-11", "declaration", "declaration")
+@pytest.mark.parametrize('fw_slug,base_decl_factory', (_g11, _g12,))
+@pytest.mark.parametrize('use_baseline', (False, True,))
+def test_g11_declaration_assessment_passes_if_answer_missing(fw_slug, base_decl_factory, use_baseline):
+    schema = generate_schema(fw_slug, "declaration", "declaration")
     if use_baseline:
         schema = schema["definitions"]["baseline"]
 
-    candidate = _definite_pass_g11_declaration()
+    candidate = base_decl_factory()
     candidate.pop('modernSlaveryReportingRequirements')
     candidate['modernSlaveryTurnover'] = False
 


### PR DESCRIPTION
This is to fulfil https://trello.com/c/kbTzccXb

Firstly I discovered that the "definite pass" G11 declaration answer used in the tests _wasn't_ a definite pass - it had missed out on some field renames/updates/splits since G10, but hadn't detected the "wrongness" because the generated schemas didn't `require` answers for any fields. So the first thing I did was make all assessed questions _by default_ required. I needed to make it possible to override this in the question yaml because of `modernSlaveryReportingRequirements`, which is the one exception.

Interestingly, the purpose of this `required` setting is **only** to help guarantee we keep the content, the test's "definite pass" candidate and the supplier frontend's custom declaration code in sync. We don't actually rely on it to police the dependencies between the questions.

The actual problem in the trello card is solved by adding support for a framework to supply "extra" schema json. This allows us to support more complex rules which are hard to express otherwise and rules which relate to more than one question. The generated schema was also changed to put the generated constraints in a redundant `allOf` to make it easier and more reliable to add new conditions.

The conditions are added through deep merging, done using the `deepmerge` package. I considered using `jsonmerge` - a very interesting library and one we could transition to if ever necessary. But more complex than we need right now (I recommend taking a look at it though, it's quite cool).

I had trouble deciding whether to accept baseline and discretionary "extra schema" separately and so make the mechanism opaque to how we implement the baseline/discretionary split, but decided against it in the end because we already rely on having a separate sub-schema named `baseline` in normal usage.