### PR TITLE
Add dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+# Dependabot config
+# https://dependabot.com/docs/config-file/
+# Checks and updates dependencies in
+# `requirements.txt`
+
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_type: "production"
+          update_type: "all"


### PR DESCRIPTION
https://trello.com/c/4ePZUeMK/1631-move-apps-tools-from-pyup-to-dependabot

We only have 1 third-party Python dependency in this repo, but we may as well be consistent.