### PR TITLE
G-Cloud 12 dates

### DIFF
--- a/frameworks/g-cloud-12/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-12/messages/homepage-sidebar.yml
@@ -1,5 +1,5 @@
 coming:
-  heading: 'G-Cloud&nbsp;12 is opening in March&nbsp;2020'
+  heading: 'G-Cloud&nbsp;12 will open on 3 March 2020'
   messages:
     - 'Provide cloud hosting, software and support.'
     - 'You’ll need to create a supplier account to apply.'

--- a/frameworks/g-cloud-12/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-12/messages/homepage-sidebar.yml
@@ -1,5 +1,5 @@
 coming:
-  heading: 'G-Cloud&nbsp;12 is opening in March&nbsp;2525'
+  heading: 'G-Cloud&nbsp;12 is opening in March&nbsp;2020'
   messages:
     - 'Provide cloud hosting, software and support.'
     - 'You’ll need to create a supplier account to apply.'
@@ -8,7 +8,7 @@ open:
   heading: 'G-Cloud&nbsp;12 is open for applications'
   messages:
     - 'You need an account to apply.'
-    - 'The application deadline is 5pm&nbsp;BST, Wednesday 22 May 2525.'
+    - 'The application deadline is 5pm&nbsp;BST, Wednesday 22 April 2020.'
 
 pending:
   heading: 'G-Cloud&nbsp;12 is closed for applications'

--- a/frameworks/g-cloud-12/questions/declaration/canProvideFromDayOne.yml
+++ b/frameworks/g-cloud-12/questions/declaration/canProvideFromDayOne.yml
@@ -2,7 +2,7 @@ name: Providing services straight away
 question: >
   If your application is successful, can you provide all the services you’re submitting to G-Cloud&nbsp;12 from the first day you’re awarded a place on the framework?
 type: boolean
-hint: You must be ready to provide the services you’re submitting from July 2525.
+hint: You must be ready to provide the services you’re submitting from July 2020.
 assessment:
   passIfIn:
     - True

--- a/frameworks/g-cloud-12/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/g-cloud-12/questions/declaration/understandHowToAskQuestions.yml
@@ -2,7 +2,7 @@ name: Asking questions
 question: >
   Do you understand that you can ask ‘clarification’ questions on the <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-12/updates" target="_blank" rel="noopener noreferrer">G-Cloud&nbsp;12 updates page (link opens in a new tab)</a> in your Digital Marketplace account?
 hint: >
-  You can ask clarification questions about G-Cloud&nbsp;12 until 5pm BST 30 April 2525. All questions and answers will be posted regularly on the G-Cloud 12 updates page. You will be notified by email when new clarification questions and answers are available.
+  You can ask clarification questions about G-Cloud&nbsp;12 until 5pm BST 1 April 2020. All questions and answers will be posted regularly on the G-Cloud 12 updates page. You will be notified by email when new clarification questions and answers are available.
 
 type: boolean
 assessment:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/Hbojps0X/265-check-all-dates-in-content-for-g12-2

Dates now confirmed and published on GOV.UK: https://www.gov.uk/guidance/what-to-do-and-when-for-g-cloud-12