### PR TITLE
Validation messages for G12 questions

### DIFF
--- a/frameworks/g-cloud-12/questions/declaration/mitigatingFactors.yml
+++ b/frameworks/g-cloud-12/questions/declaration/mitigatingFactors.yml
@@ -6,4 +6,4 @@ type: textbox_large
 validations:
   - 
     name: answer_required
-    message: You need to answer this question because you answered ‘yes’ to one of questions [[taxEvasion]] to [[misleadingInformation]].
+    message: Enter details of mitigating factors about [[taxEvasion]] to [[misleadingInformation]].

--- a/frameworks/g-cloud-12/questions/declaration/mitigatingFactors2.yml
+++ b/frameworks/g-cloud-12/questions/declaration/mitigatingFactors2.yml
@@ -6,4 +6,4 @@ type: textbox_large
 validations:
   - 
     name: answer_required
-    message: You need to answer this question because you answered ‘yes’ to either [[unspentTaxConvictions]] or [[GAAR]].
+    message: Enter details of mitigating factors about either [[unspentTaxConvictions]] or [[GAAR]].

--- a/frameworks/g-cloud-12/questions/declaration/mitigatingFactors3.yml
+++ b/frameworks/g-cloud-12/questions/declaration/mitigatingFactors3.yml
@@ -7,4 +7,4 @@ hidden: true
 validations:
   - 
     name: answer_required
-    message: You need to answer this question
+    message: Explain why your organisation does not meet the Modern Slavery Act reporting requirements.

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -9,7 +9,7 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your organisation complies with the Modern Slavery Act reporting requirements.
 
 assessment:
   passIfIn:

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatement.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatement.yml
@@ -10,8 +10,8 @@ validations:
   - name: answer_required
     message: Select a file.
   - name: file_is_open_document_format
-    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+    message: The file must be in an open format. Select an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb
-    message: Your document exceeds the 5MB limit. Please reduce file size.
+    message: The file must be smaller than 5MB.
   - name: file_can_be_saved
-    message: Your document failed to upload. Please try again.
+    message: The selected file could not be uploaded - try again.

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatement.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatement.yml
@@ -8,7 +8,7 @@ type: upload
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a file.
   - name: file_is_open_document_format
     message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatementOptional.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatementOptional.yml
@@ -11,8 +11,8 @@ type: upload
 
 validations:
   - name: file_is_open_document_format
-    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+    message: The file must be in an open format. Select an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb
-    message: Your document exceeds the 5MB limit. Please reduce file size.
+    message: The file must be smaller than 5MB.
   - name: file_can_be_saved
-    message: Your document failed to upload. Please try again.
+    message: The selected file could not be uploaded - try again.

--- a/frameworks/g-cloud-12/questions/services/APIAutomationTools.yml
+++ b/frameworks/g-cloud-12/questions/services/APIAutomationTools.yml
@@ -26,3 +26,7 @@ options:
     value: puppet
   - label: Other
     value: other
+
+validations:
+  - name: answer_required
+    message: Select an automation tool.

--- a/frameworks/g-cloud-12/questions/services/APIAutomationToolsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/APIAutomationToolsOther.yml
@@ -12,8 +12,6 @@ list_item_name: API automation tool
 type: list
 
 validations:
-  - name: answer_required
-    message: You need to answer this question.
   - name: under_10_words
     message: You can’t write more than 10 words for each API automation tool.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/APIAutomationToolsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/APIAutomationToolsOther.yml
@@ -12,6 +12,8 @@ list_item_name: API automation tool
 type: list
 
 validations:
+  - name: answer_required
+    message: Enter an automation tool.
   - name: under_10_words
     message: You can’t write more than 10 words for each API automation tool.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/APIAutomationToolsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/APIAutomationToolsOther.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Enter an automation tool.
   - name: under_10_words
-    message: You can’t write more than 10 words for each API automation tool.
+    message: Each API automation tool must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer API automation tools.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each API automation tool.
+    message: Each API automation tool must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/APIDocumentation.yml
+++ b/frameworks/g-cloud-12/questions/services/APIDocumentation.yml
@@ -15,4 +15,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide API documentation for your service.

--- a/frameworks/g-cloud-12/questions/services/APIDocumentationFormats.yml
+++ b/frameworks/g-cloud-12/questions/services/APIDocumentationFormats.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a format.

--- a/frameworks/g-cloud-12/questions/services/APIHosting.yml
+++ b/frameworks/g-cloud-12/questions/services/APIHosting.yml
@@ -17,4 +17,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is an API for your service.

--- a/frameworks/g-cloud-12/questions/services/APISandbox.yml
+++ b/frameworks/g-cloud-12/questions/services/APISandbox.yml
@@ -11,4 +11,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is a sandbox or test environment for your API.

--- a/frameworks/g-cloud-12/questions/services/APISoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/APISoftware.yml
@@ -18,4 +18,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is an API for your service.

--- a/frameworks/g-cloud-12/questions/services/APIUsage.yml
+++ b/frameworks/g-cloud-12/questions/services/APIUsage.yml
@@ -19,7 +19,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/QAAndTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/QAAndTesting.yml
@@ -13,4 +13,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide quality assurance and performance testing.

--- a/frameworks/g-cloud-12/questions/services/QAAndTestingDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/QAAndTestingDescription.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter how you help buyers do quality assurance and performance testing.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/QAAndTestingDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/QAAndTestingDescription.yml
@@ -14,7 +14,6 @@ validations:
   - name: answer_required
     message: Enter how you help buyers do quality assurance and performance testing.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
-
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/accessRestrictionManagementAndSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/accessRestrictionManagementAndSupport.yml
@@ -12,7 +12,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/accessRestrictionManagementAndSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/accessRestrictionManagementAndSupport.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/accessRestrictionTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/accessRestrictionTesting.yml
@@ -20,4 +20,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how often you test your access controls.

--- a/frameworks/g-cloud-12/questions/services/accreditationsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/accreditationsOther.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you have any other security certifications.

--- a/frameworks/g-cloud-12/questions/services/accreditationsOtherList.yml
+++ b/frameworks/g-cloud-12/questions/services/accreditationsOtherList.yml
@@ -13,7 +13,7 @@ type: list
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a security certification.
   - name: under_10_words
     message: You can’t write more than 10 words for each security certification.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/accreditationsOtherList.yml
+++ b/frameworks/g-cloud-12/questions/services/accreditationsOtherList.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Enter a security certification.
   - name: under_10_words
-    message: You can’t write more than 10 words for each security certification.
+    message: Each security certification must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer security certifications.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each security certification.
+    message: Each security certification must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/approachToResilience.yml
+++ b/frameworks/g-cloud-12/questions/services/approachToResilience.yml
@@ -22,6 +22,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/approachToResilience.yml
+++ b/frameworks/g-cloud-12/questions/services/approachToResilience.yml
@@ -20,7 +20,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/auditBuyersActions.yml
+++ b/frameworks/g-cloud-12/questions/services/auditBuyersActions.yml
@@ -32,4 +32,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how buyers access audit information about their users.

--- a/frameworks/g-cloud-12/questions/services/auditBuyersActionsStorage.yml
+++ b/frameworks/g-cloud-12/questions/services/auditBuyersActionsStorage.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how long you store users' audit data.

--- a/frameworks/g-cloud-12/questions/services/auditSuppliersActions.yml
+++ b/frameworks/g-cloud-12/questions/services/auditSuppliersActions.yml
@@ -28,4 +28,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how buyers access audit information about your organisation.

