### PR TITLE
Update error messages for 'create a DOS brief' journey

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/accessRestrictions.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/accessRestrictions.yml
@@ -11,5 +11,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Add restrictions

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/additionalTermsOutcomesSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/additionalTermsOutcomesSpecialists.yml
@@ -16,5 +16,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Add terms and conditions

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/additionalTermsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/additionalTermsParticipants.yml
@@ -21,5 +21,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Add terms and conditions

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractStartDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractStartDate.yml
@@ -4,7 +4,7 @@ hint: 'eg 31/12/2020'
 type: date
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a date.'
   - name: invalid_format
     message: "Your answer must be a valid date."
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractStartDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractStartDate.yml
@@ -1,11 +1,11 @@
 name: What's the start date?
 question: What's the start date?
-hint: 'eg 31/12/2020'
+hint: 'For example, 31 5 2020'
 type: date
 validations:
   - name: answer_required
-    message: 'Enter a date.'
+    message: 'Enter the start date.'
   - name: invalid_format
-    message: "Your answer must be a valid date."
+    message: "Enter a real start date."
 
 empty_message: Set contract start date

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractValue.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractValue.yml
@@ -1,6 +1,6 @@
 name: What's the value?
 question: What's the value?
-hint: 'eg 9900.95 for 9900 pounds and 95 pence'
+hint: 'For example, 9900.95 for 9900 pounds and 95 pence'
 type: pricing
 decimal_place_restriction: true
 fields:
@@ -11,6 +11,6 @@ validations:
     message: 'Enter a contract value.'
   - name: not_money_format
     field: awardedContractValue
-    message: "Enter your value in pounds and pence using numbers and decimals only, for example 9900.05 for 9900 pounds and 5 pence."
+    message: "Enter the value in pounds and pence, using numbers and decimals only."
 
 empty_message: Set value

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractValue.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/awardedContractValue.yml
@@ -8,7 +8,7 @@ fields:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a contract value.'
   - name: not_money_format
     field: awardedContractValue
     message: "Enter your value in pounds and pence using numbers and decimals only, for example 9900.05 for 9900 pounds and 5 pence."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
@@ -15,7 +15,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description.'
   -
     name: under_200_words
     message: 'Your answer must be no more than 200 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/backgroundInformation.yml
@@ -18,5 +18,5 @@ validations:
     message: 'Enter a description.'
   -
     name: under_200_words
-    message: 'Your answer must be no more than 200 words.'
+    message: 'Description must be 200 words or fewer.'
 empty_message: Describe why the work is being done

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/budgetRangeOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/budgetRangeOutcomesParticipants.yml
@@ -21,5 +21,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Set budget range

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/budgetRangeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/budgetRangeSpecialists.yml
@@ -19,5 +19,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Add maximum day rate

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/contractLength.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/contractLength.yml
@@ -11,5 +11,5 @@ depends:
 validations:
   -
     name: under_character_limit
-    message: "Your answer must be no more than 100 characters."
+    message: "Description must be 100 characters or fewer."
 empty_message: Set expected contract length

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -49,7 +49,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -52,7 +52,7 @@ validations:
     message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -58,6 +58,6 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each criteria must be 300 characters or fewer."
 
 empty_message: Choose cultural fit criteria

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -55,7 +55,7 @@ validations:
     message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each criteria must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -49,7 +49,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -52,7 +52,7 @@ validations:
     message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -58,6 +58,6 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each criteria must be 300 characters or fewer."
 
 empty_message: Choose cultural fit criteria

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -55,7 +55,7 @@ validations:
     message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each criteria must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingOutcomes.yml
@@ -21,7 +21,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 5 and 20.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingOutcomes.yml
@@ -23,6 +23,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 5 and 20.'
+    message: 'Weighting must be between 5 and 20.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingParticipants.yml
@@ -21,6 +21,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 10 and 70.'
+    message: 'Weighting must be between 10 and 70.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingParticipants.yml
@@ -19,7 +19,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 10 and 70.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingSpecialists.yml
@@ -21,7 +21,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 5 and 20.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalWeightingSpecialists.yml
@@ -23,6 +23,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 5 and 20.'
+    message: 'Weighting must be between 5 and 20.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/earlyMarketEngagement.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/earlyMarketEngagement.yml
@@ -13,5 +13,5 @@ depends:
 validations:
   -
     name: under_200_words
-    message: 'Your answer must be no more than 200 words.'
+    message: 'Description must be 200 words or fewer.'
 empty_message: Describe early market engagement

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
@@ -22,5 +22,5 @@ validations:
     message: 'Enter a description of the users.'
   -
     name: under_200_words
