### PR TITLE
G12 file upload guidance

### DIFF
--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -1,8 +1,6 @@
 name: Modern slavery reporting requirements
 question: Does your organisation comply with the annual reporting requirements of section 54 of The Modern Slavery Act (2015)?
-
-hint: >
-  You must publish a slavery and human trafficking statement to comply with the act. Read the Home Office guidance for information about <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">how to write a statement and what information it must include (link opens in a new tab)</a>.
+hint: You must publish a slavery and human trafficking statement to comply with the act.
 
 hidden: true
 type: boolean

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatement.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatement.yml
@@ -1,7 +1,19 @@
 name: Modern slavery statement required
-question: Upload a copy of your organisation’s slavery and human trafficking statement.
+question: >
+  <p class="govuk-body">Upload a copy of your organisation’s slavery and human trafficking statement.</p>
 
-hint: Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
+  <p class="govuk-body">Your statement should:</p>
+  <ul class="govuk-list">
+    <li>be an Open Document Format (ODF) or PDF/A</li>
+    <li>have a maximum file size of 5MB</li>
+    <li>meet accessibility standards</li>
+  </ul>
+  <p class="govuk-body">
+    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs">Read the guidance on accessible documents (link opens in a new tab)</a>.
+  </p>
+  <p class="govuk-body">
+    <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">Read the Home Office guidance about how to write a statement and what information to include (link opens in a new tab)</a>.
+  </p>
 
 hidden: true
 type: upload

--- a/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatementOptional.yml
+++ b/frameworks/g-cloud-12/questions/declaration/modernSlaveryStatementOptional.yml
@@ -1,10 +1,21 @@
 name: Modern slavery statement optional
 question: >
-  You don’t need to publish a slavery and human trafficking statement to meet the modern slavery requirements for G-Cloud 12.
-question_advice: >
-  You can choose to upload a statement. Read the Home Office guidance for information about <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">how to write a statement and what information it must include (link opens in a new tab)</a>.
-hint: >
-  Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
+  <p class="govuk-body">You don’t need to publish a slavery and human trafficking statement to meet the modern slavery requirements for G-Cloud 12.</p>
+
+  <p class="govuk-body">You can choose to upload a statement.</p>
+
+  <p class="govuk-body">Your statement should:</p>
+  <ul class="govuk-list">
+    <li>be an Open Document Format (ODF) or PDF/A</li>
+    <li>have a maximum file size of 5MB</li>
+    <li>meet accessibility standards</li>
+  </ul>
+  <p class="govuk-body">
+    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs">Read the guidance on accessible documents (link opens in a new tab)</a>.
+  </p>
+  <p class="govuk-body">
+    <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">Read the Home Office guidance about how to write a statement and what information to include (link opens in a new tab)</a>.
+  </p>
 
 hidden: true
 type: upload

--- a/frameworks/g-cloud-12/questions/services/pricingDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/pricingDocumentURL.yml
@@ -1,6 +1,16 @@
 name: Pricing document
 question: Add your pricing document
-hint: This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
+hint: >
+  <p class="govuk-body">This document will not be indexed by search on the Digital Marketplace.</p>
+  <p class="govuk-body">Your document should:</p>
+  <ul class="govuk-list">
+    <li>be an Open Document Format (ODF) or PDF/A</li>
+    <li>have a maximum file size of 5MB</li>
+    <li>meet accessibility standards</li>
+  </ul>
+  <p class="govuk-body">
+    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs">Read the guidance on accessible documents (link opens in a new tab)</a>.
+  </p>
 
 depends:
   - "on": lot

--- a/frameworks/g-cloud-12/questions/services/serviceDefinitionDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/serviceDefinitionDocumentURL.yml
@@ -2,8 +2,16 @@ name: Service definition document
 question: Add your service definition document
 question_advice: Read the suppliers’ guide for guidance on what to include.
 hint: >
-  This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A
-  (eg .pdf, .odt). (Maximum file size 5MB.)
+  <p class="govuk-body">This document will not be indexed by search on the Digital Marketplace.</p>
+  <p class="govuk-body">Your document should:</p>
+  <ul class="govuk-list">
+    <li>be an Open Document Format (ODF) or PDF/A</li>
+    <li>have a maximum file size of 5MB</li>
+    <li>meet accessibility standards</li>
+  </ul>
+  <p class="govuk-body">
+    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs">Read the guidance on accessible documents (link opens in a new tab)</a>.
+  </p>
 
 depends:
   - "on": lot

--- a/frameworks/g-cloud-12/questions/services/sfiaRateDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/sfiaRateDocumentURL.yml
@@ -1,6 +1,16 @@
 name: Skills Framework for the Information Age rate card
 question: Add your Skills Framework for the Information Age (SFIA) rate card
-hint: This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
+hint: >
+  <p class="govuk-body">This document will not be indexed by search on the Digital Marketplace.</p>
+  <p class="govuk-body">Your document should:</p>
+  <ul class="govuk-list">
+    <li>be an Open Document Format (ODF) or PDF/A</li>
+    <li>have a maximum file size of 5MB</li>
+    <li>meet accessibility standards</li>
+  </ul>
+  <p class="govuk-body">
+    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs">Read the guidance on accessible documents (link opens in a new tab)</a>.
+  </p>
 
 optional: true
 depends:

--- a/frameworks/g-cloud-12/questions/services/termsAndConditionsDocumentURL.yml
+++ b/frameworks/g-cloud-12/questions/services/termsAndConditionsDocumentURL.yml
@@ -1,8 +1,16 @@
 name: Terms and conditions document
 question: Add your terms and conditions document
 hint: >
-  This document will not be indexed by search on the Digital Marketplace. Use an Open Document Format (ODF) or PDF/A
-  (eg .pdf, .odt). (Maximum file size 5MB.)
+  <p class="govuk-body">This document will not be indexed by search on the Digital Marketplace.</p>
+  <p class="govuk-body">Your document should:</p>
+  <ul class="govuk-list">
+    <li>be an Open Document Format (ODF) or PDF/A</li>
+    <li>have a maximum file size of 5MB</li>
+    <li>meet accessibility standards</li>
+  </ul>
+  <p class="govuk-body">
+    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs">Read the guidance on accessible documents (link opens in a new tab)</a>.
+  </p>
 
 depends:
   - "on": lot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.6.0",
+  "version": "17.7.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.6.0",
+  "version": "17.7.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/Rtcc6oi6/316-add-link-to-guidance-on-making-accessible-pdfs-on-application-5-places

We want to provide suppliers with guidance on uploading accessible documents.

Paired with @NoraGDS on the content.

There are 6 questions that involve file uploads:

1) Modern Slavery Statement (for suppliers with < £36m turnover) 
2) Modern Slavery Statement (for suppliers with >= £36m turnover)
3) Service definition document
4) Terms and conditions document
5) SFIA rate card 
6) Pricing document

### Screenshot for 1 (Q2 is very similar):
![pdf-guidance-modern-slavery](https://user-images.githubusercontent.com/3492540/75047690-1cfc3980-54bf-11ea-9f51-02b13d648c4d.png)


### Screenshot for 3 (Q4, 5 and 6 are very similar): 
![pdf-guidance-service-def-doc](https://user-images.githubusercontent.com/3492540/75047647-081fa600-54bf-11ea-95d0-c0df7ecc5bd7.png)