--- a/frameworks/g-cloud-12/questions/services/auditSuppliersActionsStorage.yml
+++ b/frameworks/g-cloud-12/questions/services/auditSuppliersActionsStorage.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how long you store your organisation's audit data.

--- a/frameworks/g-cloud-12/questions/services/backup.yml
+++ b/frameworks/g-cloud-12/questions/services/backup.yml
@@ -22,4 +22,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your service provides backup and recovery.

--- a/frameworks/g-cloud-12/questions/services/backupControls.yml
+++ b/frameworks/g-cloud-12/questions/services/backupControls.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter details of how users can control what backups are performed.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/backupControls.yml
+++ b/frameworks/g-cloud-12/questions/services/backupControls.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter details of how users can control what backups are performed.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/backupDatacentre.yml
+++ b/frameworks/g-cloud-12/questions/services/backupDatacentre.yml
@@ -24,4 +24,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a datacentre setup.

--- a/frameworks/g-cloud-12/questions/services/backupRecovery.yml
+++ b/frameworks/g-cloud-12/questions/services/backupRecovery.yml
@@ -16,4 +16,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a recovery method.

--- a/frameworks/g-cloud-12/questions/services/backupScheduling.yml
+++ b/frameworks/g-cloud-12/questions/services/backupScheduling.yml
@@ -18,4 +18,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how users schedule backups.

--- a/frameworks/g-cloud-12/questions/services/backupWhatData.yml
+++ b/frameworks/g-cloud-12/questions/services/backupWhatData.yml
@@ -13,6 +13,8 @@ list_item_name: backup item
 type: list
 
 validations:
+  - name: answer_required
+    message: Enter a backup item.
   - name: max_items_limit
     message: You must have 10 or fewer backup items.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/backupWhatData.yml
+++ b/frameworks/g-cloud-12/questions/services/backupWhatData.yml
@@ -13,8 +13,6 @@ list_item_name: backup item
 type: list
 
 validations:
-  - name: answer_required
-    message: You need to answer this question.
   - name: max_items_limit
     message: You must have 10 or fewer backup items.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/backupWhatData.yml
+++ b/frameworks/g-cloud-12/questions/services/backupWhatData.yml
@@ -1,6 +1,7 @@
 name: What’s backed up
 question: What can the service back up?
 question_advice: Examples include files, virtual machines, or databases.
+hint: 10 words for each backup item, 10 backup items maximum.
 
 optional: true
 hidden: true
@@ -17,5 +18,7 @@ validations:
     message: Enter a backup item.
   - name: max_items_limit
     message: You must have 10 or fewer backup items.
+  - name: under_10_words
+    message: Each backup item must be 10 words or fewer.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each backup item.
+    message: Each backup item must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/boardLevelServiceSecurity.yml
+++ b/frameworks/g-cloud-12/questions/services/boardLevelServiceSecurity.yml
@@ -17,4 +17,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your organisation has a board-level person responsible for service security.

--- a/frameworks/g-cloud-12/questions/services/browsersAccess.yml
+++ b/frameworks/g-cloud-12/questions/services/browsersAccess.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your service is accessed through a browser.

--- a/frameworks/g-cloud-12/questions/services/browsersSupported.yml
+++ b/frameworks/g-cloud-12/questions/services/browsersSupported.yml
@@ -32,4 +32,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a browser.

--- a/frameworks/g-cloud-12/questions/services/cloudDeploymentModel.yml
+++ b/frameworks/g-cloud-12/questions/services/cloudDeploymentModel.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a service type.

--- a/frameworks/g-cloud-12/questions/services/commandLineInterface.yml
+++ b/frameworks/g-cloud-12/questions/services/commandLineInterface.yml
@@ -15,4 +15,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is a command line interface for your service.

--- a/frameworks/g-cloud-12/questions/services/commandLineOS.yml
+++ b/frameworks/g-cloud-12/questions/services/commandLineOS.yml
@@ -20,4 +20,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select an operating system.

--- a/frameworks/g-cloud-12/questions/services/commandLineUsage.yml
+++ b/frameworks/g-cloud-12/questions/services/commandLineUsage.yml
@@ -18,7 +18,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/configurationAndChangeManagementProcesses.yml
+++ b/frameworks/g-cloud-12/questions/services/configurationAndChangeManagementProcesses.yml
@@ -19,6 +19,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/configurationAndChangeManagementProcesses.yml
+++ b/frameworks/g-cloud-12/questions/services/configurationAndChangeManagementProcesses.yml
@@ -17,7 +17,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/configurationAndChangeManagementType.yml
+++ b/frameworks/g-cloud-12/questions/services/configurationAndChangeManagementType.yml
@@ -20,4 +20,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select if your organisation conforms to a recognised standard or defines its own controls.

--- a/frameworks/g-cloud-12/questions/services/customisationAvailable.yml
+++ b/frameworks/g-cloud-12/questions/services/customisationAvailable.yml
@@ -13,4 +13,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if buyers can customise your service.

--- a/frameworks/g-cloud-12/questions/services/customisationDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/customisationDescription.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/customisationDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/customisationDescription.yml
@@ -18,7 +18,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/dataExportFormats.yml
+++ b/frameworks/g-cloud-12/questions/services/dataExportFormats.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a format.

--- a/frameworks/g-cloud-12/questions/services/dataExportFormatsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataExportFormatsOther.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Enter a format.
   - name: under_10_words
-    message: You can’t write more than 10 words for each data format.
+    message: Each data format must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer data formats.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each data format.
+    message: Each data format must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/dataExportFormatsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataExportFormatsOther.yml
@@ -12,6 +12,8 @@ type: list
 list_item_name: data format
 
 validations:
+  - name: answer_required
+    message: Enter a format.
   - name: under_10_words
     message: You can’t write more than 10 words for each data format.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/dataExportHow.yml
+++ b/frameworks/g-cloud-12/questions/services/dataExportHow.yml
@@ -13,6 +13,6 @@ validations:
   - name: answer_required
     message: Enter details of how users can export their data.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/dataExportHow.yml
+++ b/frameworks/g-cloud-12/questions/services/dataExportHow.yml
@@ -11,7 +11,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter details of how users can export their data.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/dataImportFormats.yml
+++ b/frameworks/g-cloud-12/questions/services/dataImportFormats.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a format.

--- a/frameworks/g-cloud-12/questions/services/dataImportFormatsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataImportFormatsOther.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Enter a format.
   - name: under_10_words
-    message: You can’t write more than 10 words for each data format.
+    message: Each data format must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer data formats.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each data format.
+    message: Each data format must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/dataImportFormatsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataImportFormatsOther.yml
@@ -12,6 +12,8 @@ type: list
 list_item_name: data format
 
 validations:
+  - name: answer_required
+    message: Enter a format.
   - name: under_10_words
     message: You can’t write more than 10 words for each data format.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/dataProtectionBetweenNetworks.yml
+++ b/frameworks/g-cloud-12/questions/services/dataProtectionBetweenNetworks.yml
@@ -37,4 +37,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a data protection method.

--- a/frameworks/g-cloud-12/questions/services/dataProtectionBetweenNetworksOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataProtectionBetweenNetworksOther.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/dataProtectionBetweenNetworksOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataProtectionBetweenNetworksOther.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/dataProtectionWithinNetwork.yml
+++ b/frameworks/g-cloud-12/questions/services/dataProtectionWithinNetwork.yml
@@ -31,4 +31,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a data protection method.