-    message: 'Your answer must be no more than 200 words.'
+    message: 'Description must be 200 words or fewer.'
 empty_message: Describe the users and their needs

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/endUsers.yml
@@ -19,7 +19,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the users.'
   -
     name: under_200_words
     message: 'Your answer must be no more than 200 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
@@ -20,7 +20,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
@@ -29,5 +29,5 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each requirement must be 300 characters or fewer."
 empty_message: Add essential skills or experience

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
@@ -26,7 +26,7 @@ validations:
     message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each requirement must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
@@ -23,7 +23,7 @@ validations:
     message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
@@ -20,7 +20,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
@@ -29,5 +29,5 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each requirement must be 300 characters or fewer."
 empty_message: Add essential skills or experience

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
@@ -26,7 +26,7 @@ validations:
     message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each requirement must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
@@ -23,7 +23,7 @@ validations:
     message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
@@ -20,7 +20,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
@@ -29,5 +29,5 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each requirement must be 300 characters or fewer."
 empty_message: Add essential skills or experience

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
@@ -26,7 +26,7 @@ validations:
     message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each requirement must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
@@ -23,7 +23,7 @@ validations:
     message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeOutcomes.yml
@@ -37,5 +37,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select an assessment method.'
 empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeParticipants.yml
@@ -34,5 +34,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select an assessment method.'
 empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/evaluationTypeSpecialists.yml
@@ -38,5 +38,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select an assessment method.'
 empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamOutcomes.yml
@@ -17,5 +17,5 @@ validations:
     message: 'Enter a description of the team.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Describe existing team

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamOutcomes.yml
@@ -14,7 +14,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the team.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamSpecialists.yml
@@ -17,5 +17,5 @@ validations:
     message: 'Enter a description of the team.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Describe existing team

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/existingTeamSpecialists.yml
@@ -14,7 +14,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the team.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationOutcomes.yml
@@ -31,5 +31,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select a location.'
 empty_message: Choose location

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationParticipants.yml
@@ -30,5 +30,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select a location.'
 empty_message: Choose location

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationSpecialists.yml
@@ -31,5 +31,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select a location.'
 empty_message: Choose location

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
@@ -30,5 +30,5 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each requirement must be 300 characters or fewer."
 empty_message: Add nice-to-have skills and experience

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
@@ -24,7 +24,7 @@ validations:
     message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
@@ -21,7 +21,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
@@ -27,7 +27,7 @@ validations:
     message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each requirement must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
@@ -30,5 +30,5 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each requirement must be 300 characters or fewer."
 empty_message: Add nice-to-have skills and experience

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
@@ -24,7 +24,7 @@ validations:
     message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
@@ -21,7 +21,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
@@ -27,7 +27,7 @@ validations:
     message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each requirement must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
@@ -30,5 +30,5 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each requirement must be 300 characters or fewer."
 empty_message: Add nice-to-have skills and experience

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
@@ -24,7 +24,7 @@ validations:
     message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
@@ -21,7 +21,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 requirement.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
@@ -27,7 +27,7 @@ validations:
     message: 'Each requirement must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each requirement must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersOutcomes.yml
@@ -18,7 +18,7 @@ depends:
       - digital-outcomes
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter the number of suppliers.'
   - name: not_a_number
     message: 'You must evaluate at least 3, and no more than 15, suppliers.'
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersOutcomes.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: 'Enter the number of suppliers.'
   - name: not_a_number
-    message: 'You must evaluate at least 3, and no more than 15, suppliers.'
+    message: 'Number of suppliers must be between 3 and 15.'
 
 empty_message: Set how many suppliers to evaluate

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersParticipants.yml
@@ -18,7 +18,7 @@ depends:
       - user-research-participants
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter the number of suppliers.'
   - name: not_a_number
     message: 'You must evaluate at least 3, and no more than 15, suppliers.'
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersParticipants.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: 'Enter the number of suppliers.'
   - name: not_a_number
-    message: 'You must evaluate at least 3, and no more than 15, suppliers.'
+    message: 'Number of suppliers must be between 3 and 15.'
 
 empty_message: Set how many suppliers to evaluate

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersSpecialists.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: 'Enter the number of suppliers.'
   - name: not_a_number
