### PR TITLE
Include opening time on homepage

### DIFF
--- a/frameworks/g-cloud-12/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-12/messages/homepage-sidebar.yml
@@ -1,5 +1,5 @@
 coming:
-  heading: 'G-Cloud&nbsp;12 will open on 3 March 2020'
+  heading: 'G-Cloud&nbsp;12 will open on 3 March 2020 at 3pm GMT.'
   messages:
     - 'Provide cloud hosting, software and support.'
     - 'You’ll need to create a supplier account to apply.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.7.2",
+  "version": "17.7.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.7.2",
+  "version": "17.7.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/FmDeNVc2/370-add-3pm-gmt-to-homepage

To manage supplier expectations on opening day, let's include the opening time on the home page sidebar:

![g12-homepage-time](https://user-images.githubusercontent.com/3492540/75545539-72d06480-5a1e-11ea-8ace-3364cd93ec55.png)

This version will need to be pulled into the Buyer FE.