--- a/frameworks/g-cloud-12/questions/services/dataProtectionWithinNetworkOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataProtectionWithinNetworkOther.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/dataProtectionWithinNetworkOther.yml
+++ b/frameworks/g-cloud-12/questions/services/dataProtectionWithinNetworkOther.yml
@@ -15,7 +15,7 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.
 

--- a/frameworks/g-cloud-12/questions/services/dataSanitisation.yml
+++ b/frameworks/g-cloud-12/questions/services/dataSanitisation.yml
@@ -19,4 +19,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you have a data sanitisation process.

--- a/frameworks/g-cloud-12/questions/services/dataSanitisationTypeHosting.yml
+++ b/frameworks/g-cloud-12/questions/services/dataSanitisationTypeHosting.yml
@@ -19,4 +19,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a data sanitisation process.

--- a/frameworks/g-cloud-12/questions/services/dataSanitisationTypeSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/dataSanitisationTypeSoftware.yml
@@ -17,4 +17,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a data sanitisation process.

--- a/frameworks/g-cloud-12/questions/services/dataStorageAndProcessing.yml
+++ b/frameworks/g-cloud-12/questions/services/dataStorageAndProcessing.yml
@@ -1,9 +1,9 @@
 name: Knowledge of data storage and processing locations
-question: Do you know where data is stored and processed?
+question: Do you know where your data is stored and processed?
 question_advice: >
-  Read about the government’s <a
+  Read the government’s <a
   href="https://www.ncsc.gov.uk/guidance/cloud-security-principle-2-asset-protection-and-resilience#physical"