-    message: 'You must evaluate at least 3, and no more than 15, specialists.'
+    message: 'Number of suppliers must be between 3 and 15.'
 
 empty_message: Set how many specialists to evaluate

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/numberOfSuppliersSpecialists.yml
@@ -18,7 +18,7 @@ depends:
       - digital-specialists
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter the number of suppliers.'
   - name: not_a_number
     message: 'You must evaluate at least 3, and no more than 15, specialists.'
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/organisation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/organisation.yml
@@ -12,7 +12,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter an organisation.'
   -
     name: under_character_limit
     message: "Your organisation name must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/organisation.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/organisation.yml
@@ -15,5 +15,5 @@ validations:
     message: 'Enter an organisation.'
   -
     name: under_character_limit
-    message: "Your organisation name must be no more than 100 characters."
+    message: "Organisation name must be 100 characters or fewer."
 empty_message: Add organisation

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
@@ -10,7 +10,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the problem.'
   -
     name: under_200_words
     message: 'Your answer must be no more than 200 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/outcome.yml
@@ -13,5 +13,5 @@ validations:
     message: 'Enter a description of the problem.'
   -
     name: under_200_words
-    message: 'Your answer must be no more than 200 words.'
+    message: 'Description must be 200 words or fewer.'
 empty_message: Describe problem

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantAccessibilityNeeds.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantAccessibilityNeeds.yml
@@ -13,5 +13,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Add requirements

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantSpecification.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantSpecification.yml
@@ -21,5 +21,5 @@ depends:
 validations:
   -
     name: under_200_words
-    message: 'Your answer must be no more than 200 words.'
+    message: 'Description must be 200 words or fewer.'
 empty_message: Describe participants

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantsPerRound.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantsPerRound.yml
@@ -13,7 +13,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter details on the number of participants.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantsPerRound.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantsPerRound.yml
@@ -13,7 +13,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'Enter details on the number of participants.'
+    message: 'Enter details of the number of participants.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantsPerRound.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/participantsPerRound.yml
@@ -16,5 +16,5 @@ validations:
     message: 'Enter details of the number of participants.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Details must be 100 words or fewer.'
 empty_message: Set number of participants

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceCriteria.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceCriteria.yml
@@ -33,4 +33,4 @@ empty_message: Choose payment approach
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select a payment approach.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingOutcomes.yml
@@ -19,7 +19,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 20 and 85.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingOutcomes.yml
@@ -21,6 +21,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 20 and 85.'
+    message: 'Weighting must be between 20 and 85.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingParticipants.yml
@@ -21,6 +21,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 20 and 80.'
+    message: 'Weighting must be between 20 and 80.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingParticipants.yml
@@ -19,7 +19,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 20 and 80.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingSpecialists.yml
@@ -18,7 +18,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 20 and 85.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/priceWeightingSpecialists.yml
@@ -20,6 +20,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 20 and 85.'
+    message: 'Weighting must be between 20 and 85.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsOutcomesParticipants.yml
@@ -32,7 +32,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter details of the session.'
   -
     name: under_100_words
     message: 'Your question and answer session details must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsOutcomesParticipants.yml
@@ -35,5 +35,5 @@ validations:
     message: 'Enter details of the session.'
   -
     name: under_100_words
-    message: 'Your question and answer session details must be no more than 100 words.'
+    message: 'Details must be 100 words or fewer.'
 empty_message: Add details

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
@@ -41,5 +41,5 @@ validations:
     message: 'Enter details of the session.'
   -
     name: under_100_words
-    message: 'Your question and answer session details must be no more than 100 words.'
+    message: 'Details must be 100 words or fewer.'
 empty_message: Add details

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
@@ -38,7 +38,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter details of the session.'
   -
     name: under_100_words
     message: 'Your question and answer session details must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/requirementsLengthSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/requirementsLengthSpecialists.yml
@@ -12,5 +12,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select a time span.'
 empty_message: Set requirements length

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchAddress.yml
@@ -19,5 +19,5 @@ validations:
     message: 'Enter a location.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Location must be 100 words or fewer.'
 empty_message: Add location

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchAddress.yml
@@ -5,7 +5,7 @@ question_advice: |
 
    - the town or city where the research will happen
    - more than one address if appropriate
-   - a description of the research envrionment, eg whether the research will happen in a lab, at a participants home,
+   - a description of the research environment, eg whether the research will happen in a lab, at a participants home,
      or in a neutral location like a community centre
 type: textbox_large
 max_length_in_words: 100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchAddress.yml
@@ -16,7 +16,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a location.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchDates.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchDates.yml
@@ -12,5 +12,5 @@ validations:
     message: 'Enter details of the dates.'
   -
     name: under_character_limit
