### PR TITLE
Include missing Service interface question on display service manifest

### DIFF
--- a/frameworks/g-cloud-11/manifests/display_service.yml
+++ b/frameworks/g-cloud-11/manifests/display_service.yml
@@ -88,6 +88,8 @@
     - webInterfaceAccessibility
     - webInterfaceAccessibilityDescription
     - webInterfaceAccessibilityTesting
+    - serviceInterface
+    - serviceInterfaceDescription
     - serviceInterfaceAccessibility
     - serviceInterfaceAccessibilityDescription
     - serviceInterfaceTesting

--- a/frameworks/g-cloud-12/manifests/display_service.yml
+++ b/frameworks/g-cloud-12/manifests/display_service.yml
@@ -88,6 +88,8 @@
     - webInterfaceAccessibility
     - webInterfaceAccessibilityDescription
     - webInterfaceAccessibilityTesting
+    - serviceInterface
+    - serviceInterfaceDescription
     - serviceInterfaceAccessibility
     - serviceInterfaceAccessibilityDescription
     - serviceInterfaceTesting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.7.4",
+  "version": "17.8.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.7.4",
+  "version": "17.8.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/BuMK8EoJ/1535-service-interface-info-bug

The `serviceInterface` and `serviceInterfaceDescription` questions were introduced in G-Cloud 11. Suppliers filled out the details on Supplier FE during applications as normal. However the fields weren't included in the manifest for displaying live services on the Buyer FE. 

I've updated the manifests for G11 and G12 and tested that the fields show as expected in the 'Using the service' section:

![service-interface](https://user-images.githubusercontent.com/3492540/76840588-5eb6a080-682f-11ea-8f7c-faf19fc0e4ed.png)
