### PR TITLE
Update G-Cloud 12 dates

### DIFF
--- a/frameworks/g-cloud-12/messages/homepage-sidebar.yml
+++ b/frameworks/g-cloud-12/messages/homepage-sidebar.yml
@@ -8,7 +8,7 @@ open:
   heading: 'G-Cloud&nbsp;12 is open for applications'
   messages:
     - 'You need an account to apply.'
-    - 'The application deadline is 5pm&nbsp;BST, Wednesday 22 April 2020.'
+    - 'The application deadline is 5pm&nbsp;BST, Monday 20 July 2020.'
 
 pending:
   heading: 'G-Cloud&nbsp;12 is closed for applications'

--- a/frameworks/g-cloud-12/questions/declaration/canProvideFromDayOne.yml
+++ b/frameworks/g-cloud-12/questions/declaration/canProvideFromDayOne.yml
@@ -2,7 +2,7 @@ name: Providing services straight away
 question: >
   If your application is successful, can you provide all the services you’re submitting to G-Cloud&nbsp;12 from the first day you’re awarded a place on the framework?
 type: boolean
-hint: You must be ready to provide the services you’re submitting from July 2020.
+hint: You must be ready to provide the services you’re submitting from September 2020.
 assessment:
   passIfIn:
     - True

--- a/frameworks/g-cloud-12/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/g-cloud-12/questions/declaration/understandHowToAskQuestions.yml
@@ -2,7 +2,7 @@ name: Asking questions
 question: >
   Do you understand that you can ask ‘clarification’ questions on the <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/g-cloud-12/updates" target="_blank" rel="noopener noreferrer">G-Cloud&nbsp;12 updates page (link opens in a new tab)</a> in your Digital Marketplace account?
 hint: >
-  You can ask clarification questions about G-Cloud&nbsp;12 until 5pm BST 1 April 2020. All questions and answers will be posted regularly on the G-Cloud 12 updates page. You will be notified by email when new clarification questions and answers are available.
+  You can ask clarification questions about G-Cloud&nbsp;12 until 5pm BST 1 July 2020. All questions and answers will be posted regularly on the G-Cloud 12 updates page. You will be notified by email when new clarification questions and answers are available.
 
 type: boolean
 assessment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.8.1",
+  "version": "17.8.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.8.1",
+  "version": "17.8.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/uOuaPydJ/465-update-closing-date-for-g12-on-dmp-homepage

This is a first pass at updating the dates for G-Cloud 12. I may have missed some.