-    message: "Your answer must be no more than 100 characters."
+    message: "Details must be 100 characters or fewer."
 empty_message: Add dates

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchDates.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchDates.yml
@@ -9,7 +9,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter details of the dates.'
   -
     name: under_character_limit
     message: "Your answer must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchFrequency.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchFrequency.yml
@@ -13,5 +13,5 @@ validations:
     message: 'Enter a description of the research frequency.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Describe how often research will happen

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchFrequency.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchFrequency.yml
@@ -10,7 +10,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the research frequency.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchPlan.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchPlan.yml
@@ -11,5 +11,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Describe research plan

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchRounds.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchRounds.yml
@@ -12,7 +12,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter details of the number of research rounds.'
   -
     name: under_character_limit
     message: "Your answer must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchRounds.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/researchRounds.yml
@@ -15,5 +15,5 @@ validations:
     message: 'Enter details of the number of research rounds.'
   -
     name: under_character_limit
-    message: "Your answer must be no more than 100 characters."
+    message: "Details must be 100 characters or fewer."
 empty_message: Set number of rounds

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/securityClearance.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/securityClearance.yml
@@ -17,5 +17,5 @@ depends:
 validations:
   -
     name: under_50_words
-    message: 'Your answer must be no more than 50 words.'
+    message: 'Description must be 50 words or fewer.'
 empty_message: Add security clearance

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/specialistRole.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/specialistRole.yml
@@ -122,5 +122,5 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Select a specialist role.'
 empty_message: Choose specialist role

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/specialistWork.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/specialistWork.yml
@@ -19,5 +19,5 @@ validations:
     message: 'Enter a description of the work.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Add responsibilities

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/specialistWork.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/specialistWork.yml
@@ -16,7 +16,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the work.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/startDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/startDate.yml
@@ -2,7 +2,7 @@ name: Latest start date
 question: Latest start date
 question_advice: |
   Say when you need suppliers to start work. When you shortlist, you can exclude suppliers who can’t start by this date.
-hint: 'eg 31 12 2020'
+hint: 'For example, 31 5 2020'
 type: date
 depends:
   - "on": "lot"
@@ -11,8 +11,8 @@ depends:
       - digital-specialists
 validations:
   - name: answer_required
-    message: 'Enter a date.'
+    message: 'Enter the start date.'
   - name: invalid_format
-    message: "Your answer must be a valid date."
+    message: "Enter a real start date."
 
 empty_message: Set latest start date

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/startDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/startDate.yml
@@ -11,7 +11,7 @@ depends:
       - digital-specialists
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a date.'
   - name: invalid_format
     message: "Your answer must be a valid date."
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
@@ -27,7 +27,7 @@ validations:
     message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
@@ -24,7 +24,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
@@ -30,7 +30,7 @@ validations:
     message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each criteria must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaOutcomes.yml
@@ -33,6 +33,6 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each criteria must be 300 characters or fewer."
 
 empty_message: Choose proposal criteria

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
@@ -23,7 +23,7 @@ validations:
     message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
-    message: 'Criteria must be no more than 30 words.'
+    message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
     message: 'You must have 20 or fewer criteria.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
@@ -26,7 +26,7 @@ validations:
     message: 'Each criteria must be 30 words or fewer.'
   -
     name: max_items_limit
-    message: 'You must have 20 or fewer criteria.'
+    message: 'You can add up to 20 criteria.'
   -
     name: under_character_limit
     message: "Each criteria must be 300 characters or fewer."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
@@ -29,6 +29,6 @@ validations:
     message: 'You must have 20 or fewer criteria.'
   -
     name: under_character_limit
-    message: 'Criteria must be no more than 300 characters.'
+    message: "Each criteria must be 300 characters or fewer."
 
 empty_message: Choose evaluation criteria

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/successCriteriaParticipants.yml
@@ -20,7 +20,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter at least 1 criteria.'
   -
     name: under_30_words
     message: 'Criteria must be no more than 30 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/summary.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/summary.yml
@@ -14,7 +14,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a summary of the work.'
   -
     name: under_50_words
     message: 'Your answer must be no more than 50 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/summary.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/summary.yml
@@ -17,5 +17,5 @@ validations:
     message: 'Enter a summary of the work.'
   -
     name: under_50_words
