### PR TITLE
Exclude questions when cloning framework content

### DIFF
--- a/script_helpers/clone_helpers.py
+++ b/script_helpers/clone_helpers.py
@@ -107,8 +107,8 @@ class FrameworkContentCloner:
                     with open(os.path.join(root, filename), 'w') as f:
                         f.write(updated_content)
 
-    def update_metadata(self):
-        print("Setting metadata")
+    def update_copy_services_metadata(self):
+        print("Setting copy_services metadata")
         # Set copy_services.yml content
         copy_services_file = os.path.join(
             "frameworks", self._new_fw_slug, 'metadata', METADATA_FILES['copy_services']
@@ -125,6 +125,8 @@ class FrameworkContentCloner:
             print(f"Writing content to {copy_services_file}")
             yaml.dump(new_content, f)
 
+    def update_following_framework_metadata(self):
+        print("Setting following_framework metadata")
         # Set following_framework.yml content
         following_fw_file = os.path.join(
             "frameworks", self._new_fw_slug, 'metadata', METADATA_FILES['following_framework']
@@ -174,6 +176,7 @@ class FrameworkContentCloner:
     def clone(self):
         self.copy_fw_folder()
         self.replace_hardcoded_framework_name_and_slug()
-        self.update_metadata()
+        self.update_copy_services_metadata()
+        self.update_following_framework_metadata()
         self.update_dates()
         self.set_placeholders_for_file_urls()

--- a/script_helpers/clone_helpers.py
+++ b/script_helpers/clone_helpers.py
@@ -158,7 +158,7 @@ class FrameworkContentCloner:
     def set_placeholders_for_file_urls(self):
         print("Setting placeholder urls for as-yet unpublished files")
         file_placeholder_file = os.path.join(
-            "frameworks", self._new_fw_slug, 'metadata', FILE_PLACEHOLDER_FILES['urls']
+            "frameworks", self._new_fw_slug, FILE_PLACEHOLDER_FILES['urls']
         )
         with open(file_placeholder_file) as f:
             content = yaml.safe_load(f)

--- a/scripts/clone-latest-framework.py
+++ b/scripts/clone-latest-framework.py
@@ -10,9 +10,11 @@
 
 Usage:
     clone-latest-framework.py --family=<framework_family> --iteration=<iteration_number> --launch-year=<launch_year>
+    [--question-copy-method=exclude|copy]
 
 Example:
     ./scripts/clone-latest-framework.py --family=g-cloud --iteration=12 --launch-year=2020
+    --question-copy-method=exclude
 """
 import sys
 sys.path.insert(0, '.')
@@ -28,6 +30,9 @@ if __name__ == '__main__':
 
     iteration_number = int(arguments['--iteration'])
     launch_year = int(arguments['--launch-year'])
+    question_copy_method = arguments.get('--question-copy-method')
 
-    cloner = FrameworkContentCloner(framework_family, iteration_number, launch_year)
+    cloner = FrameworkContentCloner(
+        framework_family, iteration_number, launch_year, question_copy_method=question_copy_method
+    )
     cloner.clone()

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -5,122 +5,127 @@ import pytest
 from script_helpers.clone_helpers import get_fw_name_from_slug, get_nbsp_fw_name_from_slug, FrameworkContentCloner
 
 
-def test_get_fw_name_from_slug():
-    assert get_fw_name_from_slug('g-cloud-11') == 'G-Cloud 11'
-    assert get_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists 4'
+class TestFrameworkCloningHelpers:
+
+    def test_get_fw_name_from_slug(self):
+        assert get_fw_name_from_slug('g-cloud-11') == 'G-Cloud 11'
+        assert get_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists 4'
+
+    def test_get_nbsp_fw_name_from_slug(self):
+        assert get_nbsp_fw_name_from_slug('g-cloud-11') == 'G-Cloud&nbsp;11'
+        assert get_nbsp_fw_name_from_slug('digital-outcomes-and-specialists-4') == \
+            'Digital Outcomes and Specialists&nbsp;4'
 
 
-def test_get_nbsp_fw_name_from_slug():
-    assert get_nbsp_fw_name_from_slug('g-cloud-11') == 'G-Cloud&nbsp;11'
-    assert get_nbsp_fw_name_from_slug('digital-outcomes-and-specialists-4') == 'Digital Outcomes and Specialists&nbsp;4'
+class TestFrameworkClonerInit:
 
-
-@pytest.mark.parametrize(
-    'copy_method_kwarg, copy_method_expected',
-    [
-        ('copy', 'copy'),
-        ('exclude', 'exclude'),
-        (None, 'exclude')
-    ]
-)
-def test_framework_content_cloner_init(copy_method_kwarg, copy_method_expected):
-    cloner = FrameworkContentCloner('g-cloud', 12, 2020, question_copy_method=copy_method_kwarg)
-    assert cloner._launch_year == 2020
-    assert cloner._question_copy_method == copy_method_expected
-    assert cloner._new_fw_slug == 'g-cloud-12'
-    assert cloner._previous_fw_slug == 'g-cloud-11'
-    assert cloner._following_fw_slug == 'g-cloud-13'
-
-    assert cloner._previous_name == 'G-Cloud 11'
-    assert cloner._new_name == 'G-Cloud 12'
-    assert cloner._previous_nbsp_name == 'G-Cloud&nbsp;11'
-    assert cloner._escaped_previous_nbsp_name == 'G&#x2011;Cloud&nbsp;11'
-    assert cloner._new_nbsp_name == 'G-Cloud&nbsp;12'
-
-
-def test_framework_content_cloner_init_for_second_iteration():
-    cloner = FrameworkContentCloner('digital-outcomes-and-specialists', 2, 2017)
-    assert cloner._previous_fw_slug == 'digital-outcomes-and-specialists'
-
-
-def test_framework_content_cloner_init_fails_for_first_iteration():
-    with pytest.raises(ValueError) as exc:
-        FrameworkContentCloner('digital-outcomes-and-specialists', 1, 2016)
-    assert str(exc.value) == "Can't clone a framework on its first iteration"
-
-
-def test_replace_urls_with_placeholders():
-    cloner = FrameworkContentCloner('g-cloud', 12, 2020)
-    mock_file_contents = """
-        my_url: "https://gov.uk/path/to/g-cloud-11.pdf"
-        my_url2: "https://gov.uk/path/to/another/g-cloud-11.pdf"
-    """
-
-    with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_file_contents)) as mock_open:
-        cloner.set_placeholders_for_file_urls()
-        assert mock_open.call_args_list == [
-            mock.call('frameworks/g-cloud-12/messages/urls.yml'),
-            mock.call('frameworks/g-cloud-12/messages/urls.yml', 'w')
+    @pytest.mark.parametrize(
+        'copy_method_kwarg, copy_method_expected',
+        [
+            ('copy', 'copy'),
+            ('exclude', 'exclude'),
+            (None, 'exclude')
         ]
-        # What yaml.dump() does under the hood...
-        assert mock_open().write.call_args_list == [
-            mock.call('my_url'),
-            mock.call(':'),
-            mock.call(' '),
-            mock.call("https://gov.uk/path/to/g-cloud-11.pdf/__placeholder__"),
-            mock.call('\n'),
-            mock.call('my_url2'),
-            mock.call(':'),
-            mock.call(' '),
-            mock.call("https://gov.uk/path/to/another/g-cloud-11.pdf/__placeholder__"),
-            mock.call('\n')
-        ]
+    )
+    def test_framework_content_cloner_init(self, copy_method_kwarg, copy_method_expected):
+        cloner = FrameworkContentCloner('g-cloud', 12, 2020, question_copy_method=copy_method_kwarg)
+        assert cloner._launch_year == 2020
+        assert cloner._question_copy_method == copy_method_expected
+        assert cloner._new_fw_slug == 'g-cloud-12'
+        assert cloner._previous_fw_slug == 'g-cloud-11'
+        assert cloner._following_fw_slug == 'g-cloud-13'
+
+        assert cloner._previous_name == 'G-Cloud 11'
+        assert cloner._new_name == 'G-Cloud 12'
+        assert cloner._previous_nbsp_name == 'G-Cloud&nbsp;11'
+        assert cloner._escaped_previous_nbsp_name == 'G&#x2011;Cloud&nbsp;11'
+        assert cloner._new_nbsp_name == 'G-Cloud&nbsp;12'
+
+    def test_framework_content_cloner_init_for_second_iteration(self):
+        cloner = FrameworkContentCloner('digital-outcomes-and-specialists', 2, 2017)
+        assert cloner._previous_fw_slug == 'digital-outcomes-and-specialists'
+
+    def test_framework_content_cloner_init_fails_for_first_iteration(self):
+        with pytest.raises(ValueError) as exc:
+            FrameworkContentCloner('digital-outcomes-and-specialists', 1, 2016)
+        assert str(exc.value) == "Can't clone a framework on its first iteration"
 
 
-@pytest.mark.parametrize('copy_method', [None, 'exclude'])
-def test_update_copy_services_metadata_does_not_copy_if_mismatched_method(copy_method):
-    cloner = FrameworkContentCloner('g-cloud', 13, 2020, question_copy_method=copy_method)
-    mock_g12_copy_services_file = """
-        questions_to_copy:
-          - question1
-          - question2
-        source_framework: "g-cloud-11"
-    """
-    with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_g12_copy_services_file)) as mock_open:
-        cloner.update_copy_services_metadata()
-        assert mock_open.call_args_list == [
-            mock.call('frameworks/g-cloud-13/metadata/copy_services.yml'),
-            mock.call('frameworks/g-cloud-13/metadata/copy_services.yml', 'w')
-        ]
-        # What yaml.dump() does under the hood...
-        expected_yaml_dump_calls = [
-            'questions_to_exclude', ':', ' [', ']', '\n',
-            'source_framework', ':', ' ', 'g-cloud-12', '\n'
-        ]
-        assert mock_open().write.call_args_list == [mock.call(x) for x in expected_yaml_dump_calls]
+class TestReplaceUrls:
+
+    def test_replace_urls_with_placeholders(self):
+        cloner = FrameworkContentCloner('g-cloud', 12, 2020)
+        mock_file_contents = """
+            my_url: "https://gov.uk/path/to/g-cloud-11.pdf"
+            my_url2: "https://gov.uk/path/to/another/g-cloud-11.pdf"
+        """
+
+        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_file_contents)) as mock_open:
+            cloner.set_placeholders_for_file_urls()
+            assert mock_open.call_args_list == [
+                mock.call('frameworks/g-cloud-12/messages/urls.yml'),
+                mock.call('frameworks/g-cloud-12/messages/urls.yml', 'w')
+            ]
+            # What yaml.dump() does under the hood...
+            assert mock_open().write.call_args_list == [
+                mock.call('my_url'),
+                mock.call(':'),
+                mock.call(' '),
+                mock.call("https://gov.uk/path/to/g-cloud-11.pdf/__placeholder__"),
+                mock.call('\n'),
+                mock.call('my_url2'),
+                mock.call(':'),
+                mock.call(' '),
+                mock.call("https://gov.uk/path/to/another/g-cloud-11.pdf/__placeholder__"),
+                mock.call('\n')
+            ]
 
 
-def test_update_copy_services_metadata_clones_questions_if_matching_method():
-    cloner = FrameworkContentCloner('g-cloud', 13, 2020, question_copy_method='copy')
-    mock_g12_copy_services_file = """
-        questions_to_copy:
-          - question1
-          - question2
-        source_framework: "g-cloud-11"
-    """
-    with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_g12_copy_services_file)) as mock_open:
-        cloner.update_copy_services_metadata()
-        assert mock_open.call_args_list == [
-            mock.call('frameworks/g-cloud-13/metadata/copy_services.yml'),
-            mock.call('frameworks/g-cloud-13/metadata/copy_services.yml', 'w')
-        ]
-        # What yaml.dump() does under the hood...
-        expected_yaml_dump_calls = [
-            'questions_to_copy', ':', '\n',
-            '-', ' ', 'question1', '\n',
-            '-', ' ', 'question2', '\n',
-            'source_framework', ':', ' ', 'g-cloud-12', '\n'
-        ]
-        assert mock_open().write.call_args_list == [mock.call(x) for x in expected_yaml_dump_calls]
+class TestUpdateCopyServicesMetadata:
+
+    @pytest.mark.parametrize('copy_method', [None, 'exclude'])
+    def test_update_copy_services_metadata_does_not_copy_if_mismatched_method(self, copy_method):
+        cloner = FrameworkContentCloner('g-cloud', 13, 2020, question_copy_method=copy_method)
+        mock_g12_copy_services_file = """
+            questions_to_copy:
+              - question1
+              - question2
+            source_framework: "g-cloud-11"
+        """
+        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_g12_copy_services_file)) as mock_open:
+            cloner.update_copy_services_metadata()
+            assert mock_open.call_args_list == [
+                mock.call('frameworks/g-cloud-13/metadata/copy_services.yml'),
+                mock.call('frameworks/g-cloud-13/metadata/copy_services.yml', 'w')
+            ]
+            # What yaml.dump() does under the hood...
+            expected_yaml_dump_calls = [
+                'questions_to_exclude', ':', ' [', ']', '\n',
+                'source_framework', ':', ' ', 'g-cloud-12', '\n'
+            ]
+            assert mock_open().write.call_args_list == [mock.call(x) for x in expected_yaml_dump_calls]
+
+    def test_update_copy_services_metadata_clones_questions_if_matching_method(self):
+        cloner = FrameworkContentCloner('g-cloud', 13, 2020, question_copy_method='copy')
+        mock_g12_copy_services_file = """
+            questions_to_copy:
+              - question1
+              - question2
+            source_framework: "g-cloud-11"
+        """
+        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_g12_copy_services_file)) as mock_open:
+            cloner.update_copy_services_metadata()
+            assert mock_open.call_args_list == [
+                mock.call('frameworks/g-cloud-13/metadata/copy_services.yml'),
+                mock.call('frameworks/g-cloud-13/metadata/copy_services.yml', 'w')
+            ]
+            # What yaml.dump() does under the hood...
+            expected_yaml_dump_calls = [
+                'questions_to_copy', ':', '\n',
+                '-', ' ', 'question1', '\n',
+                '-', ' ', 'question2', '\n',
+                'source_framework', ':', ' ', 'g-cloud-12', '\n'
+            ]
+            assert mock_open().write.call_args_list == [mock.call(x) for x in expected_yaml_dump_calls]
 
 # TODO: add more test coverage for file copying/replacement :)

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -41,7 +41,7 @@ def test_framework_content_cloner_init_fails_for_first_iteration():
 
 
 def test_replace_urls_with_placeholders():
-    cloner = FrameworkContentCloner('g-cloud-12', 12, 2020)
+    cloner = FrameworkContentCloner('g-cloud', 12, 2020)
     mock_file_contents = """
         my_url: "https://gov.uk/path/to/g-cloud-11.pdf"
         my_url2: "https://gov.uk/path/to/another/g-cloud-11.pdf"
@@ -50,8 +50,8 @@ def test_replace_urls_with_placeholders():
     with mock.patch.object(builtins, 'open', mock.mock_open(read_data=mock_file_contents)) as mock_open:
         cloner.set_placeholders_for_file_urls()
         assert mock_open.call_args_list == [
-            mock.call('frameworks/g-cloud-12-12/metadata/messages/urls.yml'),
-            mock.call('frameworks/g-cloud-12-12/metadata/messages/urls.yml', 'w')
+            mock.call('frameworks/g-cloud-12/messages/urls.yml'),
+            mock.call('frameworks/g-cloud-12/messages/urls.yml', 'w')
         ]
         # What yaml.dump() does under the hood...
         assert mock_open().write.call_args_list == [


### PR DESCRIPTION
https://trello.com/c/WBjRZd14/80-2-frameworks-repo-copyservices-list-exclude-rather-than-include-fields

Updates the framework-cloning script to support questions to exclude from service copying.

- Assumes 'exclude' is the default
- Will not copy questions if the previous iteration doesn't match the copying method (i.e. DOS4 is 'questions_to_copy', so if the script was run to generate DOS5, it would produce an empty `questions_to_exclude`, ready for someone to fill in manually once we know what's to be excluded).
- If the copying methods match, clone as normal

Also did some tidying around the tests. 

These changes are only for a script, so we don't need to update the version number (as this code isn't used by the apps).