### PR TITLE
Additional copy_services fields 

### DIFF
--- a/frameworks/g-cloud-12/metadata/copy_services.yml
+++ b/frameworks/g-cloud-12/metadata/copy_services.yml
@@ -25,6 +25,8 @@ questions_to_copy:
 - backupScheduling
 - backupWhatData
 - boardLevelServiceSecurity
+- browsersAccess
+- browsersSupported
 - cloudDeploymentModel
 - commandLineInterface
 - commandLineOS
@@ -50,6 +52,8 @@ questions_to_copy:
 - datacentreSecurityStandards
 - devicesUsersManageTheServiceThrough
 - documentation
+- documentationAccessibility
+- documentationAccessibilityDescription
 - documentationFormats
 - documentationFormatsOther
 - educationPricing
@@ -60,6 +64,7 @@ questions_to_copy:
 - endOfContractDataExtraction
 - endOfContractProcess
 - energyEfficientDatacentres
+- energyEfficientDatacentresDescription
 - equipmentDisposalApproach
 - freeVersionDescription
 - freeVersionLink
@@ -107,6 +112,9 @@ questions_to_copy:
 - protectionOfDataAtRestOther
 - protectiveMonitoringApproach
 - protectiveMonitoringType
+- publicSectorNetworks
+- publicSectorNetworksOther
+- publicSectorNetworksTypes
 - resellingOrganisations
 - resellingType
 - scaling
@@ -116,6 +124,11 @@ questions_to_copy:
 - securityGovernanceApproach
 - securityGovernanceStandards
 - securityGovernanceStandardsOther
+- securityTesting
+- securityTestingAccreditations
+- securityTestingAccreditationsOther
+- securityTestingAccredited
+- securityTestingCCP
 - serviceAddOnDetails
 - serviceAddOnType
 - serviceBenefits

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.7.0",
+  "version": "17.7.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.7.0",
+  "version": "17.7.1",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/OZT4aPjn/367-copying-services-some-missing-fields

We reinstated some of the fields during the initial clone of the G12 content (https://github.com/alphagov/digitalmarketplace-frameworks/pull/599), but some got missed. This caused a bug, because we reintroduced `energyEfficientDatacentres`, but not `energyEfficientDatacentresDescription` (a dependent question).

There are also a few fields from G9 that never made it into the G11 copy list! See ticket for details.