-    message: 'Your answer must be no more than 50 words.'
+    message: 'Summary must be 50 words or fewer.'
 empty_message: Provide a summary of the work

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingOutcomes.yml
@@ -23,7 +23,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 10 and 75.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingOutcomes.yml
@@ -25,6 +25,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 10 and 75.'
+    message: 'Weighting must be between 10 and 75.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingParticipants.yml
@@ -26,6 +26,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 10 and 70.'
+    message: 'Weighting must be between 10 and 70.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingParticipants.yml
@@ -24,7 +24,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 10 and 70.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingSpecialists.yml
@@ -26,6 +26,6 @@ validations:
   - name: answer_required
     message: 'Enter a weighting.'
   - name: not_a_number
-    message: 'Weighting must be a number between 10 and 75.'
+    message: 'Weighting must be between 10 and 75.'
   - name: total_should_be_100
     message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/technicalWeightingSpecialists.yml
@@ -24,7 +24,7 @@ limits:
 
 validations:
   - name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a weighting.'
   - name: not_a_number
     message: 'Weighting must be a number between 10 and 75.'
   - name: total_should_be_100

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleOutcomesParticipants.yml
@@ -12,7 +12,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a title.'
   -
     name: under_character_limit
     message: "Your title must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleOutcomesParticipants.yml
@@ -15,5 +15,5 @@ validations:
     message: 'Enter a title.'
   -
     name: under_character_limit
-    message: "Your title must be no more than 100 characters."
+    message: "Title must be 100 characters or fewer."
 empty_message: Add title

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleSpecialists.yml
@@ -18,5 +18,5 @@ validations:
     message: 'Enter a title.'
   -
     name: under_character_limit
-    message: "Your title must be no more than 100 characters."
+    message: "Title must be 100 characters or fewer."
 empty_message: Add title

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/titleSpecialists.yml
@@ -15,7 +15,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a title.'
   -
     name: under_character_limit
     message: "Your title must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workAlreadyDone.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workAlreadyDone.yml
@@ -11,5 +11,5 @@ depends:
 validations:
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Describe any work that has already been done

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workingArrangements.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workingArrangements.yml
@@ -19,7 +19,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter a description of the working arrangements.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workingArrangements.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workingArrangements.yml
@@ -22,5 +22,5 @@ validations:
     message: 'Enter a description of the working arrangements.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Description must be 100 words or fewer.'
 empty_message: Describe working arrangements

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workplaceAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workplaceAddress.yml
@@ -11,7 +11,7 @@ depends:
 validations:
   -
     name: answer_required
-    message: 'You need to answer this question.'
+    message: 'Enter an address.'
   -
     name: under_100_words
     message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workplaceAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/workplaceAddress.yml
@@ -14,5 +14,5 @@ validations:
     message: 'Enter an address.'
   -
     name: under_100_words
-    message: 'Your answer must be no more than 100 words.'
+    message: 'Address must be 100 words or fewer.'
 empty_message: Describe where the supplier will work

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.8.2",
+  "version": "17.9.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.8.2",
+  "version": "17.9.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/Vx63PlfP/12-review-error-messages-for-create-a-dos-opportunity-journey-in-frameworks-repo

Updates the error messages in the DOS 4 buyer journey to bring them in line with the [Design System guidance](https://design-system.service.gov.uk/components/text-input/#error-messages). 

See the equivalent changes for the G12 supplier application error messages: https://github.com/alphagov/digitalmarketplace-frameworks/pull/606

### Notes:
- The commits are broken down by error type (and field type, where the message differs).
- For the two date questions, I've also updated the given example, to match the guidance.
- As per the G12 questions, some DOS4 questions have both word limits and character limits. This is due to different validation methods (client side for word limit, API for character limit). There's a [tech debt card to investigate this further](https://trello.com/c/bNgj76dC/1282-review-word-limit-vs-character-limit).
- Spotted a typo on the `researchAddress` question that's been around since DOS1 (!).

### Content advice please:
For the list questions (`culturalFitCriteriaOutcomes`), I'm not 100% sure about the content. Previously we've referred to each list entry as a 'criteria' and worded the error messages to match, but in a way that avoids confusion over singular/plural. I'd rather not use 'criteria' at all but we use it elsewhere on the page. I tried using 'requirements' in this PR (see https://github.com/alphagov/digitalmarketplace-frameworks/pull/617/commits/51fffef3dc670a8ba57a1abfa95cf3ae32b34238), but that looks wrong too. Suggestions very welcome. I'll keep this PR in draft until we make a decision.

### Technical note: 
I forgot to switch github usernames on this repo, so I have accidentally co-committed everything with the `dmp-ssp-jenkins` user 🤦‍♀️ 