### PR TITLE
remove ONS link from DOS4 framework

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationOutcomes.yml
@@ -6,7 +6,6 @@ question_advice: |
 
   Suppliers have said where they’ll provide outcomes.
 
-  [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
 depends:
 type: radios
 options:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationParticipants.yml
@@ -6,7 +6,6 @@ question_advice: |
 
   Suppliers have said where they can recruit participants.
 
-  [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
 depends:
 type: radios
 options:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/locationSpecialists.yml
@@ -6,7 +6,6 @@ question_advice: |
 
   Suppliers have said where they’ll provide specialists.
 
-  [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
 depends:
 type: radios
 options:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/agileCoachLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/agileCoachLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your agile coach work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/businessAnalystLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/businessAnalystLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your business analyst work? 
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/communicationsManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/communicationsManagerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your communications manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/contentDesignerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/contentDesignerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your content designer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataArchitectLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataArchitectLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your data architect work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataEngineerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataEngineerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your data engineer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/dataScientistLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/dataScientistLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your data scientist work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/deliveryManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/deliveryManagerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your delivery manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/designerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/designerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your designer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/developerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/developerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your developer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/outcomesLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/outcomesLocations.yml
@@ -7,7 +7,6 @@ question: |
 
   You can update the locations where you can provide services when the framework is live.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/performanceAnalystLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/performanceAnalystLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your performance analyst work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/portfolioManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/portfolioManagerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your portfolio manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/productManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/productManagerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your product manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/programmeManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/programmeManagerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your programme manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/qualityAssuranceLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/qualityAssuranceLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your quality assurance analyst work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/recruitLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/recruitLocations.yml
@@ -1,7 +1,6 @@
 id: locations
 question: Where can you recruit participants from?
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/securityConsultantLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/securityConsultantLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your cyber security consultant work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/serviceManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/serviceManagerLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your service manager work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/technicalArchitectLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/technicalArchitectLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your technical architect work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/userResearcherLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/userResearcherLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your user researcher work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/frameworks/digital-outcomes-and-specialists-4/questions/services/webOperationsLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/services/webOperationsLocations.yml
@@ -1,7 +1,6 @@
 question: Where will your web operations engineer work?
 question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
 hint: >
-    [View locations (PDF, 262KB)](http://www.ons.gov.uk/ons/guide-method/geography/beginner-s-guide/maps/regions--former-government-office-regions--gors---effective-at-31st-december--2011.pdf)
     ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
 depends:
   - "on": lot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.9.0",
+  "version": "17.10.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
This removes the ONS link as per https://trello.com/c/6b806g3r/40-remove-map-pdf-from-dos-brief-where-supplier-will-work
(I also removed it from the supplier questions, as it is assumed we would not want these links either in future iterations of the framework)
![Screenshot 2020-05-19 at 15 09 40](https://user-images.githubusercontent.com/1764158/82344512-0ac16700-99ec-11ea-93cd-4caccab7848c.png)