-  target="_blank" rel="noopener noreferrer">2nd cloud security principle: ‘Asset protection and resilience’ (link opens
+  target="_blank" rel="noopener noreferrer">cloud security guidance for data storage (link opens
   in a new tab)</a>.
 
 depends:
@@ -21,4 +21,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you know where your data is stored and processed.

--- a/frameworks/g-cloud-12/questions/services/dataStorageAndProcessingLocations.yml
+++ b/frameworks/g-cloud-12/questions/services/dataStorageAndProcessingLocations.yml
@@ -32,4 +32,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a location.

--- a/frameworks/g-cloud-12/questions/services/dataStorageAndProcessingUserControl.yml
+++ b/frameworks/g-cloud-12/questions/services/dataStorageAndProcessingUserControl.yml
@@ -12,4 +12,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if users can specify where data is stored and processed.

--- a/frameworks/g-cloud-12/questions/services/datacentreSecurityStandards.yml
+++ b/frameworks/g-cloud-12/questions/services/datacentreSecurityStandards.yml
@@ -26,4 +26,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select which standards your datacentre security setup complies with.

--- a/frameworks/g-cloud-12/questions/services/devicesUsersManageTheServiceThrough.yml
+++ b/frameworks/g-cloud-12/questions/services/devicesUsersManageTheServiceThrough.yml
@@ -29,4 +29,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a device type.

--- a/frameworks/g-cloud-12/questions/services/documentation.yml
+++ b/frameworks/g-cloud-12/questions/services/documentation.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide documentation for your service.

--- a/frameworks/g-cloud-12/questions/services/documentationAccessibility.yml
+++ b/frameworks/g-cloud-12/questions/services/documentationAccessibility.yml
@@ -24,4 +24,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what accessibility standards your documentation meets.

--- a/frameworks/g-cloud-12/questions/services/documentationAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/documentationAccessibilityDescription.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/documentationAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/documentationAccessibilityDescription.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/documentationFormats.yml
+++ b/frameworks/g-cloud-12/questions/services/documentationFormats.yml
@@ -26,4 +26,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a format.

--- a/frameworks/g-cloud-12/questions/services/documentationFormatsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/documentationFormatsOther.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Enter a format.
   - name: under_10_words
-    message: You can’t write more than 10 words for each documentation format.
+    message: Each documentation format must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer documentation formats.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each documentation format.
+    message: Each documentation format must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/documentationFormatsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/documentationFormatsOther.yml
@@ -12,6 +12,8 @@ type: list
 list_item_name: documentation format
 
 validations:
+  - name: answer_required
+    message: Enter a format.
   - name: under_10_words
     message: You can’t write more than 10 words for each documentation format.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/educationPricing.yml
+++ b/frameworks/g-cloud-12/questions/services/educationPricing.yml
@@ -13,4 +13,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you offer special pricing for educational organisations.

--- a/frameworks/g-cloud-12/questions/services/emailOrTicketingSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/emailOrTicketingSupport.yml
@@ -33,4 +33,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select the type of email or ticketing support you offer.

--- a/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportAccessibility.yml
+++ b/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportAccessibility.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what accessibility standards your online ticketing support management meets.

--- a/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportPriority.yml
+++ b/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportPriority.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if users can manage the status and priority of their support tickets.

--- a/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportResponseTimes.yml
+++ b/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportResponseTimes.yml
@@ -15,7 +15,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter how quickly you respond to questions.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportResponseTimes.yml
+++ b/frameworks/g-cloud-12/questions/services/emailOrTicketingSupportResponseTimes.yml
@@ -17,6 +17,6 @@ validations:
   - name: answer_required
     message: Enter how quickly you respond to questions.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/endOfContractDataExtraction.yml
+++ b/frameworks/g-cloud-12/questions/services/endOfContractDataExtraction.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/endOfContractProcess.yml
+++ b/frameworks/g-cloud-12/questions/services/endOfContractProcess.yml
@@ -15,7 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
-
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/endOfContractProcess.yml
+++ b/frameworks/g-cloud-12/questions/services/endOfContractProcess.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/energyEfficientDatacentres.yml
+++ b/frameworks/g-cloud-12/questions/services/energyEfficientDatacentres.yml
@@ -15,4 +15,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your datacentres adhere to the EU code of conduct.

--- a/frameworks/g-cloud-12/questions/services/energyEfficientDatacentresDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/energyEfficientDatacentresDescription.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/energyEfficientDatacentresDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/energyEfficientDatacentresDescription.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/equipmentDisposalApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/equipmentDisposalApproach.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how you dispose of equipment.

--- a/frameworks/g-cloud-12/questions/services/freeVersionDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/freeVersionDescription.yml
@@ -20,7 +20,7 @@ max_length_in_words: 50
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_50_words
     message: Your description must be no more than 50 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/freeVersionDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/freeVersionDescription.yml
@@ -22,6 +22,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_50_words
-    message: Your description must be no more than 50 words.
+    message: Description must be 50 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 500 characters.
+    message: Description must be 500 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/freeVersionLink.yml
+++ b/frameworks/g-cloud-12/questions/services/freeVersionLink.yml
@@ -14,4 +14,4 @@ type: text
 
 validations:
   - name: under_character_limit
-    message: Your link must be no more than 1000 characters.
+    message: The link must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/freeVersionTrialOption.yml
+++ b/frameworks/g-cloud-12/questions/services/freeVersionTrialOption.yml
@@ -18,4 +18,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is a free trial option for your service.

--- a/frameworks/g-cloud-12/questions/services/gettingStarted.yml
+++ b/frameworks/g-cloud-12/questions/services/gettingStarted.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/governmentSecurityClearances.yml
+++ b/frameworks/g-cloud-12/questions/services/governmentSecurityClearances.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what level of security clearance you are prepared to offer.

--- a/frameworks/g-cloud-12/questions/services/guaranteedAvailability.yml
+++ b/frameworks/g-cloud-12/questions/services/guaranteedAvailability.yml
@@ -15,7 +15,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/howLongSystemLogsStored.yml
+++ b/frameworks/g-cloud-12/questions/services/howLongSystemLogsStored.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how long you store system logs for.

--- a/frameworks/g-cloud-12/questions/services/incidentManagementApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/incidentManagementApproach.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/incidentManagementApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/incidentManagementApproach.yml
@@ -18,7 +18,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/incidentManagementType.yml
+++ b/frameworks/g-cloud-12/questions/services/incidentManagementType.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select which incident management processes your organisation complies with.

--- a/frameworks/g-cloud-12/questions/services/independenceOfResources.yml
+++ b/frameworks/g-cloud-12/questions/services/independenceOfResources.yml
@@ -12,7 +12,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/independenceOfResources.yml
+++ b/frameworks/g-cloud-12/questions/services/independenceOfResources.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/informationSecurityPoliciesAndProcesses.yml
+++ b/frameworks/g-cloud-12/questions/services/informationSecurityPoliciesAndProcesses.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/installation.yml
+++ b/frameworks/g-cloud-12/questions/services/installation.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is an application that users install to use your service.

--- a/frameworks/g-cloud-12/questions/services/installationCompatibleOperatingSystems.yml
+++ b/frameworks/g-cloud-12/questions/services/installationCompatibleOperatingSystems.yml
@@ -26,4 +26,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select an operating system.

--- a/frameworks/g-cloud-12/questions/services/managementAccessAuthentication.yml
+++ b/frameworks/g-cloud-12/questions/services/managementAccessAuthentication.yml
@@ -35,4 +35,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select an authentication method.

--- a/frameworks/g-cloud-12/questions/services/managementAccessAuthenticationDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/managementAccessAuthenticationDescription.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/managementAccessAuthenticationDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/managementAccessAuthenticationDescription.yml
@@ -15,7 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
-
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/metricsHosting.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsHosting.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide infrastructure or application metrics.

--- a/frameworks/g-cloud-12/questions/services/metricsHostingHow.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsHostingHow.yml
@@ -25,4 +25,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a reporting method.

--- a/frameworks/g-cloud-12/questions/services/metricsHostingWhat.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsHostingWhat.yml
@@ -32,3 +32,7 @@ options:
   - label: Other
     value: other
     filter_ignore: true
+
+validations:
+  - name: answer_required
+    message: Select a type of metric.

--- a/frameworks/g-cloud-12/questions/services/metricsHostingWhatOther.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsHostingWhatOther.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Enter a metric.
   - name: under_10_words
-    message: You can’t write more than 10 words for each infrastructure or application metric.
+    message: Each infrastructure or application metric must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer infrastructure or application metrics.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each infrastructure or application metric.
+    message: Each infrastructure or application metric must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/metricsHostingWhatOther.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsHostingWhatOther.yml
@@ -12,6 +12,8 @@ type: list
 list_item_name: infrastructure or application metric
 
 validations:
+  - name: answer_required
+    message: Enter a metric.
   - name: under_10_words
     message: You can’t write more than 10 words for each infrastructure or application metric.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/metricsSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsSoftware.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide service usage metrics.

--- a/frameworks/g-cloud-12/questions/services/metricsSoftwareDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsSoftwareDescription.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/metricsSoftwareDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsSoftwareDescription.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/metricsSoftwareHow.yml
+++ b/frameworks/g-cloud-12/questions/services/metricsSoftwareHow.yml
@@ -23,3 +23,7 @@ options:
   - label: Reports on request
     value: on_request
     filter_label: reports on request
+
+validations:
+  - name: answer_required
+    message: Select a reporting method.

--- a/frameworks/g-cloud-12/questions/services/mobile.yml
+++ b/frameworks/g-cloud-12/questions/services/mobile.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your service has been designed to work on mobile devices.

--- a/frameworks/g-cloud-12/questions/services/mobileDifferences.yml
+++ b/frameworks/g-cloud-12/questions/services/mobileDifferences.yml
@@ -11,6 +11,8 @@ type: textbox_large
 max_length_in_words: 100
 
 validations:
+  - name: answer_required
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/mobileDifferences.yml
+++ b/frameworks/g-cloud-12/questions/services/mobileDifferences.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/ongoingSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/ongoingSupport.yml
@@ -21,4 +21,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you support cloud hosting or software services.

--- a/frameworks/g-cloud-12/questions/services/ongoingSupportDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/ongoingSupportDescription.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/ongoingSupportDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/ongoingSupportDescription.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/ongoingSupportServices.yml
+++ b/frameworks/g-cloud-12/questions/services/ongoingSupportServices.yml
@@ -18,4 +18,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a service type.

--- a/frameworks/g-cloud-12/questions/services/onsiteSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/onsiteSupport.yml
@@ -25,4 +25,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select the type of onsite support you provide.

--- a/frameworks/g-cloud-12/questions/services/outageReporting.yml
+++ b/frameworks/g-cloud-12/questions/services/outageReporting.yml
@@ -18,7 +18,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/penetrationTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/penetrationTesting.yml
@@ -31,4 +31,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how often you do penentration testing.

--- a/frameworks/g-cloud-12/questions/services/penetrationTestingApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/penetrationTestingApproach.yml
@@ -31,4 +31,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select the type of penetration testing your organisation carries out.

--- a/frameworks/g-cloud-12/questions/services/phoneSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/phoneSupport.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide phone support.

--- a/frameworks/g-cloud-12/questions/services/phoneSupportAvailability.yml
+++ b/frameworks/g-cloud-12/questions/services/phoneSupportAvailability.yml
@@ -21,4 +21,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select when users can get phone support.

--- a/frameworks/g-cloud-12/questions/services/planningService.yml
+++ b/frameworks/g-cloud-12/questions/services/planningService.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide planning services.

--- a/frameworks/g-cloud-12/questions/services/planningServiceCompatibility.yml
+++ b/frameworks/g-cloud-12/questions/services/planningServiceCompatibility.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your planning service is for specific hosting or software services.

--- a/frameworks/g-cloud-12/questions/services/planningServiceCompatibilityList.yml
+++ b/frameworks/g-cloud-12/questions/services/planningServiceCompatibilityList.yml
@@ -11,6 +11,8 @@ type: list
 list_item_name: hosting or software service
 
 validations:
+  - name: answer_required
+    message: Enter a service.
   - name: under_10_words
     message: You can’t write more than 10 words for each hosting or software service.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/planningServiceCompatibilityList.yml
+++ b/frameworks/g-cloud-12/questions/services/planningServiceCompatibilityList.yml
@@ -14,8 +14,8 @@ validations:
   - name: answer_required
     message: Enter a service.
   - name: under_10_words
-    message: You can’t write more than 10 words for each hosting or software service.
+    message: Each hosting or software service must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer hosting or software services.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each hosting or software service.
+    message: Each hosting or software service must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/planningServiceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/planningServiceDescription.yml
@@ -14,7 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
-
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/planningServiceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/planningServiceDescription.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/pricingDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/pricingDocumentURL.yml
@@ -13,7 +13,7 @@ type: upload
 
 validations:
   - name: answer_required
-    message: You need to upload a pricing document.
+    message: Select a file.
   - name: file_is_open_document_format
     message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb

--- a/frameworks/g-cloud-12/questions/services/pricingDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/pricingDocumentURL.yml
@@ -15,8 +15,8 @@ validations:
   - name: answer_required
     message: Select a file.
   - name: file_is_open_document_format
-    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+    message: The file must be in an open format. Select an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb
-    message: Your document exceeds the 5MB limit. Please reduce file size.
+    message: The file must be smaller than 5MB.
   - name: file_can_be_saved
-    message: Your document failed to upload. Please try again.
+    message: The selected file could not be uploaded - try again.

--- a/frameworks/g-cloud-12/questions/services/protectionOfDataAtRest.yml
+++ b/frameworks/g-cloud-12/questions/services/protectionOfDataAtRest.yml
@@ -32,4 +32,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a data protection method.

--- a/frameworks/g-cloud-12/questions/services/protectionOfDataAtRestOther.yml
+++ b/frameworks/g-cloud-12/questions/services/protectionOfDataAtRestOther.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/protectionOfDataAtRestOther.yml
+++ b/frameworks/g-cloud-12/questions/services/protectionOfDataAtRestOther.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/protectiveMonitoringApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/protectiveMonitoringApproach.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/protectiveMonitoringApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/protectiveMonitoringApproach.yml
@@ -18,7 +18,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/protectiveMonitoringType.yml
+++ b/frameworks/g-cloud-12/questions/services/protectiveMonitoringType.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select the type of protective monitoring process you comply with.

--- a/frameworks/g-cloud-12/questions/services/publicSectorNetworks.yml
+++ b/frameworks/g-cloud-12/questions/services/publicSectorNetworks.yml
@@ -13,4 +13,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your service connects to any public sector networks.

--- a/frameworks/g-cloud-12/questions/services/publicSectorNetworksOther.yml
+++ b/frameworks/g-cloud-12/questions/services/publicSectorNetworksOther.yml
@@ -12,7 +12,7 @@ list_item_name: public sector network
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a network.
   - name: under_10_words
     message: You can’t write more than 10 words for each public sector network.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/publicSectorNetworksOther.yml
+++ b/frameworks/g-cloud-12/questions/services/publicSectorNetworksOther.yml
@@ -14,8 +14,8 @@ validations:
   - name: answer_required
     message: Enter a network.
   - name: under_10_words
-    message: You can’t write more than 10 words for each public sector network.
+    message: Each public sector network must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer public sector networks.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each public sector network.
+    message: Each public sector network must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/publicSectorNetworksTypes.yml
+++ b/frameworks/g-cloud-12/questions/services/publicSectorNetworksTypes.yml
@@ -27,3 +27,7 @@ options:
   - label: Other
     value: other
     filter_ignore: true 
+
+validations:
+  - name: answer_required
+    message: Select a network.

--- a/frameworks/g-cloud-12/questions/services/resellingOrganisations.yml
+++ b/frameworks/g-cloud-12/questions/services/resellingOrganisations.yml
@@ -14,7 +14,7 @@ max_length_in_words: 10
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the organisation name.
   - name: under_10_words
     message: Your answer must be no longer than 10 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/resellingType.yml
+++ b/frameworks/g-cloud-12/questions/services/resellingType.yml
@@ -30,4 +30,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select if you are reselling another organisation's services.

--- a/frameworks/g-cloud-12/questions/services/scaling.yml
+++ b/frameworks/g-cloud-12/questions/services/scaling.yml
@@ -13,4 +13,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your service scales without the user having to contact your support team.

--- a/frameworks/g-cloud-12/questions/services/scalingType.yml
+++ b/frameworks/g-cloud-12/questions/services/scalingType.yml
@@ -19,4 +19,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a scaling method.

--- a/frameworks/g-cloud-12/questions/services/secureDevelopment.yml
+++ b/frameworks/g-cloud-12/questions/services/secureDevelopment.yml
@@ -24,4 +24,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how you demonstate that you adhere to secure software development best practice.

--- a/frameworks/g-cloud-12/questions/services/securityGovernanceAccreditation.yml
+++ b/frameworks/g-cloud-12/questions/services/securityGovernanceAccreditation.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your security governance is certified to a standard.

--- a/frameworks/g-cloud-12/questions/services/securityGovernanceApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/securityGovernanceApproach.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/securityGovernanceApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/securityGovernanceApproach.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/securityGovernanceStandards.yml
+++ b/frameworks/g-cloud-12/questions/services/securityGovernanceStandards.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a standard.

--- a/frameworks/g-cloud-12/questions/services/securityGovernanceStandardsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/securityGovernanceStandardsOther.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the other standards your governance standards comply with.
   - name: under_50_words
-    message: Your description must be no more than 50 words.
+    message: Description must be 50 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 500 characters.
+    message: Description must be 500 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/securityGovernanceStandardsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/securityGovernanceStandardsOther.yml
@@ -13,7 +13,7 @@ max_length_in_words: 50
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the other standards your governance standards comply with.
   - name: under_50_words
     message: Your description must be no more than 50 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/securityTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTesting.yml
@@ -23,4 +23,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide security services.

--- a/frameworks/g-cloud-12/questions/services/securityTestingAccreditations.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingAccreditations.yml
@@ -27,4 +27,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a certification.

--- a/frameworks/g-cloud-12/questions/services/securityTestingAccreditationsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingAccreditationsOther.yml
@@ -11,6 +11,8 @@ type: list
 list_item_name: security certification
 
 validations:
+  - name: answer_required
+    message: Enter a certification.
   - name: under_10_words
     message: You can’t write more than 10 words for each security certification.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/securityTestingAccreditationsOther.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingAccreditationsOther.yml
@@ -14,8 +14,8 @@ validations:
   - name: answer_required
     message: Enter a certification.
   - name: under_10_words
-    message: You can’t write more than 10 words for each security certification.
+    message: Each security certification must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer security certifications.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each security certification.
+    message: Each security certification must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/securityTestingAccredited.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingAccredited.yml
@@ -15,4 +15,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your security testing is performed by certified security testers.

--- a/frameworks/g-cloud-12/questions/services/securityTestingCCP.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingCCP.yml
@@ -11,4 +11,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your risk analysts are CCP scheme-accredited.

--- a/frameworks/g-cloud-12/questions/services/securityTestingWhat.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingWhat.yml
@@ -35,4 +35,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a service type.

--- a/frameworks/g-cloud-12/questions/services/securityTestingWhatOther.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingWhatOther.yml
@@ -11,6 +11,8 @@ type: list
 list_item_name: kind of security service
 
 validations:
+  - name: answer_required
+    message: Enter a service.
   - name: under_10_words
     message: You can’t write more than 10 words for each kind of security service.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/securityTestingWhatOther.yml
+++ b/frameworks/g-cloud-12/questions/services/securityTestingWhatOther.yml
@@ -14,8 +14,8 @@ validations:
   - name: answer_required
     message: Enter a service.
   - name: under_10_words
-    message: You can’t write more than 10 words for each kind of security service.
+    message: Each kind of security service must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer kinds of security service.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each kind of security service.
+    message: Each kind of security service must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceAddOnDetails.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceAddOnDetails.yml
@@ -12,7 +12,7 @@ max_length_in_words: 50
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the other software services your service is an extension to.
   - name: under_50_words
     message: Your description must be no more than 50 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceAddOnDetails.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceAddOnDetails.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter the other software services your service is an extension to.
   - name: under_50_words
-    message: Your description must be no more than 50 words.
+    message: Description must be 50 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 500 characters.
+    message: Description must be 500 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceAddOnType.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceAddOnType.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select if your service is an add-on or extension to other software services.

--- a/frameworks/g-cloud-12/questions/services/serviceBenefitsHostingAndSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceBenefitsHostingAndSoftware.yml
@@ -17,7 +17,7 @@ list_item_name: service benefit
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a service benefit.
   - name: max_items_limit
     message: You can have no more than 10 benefits.
   - name: under_10_words

--- a/frameworks/g-cloud-12/questions/services/serviceBenefitsHostingAndSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceBenefitsHostingAndSoftware.yml
@@ -21,6 +21,6 @@ validations:
   - name: max_items_limit
     message: You can have no more than 10 benefits.
   - name: under_10_words
-    message: You can’t write more than 10 words for each benefit.
+    message: Each benefit must be 10 words or fewer.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each benefit.
+    message: Each benefit must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceBenefitsSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceBenefitsSupport.yml
@@ -16,7 +16,7 @@ list_item_name: service benefit
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a service benefit.
   - name: max_items_limit
     message: You can have no more than 10 benefits.
   - name: under_10_words

--- a/frameworks/g-cloud-12/questions/services/serviceBenefitsSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceBenefitsSupport.yml
@@ -20,6 +20,6 @@ validations:
   - name: max_items_limit
     message: You can have no more than 10 benefits.
   - name: under_10_words
-    message: You can’t write more than 10 words for each benefit.
+    message: Each benefit must be 10 words or fewer.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each benefit.
+    message: Each benefit must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceCategoriesSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceCategoriesSupport.yml
@@ -42,5 +42,7 @@ options:
         - true
 
 validations:
+  - name: answer_required
+    message: Select a service category.
   - message: You can’t choose more than 6 categories.
     name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/serviceConstraintsHostingAndSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceConstraintsHostingAndSoftware.yml
@@ -14,7 +14,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the service constraints.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceConstraintsHostingAndSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceConstraintsHostingAndSoftware.yml
@@ -16,6 +16,6 @@ validations:
   - name: answer_required
     message: Enter the service constraints.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceConstraintsSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceConstraintsSupport.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the service constraints.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceConstraintsSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceConstraintsSupport.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the service constraints.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceDefinitionDocumentURL.yml
@@ -16,7 +16,7 @@ type: upload
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select a file.
   - name: file_is_open_document_format
     message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb

--- a/frameworks/g-cloud-12/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceDefinitionDocumentURL.yml
@@ -18,8 +18,8 @@ validations:
   - name: answer_required
     message: Select a file.
   - name: file_is_open_document_format
-    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+    message: The file must be in an open format. Select an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb
-    message: Your document exceeds the 5MB limit. Please reduce file size.
+    message: The file must be smaller than 5MB.
   - name: file_can_be_saved
-    message: Your document failed to upload. Please try again.
+    message: The selected file could not be uploaded - try again.

--- a/frameworks/g-cloud-12/questions/services/serviceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceDescription.yml
@@ -13,7 +13,7 @@ max_length_in_words: 50
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter summary.
   - name: under_50_words
     message: Your description must be no more than 50 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceDescription.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter summary.
   - name: under_50_words
-    message: Your description must be no more than 50 words.
+    message: Description must be 50 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 500 characters.
+    message: Description must be 500 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceFeaturesHostingAndSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceFeaturesHostingAndSoftware.yml
@@ -15,7 +15,7 @@ list_item_name: service feature
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a service feature.
   - name: max_items_limit
     message: You can have no more than 10 features.
   - name: under_10_words

--- a/frameworks/g-cloud-12/questions/services/serviceFeaturesHostingAndSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceFeaturesHostingAndSoftware.yml
@@ -19,6 +19,6 @@ validations:
   - name: max_items_limit
     message: You can have no more than 10 features.
   - name: under_10_words
-    message: You can’t write more than 10 words for each feature.
+    message: Each feature must be 10 words or fewer.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each feature.
+    message: Each feature must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceFeaturesSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceFeaturesSupport.yml
@@ -20,6 +20,6 @@ validations:
   - name: max_items_limit
     message: You can have no more than 10 features.
   - name: under_10_words
-    message: You can’t write more than 10 words for each feature.
+    message: Each feature must be 10 words or fewer.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each feature.
+    message: Each feature must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceFeaturesSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceFeaturesSupport.yml
@@ -16,7 +16,7 @@ list_item_name: service feature
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a service feature.
   - name: max_items_limit
     message: You can have no more than 10 features.
   - name: under_10_words

--- a/frameworks/g-cloud-12/questions/services/serviceInterface.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterface.yml
@@ -17,4 +17,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is a service interface.

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceAccessibility.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceAccessibility.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what accessibility standards your service meets.

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceAccessibilityDescription.yml
@@ -17,6 +17,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceAccessibilityDescription.yml
@@ -15,7 +15,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceDescription.yml
@@ -12,7 +12,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceDescription.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceTesting.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/serviceInterfaceTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceInterfaceTesting.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceName.yml
@@ -14,6 +14,6 @@ type: text
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the service name.
   - name: under_character_limit
     message: Your service name must be no more than 100 characters.

--- a/frameworks/g-cloud-12/questions/services/serviceName.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceName.yml
@@ -16,4 +16,4 @@ validations:
   - name: answer_required
     message: Enter the service name.
   - name: under_character_limit
-    message: Your service name must be no more than 100 characters.
+    message: Your service name must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/setupAndMigrationService.yml
+++ b/frameworks/g-cloud-12/questions/services/setupAndMigrationService.yml
@@ -16,4 +16,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your service helps buyers migrate to the cloud or between cloud services.

--- a/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceDescription.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceDescription.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceSpecific.yml
+++ b/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceSpecific.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your migration service is for specific cloud services.

--- a/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceSpecificList.yml
+++ b/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceSpecificList.yml
@@ -11,6 +11,8 @@ type: list
 list_item_name: cloud hosting or software service
 
 validations:
+  - name: answer_required
+    message: Enter a service.
   - name: under_10_words
     message: You can’t write more than 10 words for each cloud hosting or software service.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceSpecificList.yml
+++ b/frameworks/g-cloud-12/questions/services/setupAndMigrationServiceSpecificList.yml
@@ -14,9 +14,9 @@ validations:
   - name: answer_required
     message: Enter a service.
   - name: under_10_words
-    message: You can’t write more than 10 words for each cloud hosting or software service.
+    message: Each cloud hosting or software service must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer cloud hosting or software services.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each cloud hosting or software service.
+    message: Each cloud hosting or software service must be 100 characters or fewer.
 

--- a/frameworks/g-cloud-12/questions/services/sfiaRateDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/sfiaRateDocumentURL.yml
@@ -14,8 +14,8 @@ type: upload
 
 validations:
   - name: file_is_open_document_format
-    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+    message: The file must be in an open format. Select an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb
-    message: Your document exceeds the 5MB limit. Please reduce file size.
+    message: The file must be smaller than 5MB.
   - name: file_can_be_saved
-    message: Your document failed to upload. Please try again.
+    message: The selected file could not be uploaded - try again.

--- a/frameworks/g-cloud-12/questions/services/staffSecurityClearanceChecks.yml
+++ b/frameworks/g-cloud-12/questions/services/staffSecurityClearanceChecks.yml
@@ -27,4 +27,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select how you manage staff security clearance checks.

--- a/frameworks/g-cloud-12/questions/services/standardsCSASTAR.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsCSASTAR.yml
@@ -20,4 +20,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you have a current CSA STAR certification.

--- a/frameworks/g-cloud-12/questions/services/standardsCSASTARExclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsCSASTARExclusions.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the parts of your service not covered by CSA STAR certification.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsCSASTARExclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsCSASTARExclusions.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the parts of your service not covered by CSA STAR certification.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/standardsCSASTARLevel.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsCSASTARLevel.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select the level of CSA STAR certification.

--- a/frameworks/g-cloud-12/questions/services/standardsCSASTARWhen.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsCSASTARWhen.yml
@@ -15,4 +15,4 @@ validations:
   - name: answer_required
     message: Enter the accreditation date.
   - name: under_character_limit
-    message: Your accreditation date must be no more than 50 characters.
+    message: Your accreditation date must be 50 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsCSASTARWhen.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsCSASTARWhen.yml
@@ -13,6 +13,6 @@ type: text
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditation date.
   - name: under_character_limit
     message: Your accreditation date must be no more than 50 characters.

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000.yml
@@ -19,4 +19,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you have a current ISO 28000:2007 certification.

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000Exclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000Exclusions.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the parts of your service not covered by ISO 28000:2007 certification.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000Exclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000Exclusions.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the parts of your service not covered by ISO 28000:2007 certification.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000When.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000When.yml
@@ -15,4 +15,4 @@ validations:
   - name: answer_required
     message: Enter the accreditation date.
   - name: under_character_limit
-    message: Your accreditation date must be no more than 50 characters.
+    message: Your accreditation date must be 50 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000When.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000When.yml
@@ -13,6 +13,6 @@ type: text
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditation date.
   - name: under_character_limit
     message: Your accreditation date must be no more than 50 characters.

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000Who.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000Who.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the accreditor name.
   - name: under_10_words
-    message: Your description must be no more than 10 words.
+    message: Accreditor name must be 10 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 100 characters.
+    message: Accreditor name must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsISO28000Who.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISO28000Who.yml
@@ -13,7 +13,7 @@ max_length_in_words: 10
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditor name.
   - name: under_10_words
     message: Your description must be no more than 10 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001.yml
@@ -19,4 +19,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you have a current ISO/IEC 27001 certification.

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Exclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Exclusions.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the parts of your service not covered by ISO/IEC 27001 certification.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Exclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Exclusions.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the parts of your service not covered by ISO/IEC 27001 certification.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001When.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001When.yml
@@ -15,4 +15,4 @@ validations:
   - name: answer_required
     message: Enter the accreditation date.
   - name: under_character_limit
-    message: Your accreditation date must be no more than 100 characters.
+    message: Your accreditation date must be 50 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001When.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001When.yml
@@ -13,6 +13,6 @@ type: text
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditation date.
   - name: under_character_limit
     message: Your accreditation date must be no more than 100 characters.

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Who.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Who.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the accreditor name.
   - name: under_10_words
-    message: Your description must be no more than 10 words.
+    message: Accreditor name must be 10 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 100 characters.
+    message: Accreditor name must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Who.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsISOIEC27001Who.yml
@@ -13,7 +13,7 @@ max_length_in_words: 10
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditor name.
   - name: under_10_words
     message: Your description must be no more than 10 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/standardsPCI.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCI.yml
@@ -19,4 +19,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you have a current PCI DSS certification.

--- a/frameworks/g-cloud-12/questions/services/standardsPCIExclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCIExclusions.yml
@@ -13,7 +13,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the parts of your service not covered by PCI DSS certification.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/standardsPCIExclusions.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCIExclusions.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the parts of your service not covered by PCI DSS certification.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsPCIWhen.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCIWhen.yml
@@ -15,4 +15,4 @@ validations:
   - name: answer_required
     message: Enter the accreditation date.
   - name: under_character_limit
-    message: Your accreditation date must be no more than 50 characters.
+    message: Your accreditation date must be 50 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsPCIWhen.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCIWhen.yml
@@ -13,6 +13,6 @@ type: text
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditation date.
   - name: under_character_limit
     message: Your accreditation date must be no more than 50 characters.

--- a/frameworks/g-cloud-12/questions/services/standardsPCIWho.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCIWho.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter the accreditor name.
   - name: under_10_words
-    message: Your description must be no more than 10 words.
+    message: Accreditor name must be 10 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 100 characters.
+    message: Accreditor name must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/standardsPCIWho.yml
+++ b/frameworks/g-cloud-12/questions/services/standardsPCIWho.yml
@@ -13,7 +13,7 @@ max_length_in_words: 10
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the accreditor name.
   - name: under_10_words
     message: Your description must be no more than 10 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/supportAvailableToThirdParty.yml
+++ b/frameworks/g-cloud-12/questions/services/supportAvailableToThirdParty.yml
@@ -12,4 +12,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if third parties engaged by the buyer can access the support features of your service.

--- a/frameworks/g-cloud-12/questions/services/supportLevels.yml
+++ b/frameworks/g-cloud-12/questions/services/supportLevels.yml
@@ -19,7 +19,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your answer must be no longer than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/systemRequirements.yml
+++ b/frameworks/g-cloud-12/questions/services/systemRequirements.yml
@@ -20,6 +20,6 @@ validations:
   - name: max_items_limit
     message: You can have no more than 10 system requirements.
   - name: under_10_words
-    message: You can’t write more than 10 words for each system requirement.
+    message: Each system requirement must be 10 words or fewer.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each system requirement.
+    message: Each system requirement must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/systemRequirements.yml
+++ b/frameworks/g-cloud-12/questions/services/systemRequirements.yml
@@ -16,7 +16,7 @@ type: list
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter a system requirement.
   - name: max_items_limit
     message: You can have no more than 10 system requirements.
   - name: under_10_words

--- a/frameworks/g-cloud-12/questions/services/termsAndConditionsDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/termsAndConditionsDocumentURL.yml
@@ -15,7 +15,7 @@ type: upload
 
 validations:
   - name: answer_required
-    message: You need to upload a terms and conditions document.
+    message: Select a file.
   - name: file_is_open_document_format
     message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb

--- a/frameworks/g-cloud-12/questions/services/termsAndConditionsDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/termsAndConditionsDocumentURL.yml
@@ -17,8 +17,8 @@ validations:
   - name: answer_required
     message: Select a file.
   - name: file_is_open_document_format
-    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+    message: The file must be in an open format. Select an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
   - name: file_is_less_than_5mb
-    message: Your document exceeds the 5MB limit. Please reduce file size.
+    message: The file must be smaller than 5MB.
   - name: file_can_be_saved
-    message: Your document failed to upload. Please try again.
+    message: The selected file could not be uploaded - try again.

--- a/frameworks/g-cloud-12/questions/services/training.yml
+++ b/frameworks/g-cloud-12/questions/services/training.yml
@@ -15,4 +15,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you provide training for cloud software and hosting services.

--- a/frameworks/g-cloud-12/questions/services/trainingDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/trainingDescription.yml
@@ -14,7 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
-
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/trainingDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/trainingDescription.yml
@@ -12,7 +12,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/trainingServiceSpecific.yml
+++ b/frameworks/g-cloud-12/questions/services/trainingServiceSpecific.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if your training is for specific cloud hosting or software services.

--- a/frameworks/g-cloud-12/questions/services/trainingServiceSpecificList.yml
+++ b/frameworks/g-cloud-12/questions/services/trainingServiceSpecificList.yml
@@ -11,6 +11,8 @@ type: list
 list_item_name: cloud hosting or software service
 
 validations:
+  - name: answer_required
+    message: Enter a service.
   - name: under_10_words
     message: You can’t write more than 10 words for each cloud hosting or software service.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/trainingServiceSpecificList.yml
+++ b/frameworks/g-cloud-12/questions/services/trainingServiceSpecificList.yml
@@ -14,8 +14,8 @@ validations:
   - name: answer_required
     message: Enter a service.
   - name: under_10_words
-    message: You can’t write more than 10 words for each cloud hosting or software service.
+    message: Each cloud hosting or software service must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer cloud hosting or software services.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each cloud hosting or software service.
+    message: Each cloud hosting or software service must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/usageNotifications.yml
+++ b/frameworks/g-cloud-12/questions/services/usageNotifications.yml
@@ -14,4 +14,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you notify users if their usage nears service limits.

--- a/frameworks/g-cloud-12/questions/services/usageNotificationsHow.yml
+++ b/frameworks/g-cloud-12/questions/services/usageNotificationsHow.yml
@@ -17,3 +17,7 @@ options:
     value: sms
   - label: Other
     value: other
+
+validations:
+  - name: answer_required
+    message: Select a notification method.

--- a/frameworks/g-cloud-12/questions/services/userAuthenticationDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/userAuthenticationDescription.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/userAuthenticationDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/userAuthenticationDescription.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/userAuthenticationHosting.yml
+++ b/frameworks/g-cloud-12/questions/services/userAuthenticationHosting.yml
@@ -40,4 +40,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select an authentication method.

--- a/frameworks/g-cloud-12/questions/services/userAuthenticationNeeded.yml
+++ b/frameworks/g-cloud-12/questions/services/userAuthenticationNeeded.yml
@@ -13,4 +13,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if users need to be authenticated when using your service.

--- a/frameworks/g-cloud-12/questions/services/userAuthenticationSoftware.yml
+++ b/frameworks/g-cloud-12/questions/services/userAuthenticationSoftware.yml
@@ -41,4 +41,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select an authentication method.

--- a/frameworks/g-cloud-12/questions/services/virtualisation.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisation.yml
@@ -20,4 +20,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if you rely on virtualisation technology for shared infrastructure.

--- a/frameworks/g-cloud-12/questions/services/virtualisationImplementedBy.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationImplementedBy.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select if virtualisation technology is implemented by you or a third party.

--- a/frameworks/g-cloud-12/questions/services/virtualisationSeparation.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationSeparation.yml
@@ -13,7 +13,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/virtualisationSeparation.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationSeparation.yml
@@ -15,6 +15,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsed.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsed.yml
@@ -32,8 +32,8 @@ validations:
   - name: answer_required
     message: Select what virtualisation technologies are used.
   - name: under_10_words
-    message: You can’t write more than 10 words for each virtualisation technology.
+    message: Each virtualisation technology must be 10 words or fewer.
   - name: max_items_limit
     message: You must have 10 or fewer virtualisation technology.
   - name: under_character_limit
-    message: You can’t write more than 100 characters for each virtualisation technology.
+    message: Each virtualisation technology must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsed.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsed.yml
@@ -30,7 +30,7 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what virtualisation technologies are used.
   - name: under_10_words
     message: You can’t write more than 10 words for each virtualisation technology.
   - name: max_items_limit

--- a/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsedOther.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsedOther.yml
@@ -12,7 +12,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter details of the other virtualisation technology you use.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsedOther.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationTechnologiesUsedOther.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter details of the other virtualisation technology you use.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/virtualisationThirdPartyProvider.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationThirdPartyProvider.yml
@@ -11,7 +11,7 @@ type: text
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter the provider name.
   - name: under_10_words
     message: Your description must be no more than 10 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/virtualisationThirdPartyProvider.yml
+++ b/frameworks/g-cloud-12/questions/services/virtualisationThirdPartyProvider.yml
@@ -13,7 +13,6 @@ validations:
   - name: answer_required
     message: Enter the provider name.
   - name: under_10_words
-    message: Your description must be no more than 10 words.
+    message: Provider name must be 10 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 100 characters.
-
+    message: Provider name must be 100 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/vulnerabilityManagementApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/vulnerabilityManagementApproach.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your answer must be no longer than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your answer must be no longer than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/vulnerabilityManagementApproach.yml
+++ b/frameworks/g-cloud-12/questions/services/vulnerabilityManagementApproach.yml
@@ -18,7 +18,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your answer must be no longer than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/vulnerabilityManagementType.yml
+++ b/frameworks/g-cloud-12/questions/services/vulnerabilityManagementType.yml
@@ -22,4 +22,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select which vulnerability management process your organisation complies with.

--- a/frameworks/g-cloud-12/questions/services/webChatSupport.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupport.yml
@@ -36,4 +36,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select the type of web chat support you provide.

--- a/frameworks/g-cloud-12/questions/services/webChatSupportAccessibility.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupportAccessibility.yml
@@ -25,4 +25,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what accessibility standards your web chat meets.

--- a/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityDescription.yml
@@ -20,7 +20,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
-
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityDescription.yml
@@ -18,7 +18,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityTesting.yml
@@ -16,6 +16,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupportAccessibilityTesting.yml
@@ -14,7 +14,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/webChatSupportAvailability.yml
+++ b/frameworks/g-cloud-12/questions/services/webChatSupportAvailability.yml
@@ -21,4 +21,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select when users can get web chat support.

--- a/frameworks/g-cloud-12/questions/services/webInterface.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterface.yml
@@ -17,4 +17,4 @@ type: boolean
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select yes if there is a web interface for your service.

--- a/frameworks/g-cloud-12/questions/services/webInterfaceAccessibility.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceAccessibility.yml
@@ -23,4 +23,4 @@ options:
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Select what accessibility standards your web interface meets.

--- a/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityDescription.yml
@@ -16,7 +16,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityDescription.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityDescription.yml
@@ -18,6 +18,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityTesting.yml
@@ -12,7 +12,7 @@ max_length_in_words: 100
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_100_words
     message: Your description must be no more than 100 words.
   - name: under_character_limit

--- a/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityTesting.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceAccessibilityTesting.yml
@@ -14,6 +14,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_100_words
-    message: Your description must be no more than 100 words.
+    message: Description must be 100 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 1000 characters.
+    message: Description must be 1000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/webInterfaceUsage.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceUsage.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: Enter description.
   - name: under_200_words
-    message: Your description must be no more than 200 words.
+    message: Description must be 200 words or fewer.
   - name: under_character_limit
-    message: Your description must be no more than 2000 characters.
+    message: Description must be 2000 characters or fewer.

--- a/frameworks/g-cloud-12/questions/services/webInterfaceUsage.yml
+++ b/frameworks/g-cloud-12/questions/services/webInterfaceUsage.yml
@@ -18,7 +18,7 @@ max_length_in_words: 200
 
 validations:
   - name: answer_required
-    message: You need to answer this question.
+    message: Enter description.
   - name: under_200_words
     message: Your description must be no more than 200 words.
   - name: under_character_limit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.4.0",
+  "version": "17.6.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.5.0",
+  "version": "17.6.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/WyCs0t4g/302-3-review-and-update-answerrequired-error-messages-for-g-cloud-12-questions-in-frameworks-repo

Updates error messages to bring us in line with the Design System guidance (see https://design-system.service.gov.uk/components/text-input/#error-messages for error message examples for text input fields).

This looks like a monster PR, but the commits are arranged to (hopefully) make it manageable to review.

- Remove any redundant `answer_required` validators for where the question is optional.
- Declaration questions: these questions are mostly Yes/No, with a few text fields and one file upload field. I've split them into two commits, one for `answer_required` errors, one for file upload errors.
- Service questions: split into commits for input type (boolean, radio etc) and error type (`answer_required`, word/character limits).

I can split out the word count commits into a separate PR if that's easier to review!

Not included in this PR: 
- error message types where there isn't currently Design System guidance (eg for max number of items in a list input type)