### PR TITLE
Use headings instead of bold text

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -24,7 +24,6 @@ question_advice: |
   ##Add cultural fit criteria
   When you evaluate shortlisted suppliers on cultural fit, you must use the criteria you list here.
 
-
   ##Suggested criteria
 
   - work as a team with our organisation and other suppliers
@@ -36,8 +35,7 @@ question_advice: |
   - be comfortable standing up for their discipline
   - can work with clients with low technical expertise
 
-
-  **The supplier should:**
+  ##The supplier should:
 
 type: list
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -24,7 +24,6 @@ question_advice: |
   ##Add cultural fit criteria
   When you evaluate shortlisted specialists on cultural fit, you must use the criteria you list here.
 
-
   ##Suggested criteria
 
   - work as a team with our organisation and other suppliers
@@ -36,8 +35,7 @@ question_advice: |
   - be comfortable standing up for their discipline
   - can work with clients with low technical expertise
 
-
-  **The specialist should:**
+  ##The specialist should:
 
 type: list
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsOutcomes.yml
@@ -8,7 +8,7 @@ question_advice: |
 
   For example: have experience designing services for users with low digital literacy.
 
-  **The supplier must:**
+  ##The supplier must:
 
 list_item_name: 'essential requirement'
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsParticipants.yml
@@ -8,7 +8,7 @@ question_advice: |
 
   For example: have experience recruiting participants with low digital literacy.
 
-  **The supplier must:**
+  ##The supplier must:
 
 list_item_name: 'essential requirement'
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/essentialRequirementsSpecialists.yml
@@ -8,7 +8,7 @@ question_advice: |
 
   For example: have experience designing services for users with low digital literacy.
 
-  **The specialist must:**
+  ##The specialist must:
 
 list_item_name: 'essential requirement'
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsOutcomes.yml
@@ -7,7 +7,7 @@ question_advice: |
   List the skills and experience you’d like the supplier to have.
   For example: provide evidence of delivering at scale.
 
-  **The supplier can:**
+  ##The supplier can:
 
 list_item_name: 'nice-to-have requirement'
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsParticipants.yml
@@ -8,7 +8,7 @@ question_advice: |
 
   For example: have experience recruiting participants with hernias.
 
-  **The supplier can:**
+  ##The supplier can:
 
 list_item_name: 'nice-to-have requirement'
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/niceToHaveRequirementsSpecialists.yml
@@ -7,7 +7,7 @@ question_advice: |
   List the skills and experience you’d like the specialist to have.
   For example: provide evidence of delivering at scale.
 
-  **The specialist can:**
+  ##The specialist can:
 
 list_item_name: 'nice-to-have requirement'
 number_of_items: 20

--- a/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
@@ -7,13 +7,13 @@ question_advice: |
   - the type of session you want to run, such as webinar, phone conference or meeting
   - the date and time of your session
 
-  **When to run a question and answer session**
+  ##When to run a question and answer session
 
   If your requirements are open for 1 week, you must hold your session within the first 2 working days of publishing.
 
   If your requirements are open for 2 weeks, you must hold your session within the first 5 working days of publishing.
 
-  **Information you should include**
+  ##Information you should include
 
   Depending on the type of session you choose, you could also include:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.10.2",
+  "version": "17.10.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.10.2",
+  "version": "17.10.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/X4vKC3Bv/112-2-apply-govuk-frontend-styles-to-frameworks-content-for-the-create-a-dos-opportunity-journey

We shouldn't really be using bold text in the places that we are, really - the Design System says "[use bold sparingly](https://design-system.service.gov.uk/styles/typography/)".

I've converted the examples below to headings, as that will give the same font size/weight as the other headings on the page (which is what we have currently anyway).

 