### PR TITLE
Clone DOS 5 from DOS 4

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/manifests/award_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/award_brief.yml
@@ -1,0 +1,6 @@
+-
+  name: Award Brief
+  editable: True
+  questions:
+    - awardedContractStartDate
+    - awardedContractValue

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/briefs_search_filters.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/briefs_search_filters.yml
@@ -1,0 +1,13 @@
+-
+  name: Status
+  questions:
+    - statusOpenClosed
+-
+  name: Location
+  slug: location
+  questions:
+    - locationAllLots
+-
+  name: Specialist role
+  questions:
+    - specialistRole

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/clarification_question.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/clarification_question.yml
@@ -1,0 +1,5 @@
+-
+  name: Publish questions and answers
+  editable: true
+  questions:
+    - questionAndAnswer

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
@@ -1,0 +1,198 @@
+-
+  name: Providing suitable services
+  slug: providing-suitable-services
+  editable: True
+  prefill: False
+  description: |
+    You must answer these questions to confirm that your services are suitable for Digital Outcomes and Specialists&nbsp;5.
+
+    You must be able to truthfully answer ‘yes’ to every question for your application to be considered eligible.
+    The Crown Commercial Service may ask for proof after you’ve submitted your application.
+
+    If you can’t answer ‘yes’ to every question in this section, it’s very unlikely that your application will be accepted.
+
+  questions:
+    - skillsAndResources
+    - offerServicesYourselves
+    - fullAccountability
+
+-
+  name: What it means to be on Digital Outcomes and Specialists&nbsp;5
+  slug: what-it-means-to-be-on-digital-outcomes-and-specialists-5
+  editable: True
+  prefill: False
+  description: |
+    If you make an application to Digital Outcomes and Specialists&nbsp;5, you need to agree to the terms and conditions in the legal documentation.
+
+    You also need to confirm that you’re not guilty of misconduct that affects the fairness of the procurement.
+
+    It’s unlikely your application will be accepted if you:
+
+    <ul class="list-bullet">
+    <li>don’t agree (answer ‘no’) to the terms given in questions [[termsOfParticipation]], [[termsAndConditions]], [[canProvideFromDayOne]], [[evidence]], [[10WorkingDays]] and [[MI]]</li>
+    <li>answer ‘yes’ to say you've been involved in the misconduct listed in question [[unfairCompetition]]</li>
+    </ul>
+
+  questions:
+    - termsOfParticipation
+    - termsAndConditions
+    - canProvideFromDayOne
+    - evidence
+    - unfairCompetition
+    - 10WorkingDays
+    - MI
+
+-
+  name: Grounds for mandatory exclusion
+  slug: grounds-for-mandatory-exclusion
+  editable: True
+  prefill: True
+  description: |
+    You must be able to truthfully answer ‘no’ to every question under ‘Grounds for mandatory exclusion’ for your
+    application to be considered eligible. If you can’t answer ‘no’ to every question in this section, it’s very
+    unlikely that your application will be accepted.
+
+    In questions [[conspiracy]] to [[organisedCrime]], ‘anyone who represents, supervises or has control in your
+    organisation or a partner or parent organisation’ includes members of your group of economic operators, their
+    proposed subcontractors, and any directors, partners, or any other person who has powers of representation,
+    decision or control. Check that your organisation complies with <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/57/made" target="_blank">Regulation 57(1) of the Public Contracts
+    Regulations 2015</a>.
+  questions:
+    - conspiracy
+    - corruptionBribery
+    - fraudAndTheft
+    - terrorism
+    - organisedCrime
+
+-
+  name: Grounds for discretionary exclusion
+  slug: grounds-for-discretionary-exclusion
+  editable: True
+  prefill: True
+  description: |
+    You must be able to truthfully answer ‘no’ to every question under ‘Grounds for discretionary exclusion’
+    for your bid to be considered eligible. If you can’t answer ‘no’, your bid may not be accepted.
+
+    If you do answer ‘yes’, you must provide full details of any subsequent event or remedial action that
+    you think the Crown Commercial Service (CCS) should take into consideration. CCS will use the information
+    you provide to consider whether or not you will be able to proceed any further with this procurement.
+
+    In questions [[taxEvasion]] to [[misleadingInformation]], ‘a partner organisation’ includes members
+    of your group of economic operators or their proposed subcontractors.
+
+    CCS can also exclude you if you are guilty of serious
+    misrepresentation in providing any information referred to within
+    regulations
+    <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/23/made" target="_blank" rel="noopener noreferrer">23 (new tab)</a>,
+    <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/24/made" target="_blank" rel="noopener noreferrer">24 (new tab)</a>,
+    <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/25/made" target="_blank" rel="noopener noreferrer">25 (new tab)</a>,
+    <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/26/made" target="_blank" rel="noopener noreferrer">26 (new tab)</a> or
+    <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/27/made" target="_blank" rel="noopener noreferrer">27 (new tab)</a>
+    of the <a href="http://www.legislation.gov.uk/uksi/2015/102/contents/made" target="_blank" rel="noopener noreferrer">Public Contracts Regulations 2015 (new tab)</a>
+    or if you fail to provide any such information it requests.
+  questions:
+    - taxEvasion
+    - environmentalSocialLabourLaw
+    - bankrupt
+    - graveProfessionalMisconduct
+    - distortingCompetition
+    - conflictOfInterest
+    - distortedCompetition
+    - significantOrPersistentDeficiencies
+    - seriousMisrepresentation
+    - witheldSupportingDocuments
+    - influencedContractingAuthority
+    - confidentialInformation
+    - misleadingInformation
+    - mitigatingFactors
+    - unspentTaxConvictions
+    - GAAR
+    - mitigatingFactors2
+
+-
+  name: Working with government
+  slug: working-with-government
+  editable: True
+  prefill: True
+  description: |
+    You must be able to truthfully answer ‘yes’ to every question under ‘Working with government’ for your bid to be
+    considered eligible.
+
+    If you can’t answer ‘yes’ to every question in this section, it’s very unlikely that your bid will be accepted.
+  questions:
+    - environmentallyFriendly
+    - equalityAndDiversity
+    - employersInsurance
+    - helpBuyersComplyTechnologyCodesOfPractice
+    - serviceStandard
+    - transparentContracting
+    - publishContracts
+    - safeguardOfficialInformation
+    - safeguardPersonalData
+    - skillsAndCapabilityAssessment
+    - continuousProfessionalDevelopment
+    - customerSatisfactionProcess
+    - civilServiceValues
+
+-
+  name: How you apply
+  slug: how-you-apply
+  editable: True
+  prefill: False
+  description: |
+    You must be able to truthfully answer ‘yes’ to every question on this page for your application to be considered eligible.
+
+    If you can’t answer ‘yes’ to every question on this page, it’s very unlikely that your application will be accepted.
+
+  questions:
+    - readUnderstoodGuidance
+    - understandTool
+    - understandHowToAskQuestions
+
+-
+  name: Application accuracy
+  slug: application-accuracy
+  editable: True
+  prefill: False
+  description: |
+    You must confirm the accuracy of the information in this declaration and in your service descriptions. We might
+    ask for proof after you’ve submitted your application.
+
+  questions:
+    - accurateInformation
+    - informationChanges
+    - accuratelyDescribed
+    - proofOfClaims
+
+-
+  name: How you’ll deliver your services
+  slug: how-youll-deliver-your-services
+  editable: True
+  prefill: False
+  description: |
+    The Crown Commercial Service will use this information to manage your participation in Digital Outcomes and Specialists&nbsp;5.
+  questions:
+    - subcontracting
+    - employmentStatus
+    - outsideIR35
+
+-
+  name: Contact details
+  slug: contact-details
+  editable: True
+  prefill: True
+  description: |
+     The Crown Commercial Service will use the primary contact information to contact your organisation if it has any questions about your application.
+  questions:
+    - primaryContact
+    - primaryContactEmail
+    - contactNameContractNotice
+    - contactEmailContractNotice
+
+-
+  name: Modern slavery
+  slug: modern-slavery
+  editable: True
+  prefill: False
+  questions:
+    - multiqModernSlavery

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief.yml
@@ -1,0 +1,76 @@
+-
+  name: Overview
+  questions:
+    - specialistRole
+    - summary
+    - startDate
+    - contractLength
+    - locationOutcomes
+    - locationSpecialists
+    - locationParticipants
+    - researchDates
+    - organisation
+    - budgetRangeOutcomesParticipants
+    - budgetRangeSpecialists
+-
+  name: About the work
+  questions:
+    - backgroundInformation
+    - outcome
+    - endUsers
+    - earlyMarketEngagement
+    - workAlreadyDone
+    - existingTeamOutcomes
+    - existingTeamSpecialists
+    - specialistWork
+    - phase
+-
+  name: About the research
+  questions:
+    - participantSpecification
+    - participantAccessibilityNeeds
+    - researchPlan
+    - researchAddress
+    - accessRestrictions
+    - researchRounds
+    - participantsPerRound
+    - researchFrequency
+    - researchOutOfHours
+-
+  name: Work setup
+  questions:
+    - workplaceAddress
+    - workingArrangements
+    - securityClearance
+-
+  name: Additional information
+  questions:
+    - additionalTermsOutcomesSpecialists
+    - additionalTermsParticipants
+-
+  name: Skills and experience
+  summary_page_description: Buyers will use the essential and nice-to-have skills and experience to help them evaluate suppliers’ technical competence.
+  questions:
+    - essentialRequirementsOutcomes
+    - essentialRequirementsSpecialists
+    - essentialRequirementsParticipants
+    - niceToHaveRequirementsOutcomes
+    - niceToHaveRequirementsSpecialists
+    - niceToHaveRequirementsParticipants
+-
+  name: How suppliers will be evaluated
+  questions:
+    - numberOfSuppliersOutcomes
+    - numberOfSuppliersSpecialists
+    - numberOfSuppliersParticipants
+    - successCriteriaOutcomes
+    - successCriteriaParticipants
+    - culturalFitCriteriaOutcomes
+    - culturalFitCriteriaSpecialists
+    - priceCriteria
+    - evaluationTypeOutcomes
+    - evaluationTypeSpecialists
+    - evaluationTypeParticipants
+    - weightingOutcomes
+    - weightingSpecialists
+    - weightingParticipants

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief_response.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief_response.yml
@@ -1,0 +1,14 @@
+-
+  name: Your details
+  questions:
+    - dayRate
+    - availability
+    - respondToEmailAddress
+-
+  name: Your essential skills and experience
+  questions:
+    - essentialRequirements
+-
+  name: Your nice-to-have skills and experience
+  questions:
+    - niceToHaveRequirements

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
@@ -1,0 +1,186 @@
+-
+  name: Title
+  editable: True
+  step: 1
+  questions:
+    - titleSpecialists
+    - titleOutcomesParticipants
+-
+  name: Specialist role
+  editable: True
+  step: 1
+  questions:
+    - specialistRole
+-
+  name: Location
+  editable: True
+  step: 1
+  questions:
+    - locationOutcomes
+    - locationSpecialists
+    - locationParticipants
+-
+  name: Description of work
+  editable: True
+  step: 1
+  description: |
+    This will help suppliers decide whether to apply.
+  questions:
+    - organisation
+    - backgroundInformation
+    - outcome
+    - specialistWork
+    - endUsers
+    - earlyMarketEngagement
+    - workAlreadyDone
+    - phase
+    - existingTeamOutcomes
+    - existingTeamSpecialists
+    - researchRounds
+    - participantsPerRound
+    - researchDates
+    - researchFrequency
+    - researchOutOfHours
+    - researchAddress
+    - accessRestrictions
+    - participantSpecification
+    - participantAccessibilityNeeds
+    - researchPlan
+    - workplaceAddress
+    - workingArrangements
+    - securityClearance
+    - startDate
+    - contractLength
+    - additionalTermsOutcomesSpecialists
+    - additionalTermsParticipants
+    - budgetRangeOutcomesParticipants
+    - budgetRangeSpecialists
+    - summary
+
+-
+  name: Shortlist and evaluation process
+  editable: True
+  step: 2
+  description: |
+    There are 3 stages to finding the supplier that best meets your needs.
+
+    ##1\. View suppliers who applied
+    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+
+    ##2\. Create a shortlist
+    Once you have a list of eligible suppliers, you can exclude the suppliers who:
+
+    - have the least nice&#8209;to&#8209;have skills and experience
+    - can’t start when you need them to
+
+    You may need to ask for evidence of skills and experience if you have too many suppliers.
+
+
+    ##3\. Evaluate your shortlist
+    Ask the shortlisted suppliers for:
+
+      - evidence of their skills and experience
+      - a proposal explaining how they plan to meet your requirements
+
+    All suppliers must provide a written proposal. You can choose additional assessment methods, for example a presentation.
+
+    You must tell suppliers how you’ll evaluate and assess them.
+
+  questions:
+    - numberOfSuppliersOutcomes
+    - weightingOutcomes
+    - technicalCompetenceCriteriaOutcomes
+    - culturalFitCriteriaOutcomes
+    - priceCriteria
+    - evaluationTypeOutcomes
+
+-
+  name: Shortlist and evaluation process
+  editable: True
+  step: 2
+  description: |
+    There are 3 stages to finding the specialist that best meets your needs.
+
+    ##1\. View specialists who applied
+    When specialists apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Specialists who don’t meet your essential skills and experience are excluded.
+
+    ##2\. Create a shortlist
+    Once you have a list of eligible specialists, you can exclude the specialists who:
+
+    - have the least nice&#8209;to&#8209;have skills and experience
+    - can’t start when you need them to
+
+    You may need to ask for evidence of skills and experience if you have too many specialists.
+
+
+    ##3\. Evaluate your shortlist
+    Ask the shortlisted specialists for evidence of their skills and experience.
+
+    All suppliers must provide a written proposal. You can choose additional assessment methods, for example a presentation.
+
+    You must tell specialists how you’ll evaluate and assess them.
+
+  questions:
+    - numberOfSuppliersSpecialists
+    - weightingSpecialists
+    - technicalCompetenceCriteriaSpecialists
+    - culturalFitCriteriaSpecialists
+    - evaluationTypeSpecialists
+
+-
+  name: Shortlist and evaluation process
+  editable: True
+  step: 2
+  description: |
+    There are 3 stages to finding the supplier that best meets your needs.
+
+    ##1\. View suppliers who applied
+    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+
+    ##2\. Create a shortlist
+    Once you have a list of eligible suppliers, you can exclude the suppliers who:
+
+    - have the least nice&#8209;to&#8209;have skills and experience
+    - can’t start when you need them to
+
+    You may need to ask for evidence of skills and experience if you have too many suppliers.
+
+
+    ##3\. Evaluate your shortlist
+    Ask the shortlisted suppliers for:
+
+      - evidence of their skills and experience
+      - a proposal explaining how they plan to recruit particpants
+
+    All suppliers must provide a written proposal. You can choose additional assessment methods, for example a case study.
+
+    You must tell suppliers how you’ll evaluate and assess them.
+
+  questions:
+    - numberOfSuppliersParticipants
+    - weightingParticipants
+    - technicalCompetenceCriteriaParticipants
+    - evaluationTypeParticipants
+
+-
+  name: Set how long your requirements will be open for
+  editable: True
+  step: 3
+  questions:
+    - requirementsLengthSpecialists
+
+-
+  name: Describe question and answer session
+  editable: True
+  step: 3
+  description: |
+    While the application period is open, you need to reply to all questions suppliers ask about your requirements.
+
+    When a supplier asks a question, you’ll be sent an email to the email address you registered with.
+
+    You’ll need to post all questions and answers on the Digital Marketplace so that all suppliers can see them.
+
+    Providing a question and answer session means you can explain your needs and answer any questions quickly.
+  questions:
+    - questionAndAnswerSessionDetailsOutcomesParticipants
+    - questionAndAnswerSessionDetailsSpecialists

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief_response.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief_response.yml
@@ -1,0 +1,10 @@
+-
+  name: Apply for this opportunity
+  editable: True
+  questions:
+    - availability
+    - dayRate
+    - essentialRequirementsMet
+    - essentialRequirements
+    - niceToHaveRequirements
+    - respondToEmailAddress

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service.yml
@@ -1,0 +1,126 @@
+-
+  name: Lab name
+  editable: False
+  questions:
+    - serviceName
+
+- name: Service essentials
+  editable: False
+  questions:
+    - helpGovernmentImproveServices
+    - bespokeSystemInformation
+    - dataProtocols
+    - openStandardsPrinciples
+
+- name: User research participants essentials
+  editable: False
+  questions:
+    - anonymousRecruitment
+    - manageIncentives
+
+- name: Team capabilities
+  editable: False
+  questions:
+    - performanceAnalysis
+    - security
+    - delivery
+    - softwareDevelopment
+    - supportAndOperations
+    - testingAndAuditing
+    - userExperienceAndDesign
+    - userResearch
+
+- name: Outcomes locations
+  editable: False
+  questions:
+    - outcomesLocations
+
+- name: Individual specialist roles
+  editable: False
+  questions:
+    - agileCoach
+    - businessAnalyst
+    - communicationsManager
+    - contentDesigner
+    - securityConsultant
+    - dataArchitect
+    - dataEngineer
+    - dataScientist
+    - deliveryManager
+    - designer
+    - developer
+    - performanceAnalyst
+    - portfolioManager
+    - productManager
+    - programmeManager
+    - qualityAssurance
+    - serviceManager
+    - technicalArchitect
+    - userResearcher
+    - webOperations
+
+- name: Lab address
+  editable: False
+  questions:
+    - labAddressBuilding
+    - labAddressTown
+    - labAddressPostcode
+
+- name: Transport
+  editable: False
+  questions:
+    - labPublicTransport
+    - labCarPark
+
+- name: Lab size
+  editable: False
+  questions:
+    - labSize
+
+- name: Viewing
+  editable: False
+  questions:
+    - labViewingArea
+    - labStreaming
+    - labDesktopStreaming
+    - labDeviceStreaming
+    - labEyeTracking
+    - labWiFi
+
+- name: Technical assistance
+  editable: False
+  questions:
+    - labTechAssistance
+
+- name: Hospitality
+  editable: False
+  questions:
+    - labHosting
+    - labWaitingArea
+
+- name: Facilities
+  editable: False
+  questions:
+    - labToilets
+    - labBabyChanging
+
+- name: Accessibility
+  editable: False
+  questions:
+    - labAccessibility
+
+- name: Price
+  editable: False
+  questions:
+    - labPrice
+
+- name: Recruitment approach
+  editable: False
+  questions:
+    - recruitMethods
+    - recruitFromList
+
+- name: Location
+  editable: False
+  questions:
+    - recruitLocations

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service_as_admin.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service_as_admin.yml
@@ -1,0 +1,127 @@
+- name: Lab name
+  editable: True
+  questions:
+    - serviceName
+
+- name: Service essentials
+  editable: False
+  questions:
+    - helpGovernmentImproveServices
+    - bespokeSystemInformation
+    - dataProtocols
+    - openStandardsPrinciples
+
+- name: User research participants essentials
+  editable: False
+  questions:
+    - anonymousRecruitment
+    - manageIncentives
+
+- name: Team capabilities
+  editable: False
+  edit_questions: True
+  questions:
+    - performanceAnalysis
+    - security
+    - delivery
+    - softwareDevelopment
+    - supportAndOperations
+    - testingAndAuditing
+    - userExperienceAndDesign
+    - userResearch
+
+- name: Outcomes locations
+  editable: True
+  questions:
+    - outcomesLocations
+
+- name: Individual specialist roles
+  editable: False
+  edit_questions: True
+  questions:
+    - agileCoach
+    - businessAnalyst
+    - communicationsManager
+    - contentDesigner
+    - securityConsultant
+    - dataArchitect
+    - dataEngineer
+    - dataScientist
+    - deliveryManager
+    - designer
+    - developer
+    - performanceAnalyst
+    - portfolioManager
+    - productManager
+    - programmeManager
+    - qualityAssurance
+    - serviceManager
+    - technicalArchitect
+    - userResearcher
+    - webOperations
+
+- name: Lab address
+  editable: True
+  questions:
+    - labAddressBuilding
+    - labAddressTown
+    - labAddressPostcode
+
+- name: Transport
+  editable: True
+  questions:
+    - labPublicTransport
+    - labCarPark
+
+- name: Lab size
+  editable: True
+  questions:
+    - labSize
+
+- name: Viewing
+  editable: True
+  questions:
+    - labViewingArea
+    - labStreaming
+    - labDesktopStreaming
+    - labDeviceStreaming
+    - labEyeTracking
+    - labWiFi
+
+- name: Technical assistance
+  editable: True
+  questions:
+    - labTechAssistance
+
+- name: Hospitality
+  editable: True
+  questions:
+    - labHosting
+    - labWaitingArea
+
+- name: Facilities
+  editable: True
+  questions:
+    - labToilets
+    - labBabyChanging
+
+- name: Accessibility
+  editable: True
+  questions:
+    - labAccessibility
+
+- name: Price
+  editable: True
+  questions:
+    - labPrice
+
+- name: Recruitment approach
+  editable: True
+  questions:
+    - recruitMethods
+    - recruitFromList
+
+- name: Location
+  editable: True
+  questions:
+    - recruitLocations

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_submission.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_submission.yml
@@ -1,0 +1,145 @@
+-
+  name: Lab name
+  editable: True
+  questions:
+    - serviceName
+
+- name: Service essentials
+  editable: True
+  description: >
+    You must be able to truthfully answer ‘yes’ to every question  for your
+    bid to be considered eligible. If you can’t answer ‘yes’ to every question
+    in this section, it’s very unlikely that your bid will be accepted.
+  questions:
+    - helpGovernmentImproveServices
+    - bespokeSystemInformation
+    - dataProtocols
+    - openStandardsPrinciples
+    - accessibleApplicationsOutcomes
+
+- name: User research participants essentials
+  editable: True
+  description: >
+    You must be able to truthfully answer ‘yes’ to every question for your bid
+    to be considered eligible. If you can’t answer ‘yes’ to every question in
+    this section, it’s very unlikely that your bid will be accepted.
+  questions:
+    - anonymousRecruitment
+    - manageIncentives
+
+- name: Team capabilities
+  summary_page_description: >
+    You must be able to provide at least one team capability to be eligible to
+    supply digital outcomes.
+  editable: False
+  edit_questions: True
+  questions:
+    - performanceAnalysis
+    - security
+    - delivery
+    - softwareDevelopment
+    - supportAndOperations
+    - testingAndAuditing
+    - userExperienceAndDesign
+    - userResearch
+
+- name: Outcomes locations
+  editable: true
+  questions:
+    - outcomesLocations
+
+- name: Individual specialist roles
+  summary_page_description: >
+    You must be able to provide at least one individual specialist role to be
+    eligible to supply digital specialists.
+  editable: False
+  edit_questions: True
+  questions:
+    - agileCoach
+    - businessAnalyst
+    - communicationsManager
+    - contentDesigner
+    - securityConsultant
+    - dataArchitect
+    - dataEngineer
+    - dataScientist
+    - deliveryManager
+    - designer
+    - developer
+    - performanceAnalyst
+    - portfolioManager
+    - productManager
+    - programmeManager
+    - qualityAssurance
+    - serviceManager
+    - technicalArchitect
+    - userResearcher
+    - webOperations
+
+- name: Lab address
+  editable: True
+  questions:
+    - labAddressBuilding
+    - labAddressTown
+    - labAddressPostcode
+
+- name: Transport
+  editable: True
+  description: >
+    Help buyers understand how easy it is for visitors to reach your studio.
+  questions:
+    - labPublicTransport
+    - labCarPark
+
+- name: Lab size
+  editable: True
+  questions:
+    - labSize
+
+- name: Viewing
+  editable: True
+  questions:
+    - labViewingArea
+    - labStreaming
+    - labDesktopStreaming
+    - labDeviceStreaming
+    - labEyeTracking
+    - labWiFi
+
+- name: Technical assistance
+  editable: True
+  questions:
+    - labTechAssistance
+
+- name: Hospitality
+  editable: True
+  questions:
+    - labHosting
+    - labWaitingArea
+
+- name: Facilities
+  editable: True
+  questions:
+    - labToilets
+    - labBabyChanging
+
+- name: Accessibility
+  editable: True
+  questions:
+    - labAccessibility
+
+- name: Price
+  editable: True
+  questions:
+    - labPrice
+
+- name: Recruitment approach
+  editable: True
+  questions:
+    - recruitMethods
+    - recruitFromList
+
+- name: Location
+  editable: True
+  questions:
+    - recruitLocations

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/output_brief_response.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/output_brief_response.yml
@@ -1,0 +1,9 @@
+-
+  name: View response to requirements
+  questions:
+    - supplierName
+    - respondToEmailAddress
+    - availability
+    - dayRate
+    - essentialRequirements
+    - niceToHaveRequirements

--- a/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
@@ -1,0 +1,41 @@
+coming: |
+  <div class="explanation-list">
+    Digital Outcomes and Specialists is opening for applications.<br />
+    You will be able to apply to sell:
+    <ul class="list-bullet">
+      <li>digital outcomes, for example a team to build a service</li>
+      <li>digital specialists, for example an individual developer or user researcher</li>
+      <li>user research studios</li>
+      <li>user research participants</li>
+    </ul>
+  </div>
+
+open: |
+  <div class="explanation-list">
+    Digital Outcomes and Specialists is open for applications.<br />
+    You can apply to sell:
+    <ul class="list-bullet">
+      <li>digital outcomes, for example a team to build a service</li>
+      <li>digital specialists, for example an individual developer or user researcher</li>
+      <li>user research studios</li>
+      <li>user research participants</li>
+    </ul>
+  </div>
+
+pending: &can_not_apply |
+  <div class="explanation-list">
+    Digital Outcomes and Specialists is closed for applications.<br />
+    You will be able to apply to sell:
+    <ul class="list-bullet">
+      <li>digital outcomes, for example a team to build a service</li>
+      <li>digital specialists, for example an individual developer or user researcher</li>
+      <li>user research studios</li>
+      <li>user research participants</li>
+    </ul>
+  </div>
+
+standstill: *can_not_apply
+
+live: *can_not_apply
+
+expired: *can_not_apply

--- a/frameworks/digital-outcomes-and-specialists-5/messages/homepage-sidebar.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/homepage-sidebar.yml
@@ -1,0 +1,16 @@
+coming:
+  heading: 'Digital Outcomes and Specialists&nbsp;5 coming soon'
+  messages:
+    - 'Provide digital outcomes and specialists, and user research studios and participants.'
+    - 'You’ll need to create a supplier account to apply.'
+
+open:
+  heading: 'Digital Outcomes and Specialists&nbsp;5 is open for applications'
+  messages:
+    - 'You need an account to apply.'
+    - 'The application deadline is 5pm&nbsp;BST, 15 August 2525.'
+
+pending:
+  heading: 'Digital Outcomes and Specialists&nbsp;5 is closed for applications'
+  messages:
+    - 'Applications are being reviewed.'

--- a/frameworks/digital-outcomes-and-specialists-5/messages/urls.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/urls.yml
@@ -1,0 +1,4 @@
+call_off_contract_url: https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-call-off-contract/__placeholder__
+framework_agreement_pdf_url: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/738942/digital-outcomes-and-specialists-5-framework-agreement.pdf/__placeholder__
+framework_agreement_url: https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-framework-agreement/__placeholder__
+supplier_guide_url: https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#how-to-apply-to-the-framework/__placeholder__

--- a/frameworks/digital-outcomes-and-specialists-5/metadata/copy_services.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/metadata/copy_services.yml
@@ -1,0 +1,2 @@
+questions_to_exclude: []
+source_framework: digital-outcomes-and-specialists-4

--- a/frameworks/digital-outcomes-and-specialists-5/metadata/following_framework.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/metadata/following_framework.yml
@@ -1,0 +1,4 @@
+framework:
+  coming: '2021'
+  name: Digital Outcomes and Specialists 6
+  slug: digital-outcomes-and-specialists-6

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
@@ -1,0 +1,22 @@
+name: Earliest start date
+question: When is the earliest {% if brief.lotSlug == "digital-outcomes" %}the team can start?{% elif brief.lotSlug == "digital-specialists" %}the specialist can start work?{% else %}you can recruit participants?{% endif %}
+hint: 'eg 31/12/2020'
+question_advice: >
+  The buyer needs
+  {%- if brief.lotSlug == "digital-outcomes" %}
+  the team to start: {{ brief.startDate|datetodatetimeformat }}
+  {%- elif brief.lotSlug == "digital-specialists" %}
+  the specialist to start: {{ brief.startDate|datetodatetimeformat }}
+  {%- else %}
+  participants: {{ brief.researchDates }}
+  {%- endif %}
+type: text
+smaller: true
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your start date must be no more than 100 characters."
+empty_message: Set date

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
@@ -1,0 +1,22 @@
+name: Day rate
+question: What’s the specialist’s day rate?
+question_advice: "{% if 'budgetRange' in brief %}<h2>Buyer's maximum day rate:</h2><p>{{ brief.budgetRange }}</p>{% endif %}<h2>Your maximum day rate:</h2><p>£{{ max_day_rate }}</p>"
+type: pricing
+fields:
+  price: dayRate
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dayRate
+    message: "Day rate must be in numbers and decimal points only, for example 99.95."
+  - name: max_less_than_min
+    field: dayRate
+    message: "This can't be more than the maximum day rate you've already provided."
+
+empty_message: Set rate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirements.yml
@@ -1,0 +1,26 @@
+name: Essential skills and experience
+question: Give evidence of the essential skills and experience
+question_advice: |
+  The buyer will assess and score your evidence to shortlist the best suppliers.
+
+  You’ll need to meet or exceed their requirements to get through to the next stage.
+
+  <h3>Evidence structure</h3>
+  <div class="explanation-list">
+    <p class="lead">When you write your evidence, you should be specific about:</p>
+
+    <ul class="list-bullet">
+      <li>what the situation was</li>
+      <li>the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did</li>
+      <li>what the results were</li>
+    </ul>
+  </div>
+
+  You should only provide one example for each essential requirement (unless the buyer specifies otherwise).
+
+  You can reuse examples across different essential or nice-to-have requirements if you need to.
+
+type: dynamic_list
+dynamic_field: 'brief.essentialRequirements'
+questions:
+  - evidence

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirementsMet.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirementsMet.yml
@@ -1,0 +1,18 @@
+name: Essential skills and experience
+question: Do you have all the essential skills and experience?
+question_advice: >
+  <ul class="list-bullet">
+    {% for requirement in brief.essentialRequirements %}
+      <li>{{ requirement }}</li>
+    {% endfor %}
+  </ul>
+
+type: boolean
+required_value: true
+validations:
+  -
+    name: not_required_value
+    message: 'To carry on with your application, you need to show you have all the essential skills and experience.'
+  -
+    name: answer_required
+    message: 'You must answer ‘yes’ or ‘no’ to this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/evidence.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/evidence.yml
@@ -1,0 +1,10 @@
+question: '{{ item }}'
+type: textbox_large
+max_length_in_words: 100
+validations:
+  -
+    name: answer_required
+    message: 'You need to provide evidence.'
+  -
+    name: under_100_words
+    message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/followupEvidence.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/followupEvidence.yml
@@ -1,0 +1,12 @@
+question: 'Evidence of {{ item }}'
+id: evidence
+type: textbox_large
+max_length_in_words: 100
+hidden: True
+validations:
+  -
+    name: answer_required
+    message: 'You must provide evidence if you answer ‘yes’ to this question.'
+  -
+    name: under_100_words
+    message: 'Your answer must be no more than 100 words.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/niceToHaveRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/niceToHaveRequirements.yml
@@ -1,0 +1,28 @@
+name: Nice-to-have skills and experience
+question: Do you have any of the nice-to-have skills or experience?
+optional: true
+question_advice: |
+  All nice-to-have skills and experience are optional.
+
+  The buyer will assess and score your evidence to shortlist the best suppliers.
+
+  <h3>Evidence structure</h3>
+  <div class="explanation-list">
+    <p class="lead">When you write your evidence, you should be specific about:</p>
+
+    <ul class="list-bullet">
+      <li>what the situation was</li>
+      <li>the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did</li>
+      <li>what the results were</li>
+    </ul>
+  </div>
+
+  You should only provide one example for each nice-to-have requirement (unless the buyer specifies otherwise).
+
+  You can reuse examples across different essential or nice-to-have requirements if you need to.
+
+type: dynamic_list
+dynamic_field: 'brief.niceToHaveRequirements'
+questions:
+  - yesNo
+  - followupEvidence

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/respondToEmailAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/respondToEmailAddress.yml
@@ -1,0 +1,13 @@
+name: Email address
+question: Email address the buyer should use to contact you
+question_advice: All communication about your application will be sent to this address.
+type: text
+hint: You can add more than one email address. Use a comma between each email address.
+limits:
+  format: email
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  - name: invalid_format
+    message: "You must enter a valid email address."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/supplierName.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/supplierName.yml
@@ -1,0 +1,3 @@
+name: Supplier
+question: Supplier name
+type: text

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/yesNo.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/yesNo.yml
@@ -1,0 +1,8 @@
+question: '{{ item }}'
+type: boolean
+followup:
+  evidence:
+    - true
+validations:
+  - name: answer_required
+    message: 'You must answer ‘yes’ or ‘no’ to this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/accessRestrictions.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/accessRestrictions.yml
@@ -1,0 +1,15 @@
+name: Access restrictions at location
+question: Access restrictions at location
+question_advice: Describe any access restrictions that may affect participants at the research location, such as no wheelchair access.
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Add restrictions

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsOutcomesSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsOutcomesSpecialists.yml
@@ -1,0 +1,20 @@
+id: additionalTerms
+name: Additional terms and conditions
+question: Additional terms and conditions
+question_advice: |
+  You should use the [standard contract](https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-call-off-contract) unless your organisation needs to include additional terms and conditions.
+
+  Read about [how the terms and conditions work](https://www.gov.uk/guidance/terms-and-conditions-of-digital-marketplace-frameworks).
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Add terms and conditions

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsParticipants.yml
@@ -1,0 +1,25 @@
+id: additionalTerms
+name: Additional terms and conditions
+question: Additional terms and conditions
+question_advice: |
+  You should use the [standard contract](https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-call-off-contract) unless your organisation needs to include additional terms and conditions.
+
+  Read about [how the terms and conditions work](https://www.gov.uk/guidance/terms-and-conditions-of-digital-marketplace-frameworks).
+
+  The suppliers have already agreed that:
+
+  - their prices must include all incentives, recruitment, and travel and subsistence costs paid to participants
+  - you don’t pay for participants who don’t attend on the day
+  - they are responsible for paying participants directly
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Add terms and conditions

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/awardedContractStartDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/awardedContractStartDate.yml
@@ -1,0 +1,11 @@
+name: What's the start date?
+question: What's the start date?
+hint: 'For example, 31 5 2020'
+type: date
+validations:
+  - name: answer_required
+    message: 'Enter the start date.'
+  - name: invalid_format
+    message: "Enter a real start date."
+
+empty_message: Set contract start date

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/awardedContractValue.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/awardedContractValue.yml
@@ -1,0 +1,16 @@
+name: What's the value?
+question: What's the value?
+hint: 'For example, 9900.95 for 9900 pounds and 95 pence'
+type: pricing
+decimal_place_restriction: true
+fields:
+  price: awardedContractValue
+
+validations:
+  - name: answer_required
+    message: 'Enter a contract value.'
+  - name: not_money_format
+    field: awardedContractValue
+    message: "Enter the value in pounds and pence, using numbers and decimals only."
+
+empty_message: Set value

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/backgroundInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/backgroundInformation.yml
@@ -1,0 +1,22 @@
+name: Why the work is being done
+question: Why the work is being done
+question_advice: |
+  Describe the organisation or policy goal the work supports. For example: how
+  a new law changes the way users receive government payments.
+
+  Include any important dates. You must say if you need the work to be done by a certain date.
+  This will help suppliers understand any time constraints.
+type: textbox_large
+max_length_in_words: 200
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description.'
+  -
+    name: under_200_words
+    message: 'Description must be 200 words or fewer.'
+empty_message: Describe why the work is being done

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeOutcomesParticipants.yml
@@ -1,0 +1,25 @@
+name: Budget range
+id: budgetRange
+question: Budget range
+question_advice: |
+  Include how much you can spend.
+
+  Suppliers will find it helpful if you can provide a breakdown of costs.
+
+  You must have budget approval before you publish your requirements.
+
+  You should [talk to suppliers before you buy](https://www.gov.uk/guidance/talking-to-suppliers-before-you-buy-digital-marketplace-services)
+  so you know how much the work might cost.
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - user-research-participants
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Set budget range

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeSpecialists.yml
@@ -1,0 +1,23 @@
+name: Maximum day rate
+id: budgetRange
+question: Maximum day rate
+question_advice: |
+  How much can you afford to spend a day.
+
+  You must have budget approval before you publish your requirements.
+
+  If you don’t provide a day rate, you won’t be able to exclude specialists that exceed your budget.
+
+  Suppliers will provide you with a day rate for the specialist.
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Add maximum day rate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/contractLength.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/contractLength.yml
@@ -1,0 +1,15 @@
+name: Expected contract length
+question: Expected contract length
+question_advice: Contracts can’t last for more than 2 years.
+type: text
+optional: true
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: under_character_limit
+    message: "Description must be 100 characters or fewer."
+empty_message: Set expected contract length

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -1,0 +1,61 @@
+name: Cultural fit criteria
+id: culturalFitCriteria
+question: Cultural fit criteria
+question_advice: |
+
+  Cultural fit is about how well you and the supplier work together.
+
+  ##Cultural fit is:
+  - how the supplier works with other people
+  - how the supplier solves problems
+  - the supplier’s approach to making decisions
+  - how the supplier shares knowledge and experience
+  - the supplier’s attitude to making mistakes
+
+  ##Cultural fit isn’t:
+  - whether the supplier looks, talks or behaves in the same way as you
+  - about having agile skills – that’s technical competence
+
+  ##Giving points for individual criteria (optional)
+  You can give points to individual criteria, such as ‘transparent and collaborative when making decisions – 15 points’. If you choose to add points, you must do it for all individual criteria.
+
+  Read [how to score individual criteria](https://www.gov.uk/guidance/how-to-set-your-evaluation-criteria-when-buying-digital-outcomes-and-specialists-services#giving-points-to-individual-criteria)
+
+  ##Add cultural fit criteria
+  When you evaluate shortlisted suppliers on cultural fit, you must use the criteria you list here.
+
+  ##Suggested criteria
+
+  - work as a team with our organisation and other suppliers
+  - be transparent and collaborative when making decisions
+  - have a no-blame culture and encourage people to learn from their mistakes
+  - take responsibility for their work
+  - share knowledge and experience with other team members
+  - challenge the status quo
+  - be comfortable standing up for their discipline
+  - can work with clients with low technical expertise
+
+  ##The supplier should:
+
+type: list
+number_of_items: 20
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 criteria.'
+  -
+    name: under_30_words
+    message: 'Each criteria must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each criteria must be 300 characters or fewer."
+
+empty_message: Choose cultural fit criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -1,0 +1,61 @@
+name: Cultural fit criteria
+id: culturalFitCriteria
+question: Cultural fit criteria
+question_advice: |
+
+  Cultural fit is about how well you and the specialist work together.
+
+  ##Cultural fit is:
+  - how the specialist works with other people
+  - how the specialist solves problems
+  - the specialist’s approach to making decisions
+  - how the specialist shares knowledge and experience
+  - the specialist’s attitude to making mistakes
+
+  ##Cultural fit isn’t:
+  - whether the specialist looks, talks or behaves in the same way as you
+  - about having agile skills – that’s technical competence
+
+  ##Giving points for individual criteria (optional)
+  You can give points to individual criteria, such as ‘transparent and collaborative when making decisions – 15 points’. If you choose to add points, you must do it for all individual criteria.
+
+  Read [how to score individual criteria](https://www.gov.uk/guidance/how-to-set-your-evaluation-criteria-when-buying-digital-outcomes-and-specialists-services#giving-points-to-individual-criteria)
+
+  ##Add cultural fit criteria
+  When you evaluate shortlisted specialists on cultural fit, you must use the criteria you list here.
+
+  ##Suggested criteria
+
+  - work as a team with our organisation and other suppliers
+  - be transparent and collaborative when making decisions
+  - have a no-blame culture and encourage people to learn from their mistakes
+  - take responsibility for their work
+  - share knowledge and experience with other team members
+  - challenge the status quo
+  - be comfortable standing up for their discipline
+  - can work with clients with low technical expertise
+
+  ##The specialist should:
+
+type: list
+number_of_items: 20
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 criteria.'
+  -
+    name: under_30_words
+    message: 'Each criteria must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each criteria must be 300 characters or fewer."
+
+empty_message: Choose cultural fit criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalWeightingOutcomes.yml
@@ -1,0 +1,28 @@
+id: culturalWeighting
+question: 'Cultural fit'
+question_advice: >
+  Cultural fit is how well you and the supplier will work together.
+  If the supplier’s values and behaviour are similar to your organisation’s, they should be a good cultural fit.
+hint: 'This can be between 5% and 20%'
+
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 5
+  max_value: 20
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 5 and 20.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalWeightingParticipants.yml
@@ -1,0 +1,26 @@
+id: culturalWeighting
+question: 'Availability'
+question_advice: Availability is whether the supplier can recruit user research participants when you need them.
+hint: 'This can be between 10% and 70%'
+
+depends:
+  - "on": lot
+    being:
+      - user-research-participants
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 10
+  max_value: 70
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 10 and 70.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalWeightingSpecialists.yml
@@ -1,0 +1,28 @@
+id: culturalWeighting
+question: 'Cultural fit'
+question_advice: >
+  Cultural fit is how well you and the specialist will work together.
+  If the specialist’s values and behaviour are similar to your organisation’s, they should be a good cultural fit.
+hint: 'This can be between 5% and 20%'
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 5
+  max_value: 20
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 5 and 20.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/earlyMarketEngagement.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/earlyMarketEngagement.yml
@@ -1,0 +1,17 @@
+name: Early market engagement
+question: Early market engagement
+question_advice: If you’ve done early market engagement, you must include a summary of any relevant findings.
+type: textbox_large
+optional: true
+max_length_in_words: 200
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+      - user-research-participants
+validations:
+  -
+    name: under_200_words
+    message: 'Description must be 200 words or fewer.'
+empty_message: Describe early market engagement

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/endUsers.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/endUsers.yml
@@ -1,0 +1,26 @@
+name: Who the users are and what they need to do
+question: Who the users are and what they need to do
+question_advice: |
+  You should use this format:
+
+  As a&hellip; (who is the user?)
+
+  I need to&hellip; (what does the user want to do?)
+
+  So that&hellip; (why does the user want to do this?)
+
+  For example: As a carer, I need to know if I can get Carer’s Allowance, so that I know if I should apply for it or not.
+type: textbox_large
+max_length_in_words: 200
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the users.'
+  -
+    name: under_200_words
+    message: 'Description must be 200 words or fewer.'
+empty_message: Describe the users and their needs

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsOutcomes.yml
@@ -1,0 +1,34 @@
+name: 'Essential skills and experience'
+id: essentialRequirements
+question: 'Essential skills and experience'
+question_advice: |
+  When suppliers apply they declare which of your essential skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+
+  List all the specific skills or experience the supplier must have.
+
+  For example: have experience designing services for users with low digital literacy.
+
+  ##The supplier must:
+
+list_item_name: 'essential requirement'
+number_of_items: 20
+type: list
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 requirement.'
+  -
+    name: under_30_words
+    message: 'Each requirement must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each requirement must be 300 characters or fewer."
+empty_message: Add essential skills or experience

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsParticipants.yml
@@ -1,0 +1,34 @@
+name: 'Essential skills and experience'
+id: essentialRequirements
+question: 'Essential skills and experience'
+question_advice: |
+  Suppliers who don’t have all the essential skills you list here will be automatically notified that their application was unsuccessful.
+
+  List all the specific skills or experience the supplier must have.
+
+  For example: have experience recruiting participants with low digital literacy.
+
+  ##The supplier must:
+
+list_item_name: 'essential requirement'
+number_of_items: 20
+type: list
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 requirement.'
+  -
+    name: under_30_words
+    message: 'Each requirement must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each requirement must be 300 characters or fewer."
+empty_message: Add essential skills or experience

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsSpecialists.yml
@@ -1,0 +1,34 @@
+name: 'Essential skills and experience'
+id: essentialRequirements
+question: 'Essential skills and experience'
+question_advice: |
+  Suppliers who don’t have all the essential skills you list here will be automatically notified that their application was unsuccessful.
+
+  List all the specific skills or experience the specialist must have.
+
+  For example: have experience designing services for users with low digital literacy.
+
+  ##The specialist must:
+
+list_item_name: 'essential requirement'
+number_of_items: 20
+type: list
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 requirement.'
+  -
+    name: under_30_words
+    message: 'Each requirement must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each requirement must be 300 characters or fewer."
+empty_message: Add essential skills or experience

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeOutcomes.yml
@@ -1,0 +1,41 @@
+name: Additional assessment methods
+id: evaluationType
+question: How you’ll assess suppliers
+question_advice: |
+  All suppliers will have to provide a written proposal. However, you can also choose additional ways to assess them, if you want to.
+
+  Choose additional ways to assess suppliers.
+
+  You can only use the methods you choose here, so if you don’t select a case study now, you won’t be able to ask for one later.
+
+  Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
+type: checkboxes
+optional: true
+
+options:
+  - label: "Case study"
+    description: >
+       A case study is a good way to see the work suppliers have done before. It can help you understand whether the
+       people who’ll be working on your project have the right skills and experience.
+  - label: "Work history"
+    description: >
+       A work history lists the previous work a supplier has done. It should give you a view of the skills and
+       experience of the team members who’ll be working on your project.
+  - label: "Reference"
+    description: >
+       A written reference is a good way of confirming whether a supplier has done the work they’ve said they’ve done.
+       You should always ask for references that relate to a specific timeframe, such as work they’ve done in the last
+       2 years.
+  - label: "Presentation"
+    description: >
+       A presentation can help you understand a supplier’s approach to delivering an outcome, such as a practical
+       demonstration of a prototype or discovery kick-off meeting.
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Select an assessment method.'
+empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeParticipants.yml
@@ -1,0 +1,38 @@
+name: Additional assessment methods
+id: evaluationType
+question: How you’ll assess suppliers
+question_advice: |
+  All suppliers will have to provide a written proposal. However, you can also choose additional ways to assess them, if you want to.
+
+  Choose additional ways to assess suppliers.
+
+  You can only use the methods you choose here, so if you don’t select a reference now, you won’t be able to ask for one later.
+
+  Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
+type: checkboxes
+optional: true
+
+options:
+  - label: "Case study"
+    description: >
+       A case study is a good way to see the work suppliers have done before. It can help you understand whether the
+       people who’ll be working on your project have the right skills and experience.
+  - label: "Reference"
+    description: >
+       A written reference is a good way of confirming whether a supplier has done the work they’ve said they’ve done.
+       You should always ask for references that relate to a specific timeframe, such as work they’ve done in the last
+       2 years.
+  - label: "Interview"
+    description: >
+       An interview can help you understand whether a supplier or team has the skills needed to work on your project.
+       It will also help you see whether they will be a good fit for your existing team. You should follow an agreed
+       format in which you ask all suppliers the same set of questions.
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Select an assessment method.'
+empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeSpecialists.yml
@@ -1,0 +1,42 @@
+name: Additional assessment methods
+id: evaluationType
+question: How you’ll assess specialists
+question_advice: |
+  All suppliers will have to provide a work history. However, you can also choose additional ways to assess them, if you want to.
+
+  Choose additional ways to assess specialists.
+
+  You can only use the methods you choose here, so if you don’t select an interview, you won’t be able to interview specialists.
+
+  Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
+type: checkboxes
+optional: true
+
+options:
+  - label: "Reference"
+    description: >
+      A written reference is a good way of confirming whether a specialist has done the work they’ve said they’ve
+      done. You should always ask for references that relate to a specific timeframe, such as work they’ve done
+      in the last 2 years.
+  - label: "Interview"
+    description: >
+      An interview can help you understand whether a specialist or team has the skills needed to work on your project.
+      It will also help you see whether they will be a good fit for your existing team. You should follow an agreed
+      format in which you ask all specialists the same set of questions.
+  - label: "Scenario or test"
+    description: >
+      A scenario or test can help you confirm a supplier’s skill level and understanding in a controlled environment,
+      for example: a coding test for a developer or the approach a product manager would take to solve an example problem.
+  - label: "Presentation"
+    description: >
+      A presentation can help you understand a specialist’s approach to delivering work,
+      for example: a practical demonstration of a prototype or discovery kick-off meeting.
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Select an assessment method.'
+empty_message: Choose additional assessment methods

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/existingTeamOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/existingTeamOutcomes.yml
@@ -1,0 +1,20 @@
+name: Existing team
+id: existingTeam
+question: Existing team
+question_advice: >
+  Describe the team the supplier will be working with and if it involves
+  working with another supplier.
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the team.'
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Describe existing team

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/existingTeamSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/existingTeamSpecialists.yml
@@ -1,0 +1,21 @@
+name: Who the specialist will work with
+id: existingTeam
+question: Who the specialist will work with
+question_advice: |
+  Describe the team the specialist will be working with on this project.
+
+  For example: You’ll be working with a user researcher and a designer
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the team.'
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Describe existing team

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationAllLots.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationAllLots.yml
@@ -1,0 +1,20 @@
+name: Location
+question: Location
+id: location
+type: radios
+options:
+  - label: Scotland
+  - label: North East England
+  - label: North West England
+  - label: Yorkshire and the Humber
+  - label: East Midlands
+  - label: West Midlands
+  - label: East of England
+  - label: London
+  - label: South East England
+  - label: South West England
+  - label: Wales
+  - label: Northern Ireland
+  - label: International (outside the UK)
+  - label: Off-site
+    value: Offsite

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationOutcomes.yml
@@ -1,0 +1,34 @@
+name: Location
+question: Where you want the supplier to work
+id: location
+question_advice: |
+  Select the primary location where they’ll be working.
+
+  Suppliers have said where they’ll provide outcomes.
+
+depends:
+type: radios
+options:
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Wales"
+  - label: "Northern Ireland"
+  - label: "No specific location, for example they can work remotely"
+    value: "Offsite"
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Select a location.'
+empty_message: Choose location

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationParticipants.yml
@@ -1,0 +1,33 @@
+name: Location
+question: Where the research will take place
+id: location
+question_advice: |
+  Select the primary location where they’ll be working.
+
+  Suppliers have said where they can recruit participants.
+
+depends:
+type: radios
+options:
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Wales"
+  - label: "Northern Ireland"
+  - label: "International (outside the UK)"
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Select a location.'
+empty_message: Choose location

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/locationSpecialists.yml
@@ -1,0 +1,34 @@
+name: Location
+question: Where you want the specialist to work
+id: location
+question_advice: |
+  Select the primary location where they’ll be working.
+
+  Suppliers have said where they’ll provide specialists.
+
+depends:
+type: radios
+options:
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Wales"
+  - label: "Northern Ireland"
+  - label: "No specific location, for example they can work remotely"
+    value: "Offsite"
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Select a location.'
+empty_message: Choose location

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/niceToHaveRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/niceToHaveRequirementsOutcomes.yml
@@ -1,0 +1,34 @@
+name: 'Nice-to-have skills and experience'
+id: niceToHaveRequirements
+question: 'Nice-to-have skills and experience'
+question_advice: |
+  If too many suppliers have all the essential skills and experience, use the nice-to-have skills and experience to exclude suppliers.
+
+  List the skills and experience you’d like the supplier to have.
+  For example: provide evidence of delivering at scale.
+
+  ##The supplier can:
+
+list_item_name: 'nice-to-have requirement'
+number_of_items: 20
+optional: true
+type: list
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 requirement.'
+  -
+    name: under_30_words
+    message: 'Each requirement must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each requirement must be 300 characters or fewer."
+empty_message: Add nice-to-have skills and experience

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/niceToHaveRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/niceToHaveRequirementsParticipants.yml
@@ -1,0 +1,35 @@
+name: 'Nice-to-have skills and experience'
+id: niceToHaveRequirements
+question: 'Nice-to-have skills and experience'
+question_advice: |
+  If too many suppliers have all the essential skills and experience, use the nice-to-have skills and experience to exclude suppliers.
+
+  List the skills and experience you’d like the supplier to have.
+
+  For example: have experience recruiting participants with hernias.
+
+  ##The supplier can:
+
+list_item_name: 'nice-to-have requirement'
+number_of_items: 20
+optional: true
+type: list
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 requirement.'
+  -
+    name: under_30_words
+    message: 'Each requirement must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each requirement must be 300 characters or fewer."
+empty_message: Add nice-to-have skills and experience

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/niceToHaveRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/niceToHaveRequirementsSpecialists.yml
@@ -1,0 +1,34 @@
+name: 'Nice-to-have skills and experience'
+id: niceToHaveRequirements
+question: 'Nice-to-have skills and experience'
+question_advice: |
+  If too many specialists have all the essential skills and experience, use the nice-to-have skills and experience to exclude specialists.
+
+  List the skills and experience you’d like the specialist to have.
+  For example: provide evidence of delivering at scale.
+
+  ##The specialist can:
+
+list_item_name: 'nice-to-have requirement'
+number_of_items: 20
+optional: true
+type: list
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 requirement.'
+  -
+    name: under_30_words
+    message: 'Each requirement must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each requirement must be 300 characters or fewer."
+empty_message: Add nice-to-have skills and experience

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/numberOfSuppliersOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/numberOfSuppliersOutcomes.yml
@@ -1,0 +1,25 @@
+name: How many suppliers to evaluate
+id: numberOfSuppliers
+question: How many suppliers to evaluate
+question_advice: |
+  Enter how many suppliers you will evaluate. You must evaluate at least 3.
+
+  Read about [how many suppliers to evaluate](https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers#how-many-suppliers-to-evaluate).
+
+type: number
+limits:
+  integer_only: true
+  min_value: 3
+  max_value: 15
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  - name: answer_required
+    message: 'Enter the number of suppliers.'
+  - name: not_a_number
+    message: 'Number of suppliers must be between 3 and 15.'
+
+empty_message: Set how many suppliers to evaluate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/numberOfSuppliersParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/numberOfSuppliersParticipants.yml
@@ -1,0 +1,25 @@
+name: How many suppliers to evaluate
+id: numberOfSuppliers
+question: How many suppliers to evaluate
+question_advice: |
+  Enter how many suppliers you will evaluate. You must evaluate at least 3.
+
+  Read about [how many suppliers to evaluate](https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers#how-many-suppliers-to-evaluate).
+
+type: number
+limits:
+  integer_only: true
+  min_value: 3
+  max_value: 15
+
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  - name: answer_required
+    message: 'Enter the number of suppliers.'
+  - name: not_a_number
+    message: 'Number of suppliers must be between 3 and 15.'
+
+empty_message: Set how many suppliers to evaluate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/numberOfSuppliersSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/numberOfSuppliersSpecialists.yml
@@ -1,0 +1,25 @@
+name: How many specialists to evaluate
+id: numberOfSuppliers
+question: How many specialists to evaluate
+question_advice: |
+  Enter how many specialists you will evaluate. You must evaluate at least 3.
+
+  Read about [how many specialists to evaluate](https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers#how-many-suppliers-to-evaluate).
+
+type: number
+limits:
+  integer_only: true
+  min_value: 3
+  max_value: 15
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  - name: answer_required
+    message: 'Enter the number of suppliers.'
+  - name: not_a_number
+    message: 'Number of suppliers must be between 3 and 15.'
+
+empty_message: Set how many specialists to evaluate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/organisation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/organisation.yml
@@ -1,0 +1,19 @@
+name: Organisation the work is for
+question: Organisation the work is for
+question_advice: 'For example: National Audit Office or Lewisham Council'
+hint: 100 characters maximum
+type: text
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter an organisation.'
+  -
+    name: under_character_limit
+    message: "Organisation name must be 100 characters or fewer."
+empty_message: Add organisation

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/outcome.yml
@@ -1,0 +1,18 @@
+name: Problem to be solved
+question: Problem to be solved
+question_advice: >
+  For example: patients can’t access their medical records
+type: textbox_large
+max_length_in_words: 200
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the problem.'
+  -
+    name: under_200_words
+    message: 'Description must be 200 words or fewer.'
+empty_message: Describe problem

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/participantAccessibilityNeeds.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/participantAccessibilityNeeds.yml
@@ -1,0 +1,17 @@
+name: Assisted digital and accessibility requirements
+question: Assisted digital and accessibility requirements
+question_advice: >
+  Describe any assisted digital, digital inclusion and accessibility needs participants should have,
+  such as users who rely on a screen reader, magnifier, mouth stick or head wand.
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Add requirements

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/participantSpecification.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/participantSpecification.yml
@@ -1,0 +1,25 @@
+name: Description of your participants
+question: Description of your participants
+question_advice: |
+  Describe any skills, behaviour or attributes participants should, and should not, have.
+
+  Say if they must:
+
+   - be from a particular demographic, such as women under 30 years of age
+   - be from a specific target user group, such as small business owners
+   - have experience of a particular situation, such as users who have recently moved home
+   - have a specific level of digital skills or use of digital technology, such as users who have basic online skills
+   - meet specific research requirements, such as must not have participated in user research in the last 3 months or must be prepared to be recorded or filmed
+
+  Always try to recruit a representative sample of your users.
+type: textbox_large
+max_length_in_words: 200
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: under_200_words
+    message: 'Description must be 200 words or fewer.'
+empty_message: Describe participants

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/participantsPerRound.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/participantsPerRound.yml
@@ -1,0 +1,20 @@
+name: Number of participants a round
+question: Number of participants a round
+question_advice: |
+  Include details of any spare participants in each round.
+
+  A spare participant is someone who will be there to stand in for any cancellations.
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter details of the number of participants.'
+  -
+    name: under_100_words
+    message: 'Details must be 100 words or fewer.'
+empty_message: Set number of participants

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/phase.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/phase.yml
@@ -1,0 +1,42 @@
+name: Current phase
+question: Phase the work is currently in
+question_advice: |
+  Read more about [service design phases](https://www.gov.uk/service-manual/phases).
+type: radios
+options:
+  -
+    label: Not applicable
+    value: not_applicable
+  -
+    label: Not started
+    value: not_started
+  -
+    label: Discovery
+    value: discovery
+    description: >
+      A short phase, in which you start researching the needs of your service’s users,
+      find out what you should be measuring, and explore technological or policy-related constraints.
+  -
+    label: Alpha
+    value: alpha
+    description: >
+      A short phase in which you prototype solutions for your users needs.
+      You’ll be testing with a small group of users or stakeholders, and getting early feedback about the design of
+      the service.
+  -
+    label: Beta
+    value: beta
+    description: >
+      You’re developing against the demands of a live environment, understanding how to build and scale while meeting
+      user needs. You’ll also be releasing a version to test in public.
+  -
+    label: Live
+    value: live
+    description: >
+      The work doesn’t stop once your service is live. You’ll be iteratively improving your service,
+      reacting to new needs and demands, and meeting targets set during its development.
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+empty_message: Choose phase

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceCriteria.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceCriteria.yml
@@ -1,0 +1,36 @@
+name: Payment approach
+question: Payment approach
+question_advice: You should choose the approach that best fits the way you work and provides the best value for money.
+type: radios
+options:
+  -
+    label: Fixed price
+    description: >
+      A fixed price approach can be more expensive because the supplier owns most of the risk. It works best when your
+      requirements are well defined so the supplier can provide an accurate quote without incorporating extra costs.
+      The supplier must do all the work you specify in each particular ‘statement of work’ within the time you agreed
+      it would take.
+  -
+    label: Time and materials
+    description: >
+      A time and materials approach means you own more of the risk. The supplier can send a pricing matrix showing
+      how long they need to provide the work. If it takes longer to do the work defined in a statement of work, you
+      pay the day rate and expenses for any extra days worked.
+  -
+    label: Capped time and materials
+    description: >
+      A capped time and materials approach is the same as a time and materials approach but there’s a limit on how
+      much you have to pay for the work. If you reach the limit before the work is finished, the supplier has to
+      complete the work at their own cost. If the supplier finishes the work before they said they would, you only
+      pay them for the time they took to do the work.
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+empty_message: Choose payment approach
+
+validations:
+  -
+    name: answer_required
+    message: 'Select a payment approach.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceWeightingOutcomes.yml
@@ -1,0 +1,26 @@
+id: priceWeighting
+question: 'Price'
+question_advice: Price is evaluated on how close each supplier’s quote is to the cheapest quote.
+hint: 'This can be between 20% and 85%'
+
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 20
+  max_value: 85
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 20 and 85.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceWeightingParticipants.yml
@@ -1,0 +1,26 @@
+id: priceWeighting
+question: 'Price'
+question_advice: Price is evaluated on how close each supplier’s quote is to the cheapest quote.
+hint: 'This can be between 20% and 80%'
+
+depends:
+  - "on": lot
+    being:
+      - user-research-participants
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 20
+  max_value: 80
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 20 and 80.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/priceWeightingSpecialists.yml
@@ -1,0 +1,25 @@
+id: priceWeighting
+question: 'Price'
+hint: 'This can be between 20% and 85%'
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 20
+  max_value: 85
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 20 and 85.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/questionAndAnswerSessionDetailsOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/questionAndAnswerSessionDetailsOutcomesParticipants.yml
@@ -1,0 +1,39 @@
+id: questionAndAnswerSessionDetails
+name: Question and answer session details
+question: Question and answer session details
+question_advice: |
+
+  You must give details of what type of session you want to hold, when it is and any details the attendees need.
+
+  - the type of session you want to run, such as webinar, phone conference or meeting
+  - the date and time of the session (this should happen within 1 week of publishing your requirements)
+
+  Depending on the type of session you choose, you could also include:
+
+  - software needed
+  - the url
+  - the phone number
+  - the access code
+  - the address (including postcode)
+  - anything else needed to take part
+
+  This information will only be available to eligible suppliers who have logged in.
+
+  You must post all questions and answers on the Digital Marketplace so all suppliers can see them.
+
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter details of the session.'
+  -
+    name: under_100_words
+    message: 'Details must be 100 words or fewer.'
+empty_message: Add details

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/questionAndAnswerSessionDetailsSpecialists.yml
@@ -1,0 +1,45 @@
+id: questionAndAnswerSessionDetails
+name: Question and answer session details
+question: Question and answer session details
+question_advice: |
+  If you run a question and answer session, you must include:
+
+  - the type of session you want to run, such as webinar, phone conference or meeting
+  - the date and time of your session
+
+  ##When to run a question and answer session
+
+  If your requirements are open for 1 week, you must hold your session within the first 2 working days of publishing.
+
+  If your requirements are open for 2 weeks, you must hold your session within the first 5 working days of publishing.
+
+  ##Information you should include
+
+  Depending on the type of session you choose, you could also include:
+
+  - software needed
+  - the url
+  - the phone number
+  - the access code
+  - the address (including postcode)
+  - anything else needed to take part
+
+  This information will only be available to eligible suppliers who have logged in.
+
+  You must post all questions and answers on the Digital Marketplace so all suppliers can see them.
+
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Enter details of the session.'
+  -
+    name: under_100_words
+    message: 'Details must be 100 words or fewer.'
+empty_message: Add details

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/requirementsLengthSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/requirementsLengthSpecialists.yml
@@ -1,0 +1,16 @@
+name: Set how long your requirements will be open for
+question: Set how long your requirements will be open for
+id: requirementsLength
+type: radios
+options:
+  - label: "1 week"
+  - label: "2 weeks"
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Select a time span.'
+empty_message: Set requirements length

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchAddress.yml
@@ -1,0 +1,23 @@
+name: Research location
+question: Specific place where the research will happen
+question_advice: |
+  Include:
+
+   - the town or city where the research will happen
+   - more than one address if appropriate
+   - a description of the research environment, such as whether the research will happen in a lab, at a participant’s home,
+     or in a neutral location like a community centre
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter a location.'
+  -
+    name: under_100_words
+    message: 'Location must be 100 words or fewer.'
+empty_message: Add location

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchDates.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchDates.yml
@@ -1,0 +1,16 @@
+name: Research dates
+question: Research dates
+question_advice: If you don’t have exact dates, say when you expect research to start and end.
+type: text
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter details of the dates.'
+  -
+    name: under_character_limit
+    message: "Details must be 100 characters or fewer."
+empty_message: Add dates

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchFrequency.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchFrequency.yml
@@ -1,0 +1,18 @@
+name: How often research will happen
+question: How often research will happen
+question_advice: >
+  Include the days or dates you expect research to happen, for example: Tuesdays, every 2 weeks.
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the research frequency.'
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Describe how often research will happen

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchOutOfHours.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchOutOfHours.yml
@@ -1,0 +1,13 @@
+name: Evening or weekend research
+question: Evening or weekend research
+question_advice: Tell the supplier if you need the research to happen outside the standard working day.
+optional: true
+type: checkboxes
+options:
+  - label: "Weekday evenings"
+  - label: "Weekends"
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+empty_message: Add evening or weekend research

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchPlan.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchPlan.yml
@@ -1,0 +1,15 @@
+name: Research plan
+question: Research plan
+question_advice: Describe your research plan and how it might change.
+optional: true
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Describe research plan

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchRounds.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchRounds.yml
@@ -1,0 +1,19 @@
+name: Number of research rounds
+question: Number of research rounds
+question_advice: |
+  Each round can have several participants.
+
+  A research round often lasts for a day.
+type: text
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter details of the number of research rounds.'
+  -
+    name: under_character_limit
+    message: "Details must be 100 characters or fewer."
+empty_message: Set number of rounds

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/securityClearance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/securityClearance.yml
@@ -1,0 +1,21 @@
+name: Security clearance
+question: Security clearance
+question_advice: |
+  Describe any security clearance the individual or team must have when they start work.
+
+  You shouldn’t exclude suppliers if they don’t currently have the security clearance you need.
+
+  You may need to organise security clearance.
+type: textbox_large
+optional: true
+max_length_in_words: 50
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: under_50_words
+    message: 'Description must be 50 words or fewer.'
+empty_message: Add security clearance

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/specialistRole.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/specialistRole.yml
@@ -1,0 +1,129 @@
+name: Specialist role
+question: Type of specialist you need
+question_advice: >
+  You can only post requirements for 1 specialist role at a time, for example
+  if you want to find 3 developers, you must post 3 separate requirements – 1
+  for each developer.
+type: radios
+options:
+  -
+    label: Agile coach
+    value: agileCoach
+    description: >
+      Help individuals, teams and managers be as effective as possible by embedding an agile culture.
+  -
+    label: Business analyst
+    value: businessAnalyst
+    description: >
+      Analyse a service or organisation’s business processes and systems. Specify, collect and present findings.
+  -
+    label: Communications manager
+    value: communicationsManager
+    description: >
+      Develop user-focused messages, measurement techniques and communication approaches.
+      Establish integrated communication plans across a range of digital channels
+      to ensure that communication is ongoing, open and clear.
+  -
+    label: Content designer
+    value: contentDesigner
+    description: >
+      Ensure content is as clear and simple as possible to meet user needs.
+  -
+    label: Cyber security consultant
+    value: securityConsultant
+    description: >
+      Minimise the chance of data or information systems security breaches.
+      Ensure information is protected against unauthorised or unintended access.
+      Put systems in place to prevent data destruction or disruption.
+  -
+    label: Data architect
+    value: dataArchitect
+    description: >
+      Set the vision for the organisation’s use of data, through data design, to meet business needs.
+  -
+    label: Data engineer
+    value: dataEngineer
+    description: >
+      Design, build, test and maintain data management systems,
+      making sure they meet business requirements and user needs.
+  -
+    label: Data scientist
+    value: dataScientist
+    description: >
+      Identify complex business problems while working with policy and operations teams to understand
+      where data can add value.
+  -
+    label: Delivery manager
+    value: deliveryManager
+    description: >
+      Set up a team for successful delivery.
+      Remove obstacles, track progress, facilitate meetings and help the team organise itself.
+  -
+    label: Designer
+    value: designer
+    description: >
+      Provide user-centred interaction design, service design and graphic design expertise.
+  -
+    label: Developer
+    value: developer
+    description: >
+      Build software that supports user needs. Continually improve the service by
+      identifying new tools and techniques, removing technical bottlenecks, and adapting and maintaining code.
+  -
+    label: Performance analyst
+    value: performanceAnalyst
+    description: >
+      Specify, collect and present the key performance data and analysis for a service.
+  -
+    label: Portfolio manager
+    value: portfolioManager
+    description: >
+      Lead a digital portfolio of projects and programmes.
+  -
+    label: Product manager
+    value: productManager
+    description: >
+      Lead the delivery and continuous improvement of one or more digital products or platforms.
+  -
+    label: Programme manager
+    value: programmeManager
+    description: >
+      Manage and organise groups of related projects so they work together to achieve a strategic objective.
+  -
+    label: Quality assurance analyst
+    value: qualityAssurance
+    description: >
+      Ensure the quality of the digital service by testing it manually and writing automated tests
+      covering a range of conditions.
+  -
+    label: Service manager
+    value: serviceManager
+    description: >
+      Develop and deliver an effective user-focused digital service.
+      Manage the full product lifecycle, including user research, design, delivery and continuous improvement.
+  -
+    label: Technical Architect
+    value: technicalArchitect
+    description: >
+      Break down complex problems and identify steps towards solutions. Coach individuals and engage with
+      non-technical people at all levels of seniority. Write code as a senior member of the development team.
+  -
+    label: User researcher
+    value: userResearcher
+    description: >
+      Design, conduct and analyse user research using a range of techniques,
+      such as one-to-one interviews or usability tests.
+  -
+    label: Web operations engineer
+    value: webOperations
+    description: >
+      Run the production systems to help the development team build software that is easy to operate, scale and secure.
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Select a specialist role.'
+empty_message: Choose specialist role

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/specialistWork.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/specialistWork.yml
@@ -1,0 +1,23 @@
+name: What the specialist will work on
+question: What the specialist will work on
+question_advice: |
+  List all the work you expect the specialist to do. They can only work on the things you include here.
+
+  For example:
+
+  1. Do the front-end development work on the ‘Check your state pension’ service.
+  2. Implement toolkits and APIs to optimise the performance of the ‘Personal Tax Account’ service.
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the work.'
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Add responsibilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/startDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/startDate.yml
@@ -1,0 +1,18 @@
+name: Latest start date
+question: Latest start date
+question_advice: |
+  Say when you need suppliers to start work. When you shortlist, you can exclude suppliers who can’t start by this date.
+hint: 'For example, 31 5 2020'
+type: date
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  - name: answer_required
+    message: 'Enter the start date.'
+  - name: invalid_format
+    message: "Enter a real start date."
+
+empty_message: Set latest start date

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/statusOpenClosed.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/statusOpenClosed.yml
@@ -1,0 +1,7 @@
+name: Status
+id: statusOpenClosed
+question: statusOpenClosed
+type: radios
+options:
+  - label: open
+  - label: closed

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/successCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/successCriteriaOutcomes.yml
@@ -1,0 +1,38 @@
+name: 'Proposal criteria'
+id: successCriteria
+question: 'Proposal criteria'
+question_advice: |
+  When you evaluate shortlisted suppliers on the technical competence of their proposal, you must use the criteria you list here.
+
+  Suggested criteria
+
+  - technical solution
+  - approach and methodology
+  - how the approach or solution meets user needs
+  - how the approach or solution meets your organisation’s policy or goal
+  - estimated timeframes for the work
+  - how they’ve identified risks and dependencies and offered approaches to manage them
+  - team structure
+  - value for money
+
+type: list
+number_of_items: 20
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 criteria.'
+  -
+    name: under_30_words
+    message: 'Each criteria must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each criteria must be 300 characters or fewer."
+
+empty_message: Choose proposal criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/successCriteriaParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/successCriteriaParticipants.yml
@@ -1,0 +1,34 @@
+name: 'Proposal criteria'
+id: successCriteria
+question: 'Proposal criteria'
+question_advice: |
+  When you evaluate shortlisted suppliers on the technical competence of their proposal, you must use the criteria you list here.
+
+  Suggested criteria
+
+  - approach to recruiting specialist participants
+  - estimated timeframes for the work
+  - breakdown of recruitment costs and incentives
+  - how they’ve identified risks and dependencies and offered approaches to manage them
+
+type: list
+number_of_items: 20
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter at least 1 criteria.'
+  -
+    name: under_30_words
+    message: 'Each criteria must be 30 words or fewer.'
+  -
+    name: max_items_limit
+    message: 'You can add up to 20 criteria.'
+  -
+    name: under_character_limit
+    message: "Each criteria must be 300 characters or fewer."
+
+empty_message: Choose evaluation criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/summary.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/summary.yml
@@ -1,0 +1,21 @@
+name: Summary of the work
+question: Summary
+question_advice: >
+  This will appear on the supplier opportunities page on the Digital Marketplace.
+  It will help suppliers decide whether or not to view your requirements.
+type: textbox_large
+max_length_in_words: 50
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter a summary of the work.'
+  -
+    name: under_50_words
+    message: 'Summary must be 50 words or fewer.'
+empty_message: Provide a summary of the work

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalCompetenceCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalCompetenceCriteriaOutcomes.yml
@@ -1,0 +1,35 @@
+name: Technical competence criteria
+question: Technical competence criteria
+question_advice: |
+  Technical competence is how well the supplier can do the work you need them to do.
+
+  Evaluate suppliers’ technical competence using criteria for:
+
+  - essential skills and experience
+  - nice-to-have skills and experience
+  - proposal
+
+  ##Giving points for individual criteria (optional)
+
+  You can give points to individual criteria, such as ‘have experience designing services for users with low digital
+  literacy – 15 points’. If you choose to add points, you must do it for all individual criteria.
+
+  Unless you have asked for several examples, you should not score a supplier higher or lower because they give more or
+  less examples than another supplier.
+
+  The points you give for nice-to-have skills and experience must be lower than the points you give for
+  essential skills and experience and proposal criteria.
+  Read [how to score individual criteria](https://www.gov.uk/guidance/how-to-set-your-evaluation-criteria-when-buying-digital-outcomes-and-specialists-services#giving-points-to-individual-criteria).
+
+optional: false
+type: multiquestion
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+questions:
+  - essentialRequirementsOutcomes
+  - niceToHaveRequirementsOutcomes
+  - successCriteriaOutcomes
+
+empty_message: Set technical competence criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalCompetenceCriteriaParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalCompetenceCriteriaParticipants.yml
@@ -1,0 +1,33 @@
+name: Technical competence criteria
+question: Technical competence criteria
+question_advice: |
+  Technical competence is how well the supplier can do the work you need them to do.
+
+  Evaluate suppliers’ technical competence using criteria for:
+
+  - essential skills and experience
+  - nice-to-have skills and experience
+  - proposal
+
+  ##Giving points for individual criteria (optional)
+  You can give points to individual criteria, for example: ‘have experience recruiting participants with low digital literacy – 15 points’.
+
+  Unless you have asked for several examples, you should not score a supplier higher or lower because they give more or
+  less examples than another supplier.
+
+  The points you give for nice-to-have skills and experience must be lower than the points you give for
+  essential skills and experience and proposal criteria.
+  Read [how to score individual criteria](https://www.gov.uk/guidance/how-to-set-your-evaluation-criteria-when-buying-digital-outcomes-and-specialists-services#giving-points-to-individual-criteria).
+
+optional: false
+type: multiquestion
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+questions:
+  - essentialRequirementsParticipants
+  - niceToHaveRequirementsParticipants
+  - successCriteriaParticipants
+
+empty_message: Set technical competence criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalCompetenceCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalCompetenceCriteriaSpecialists.yml
@@ -1,0 +1,32 @@
+name: Technical competence criteria
+question: Technical competence criteria
+question_advice: |
+  Technical competence is how well the supplier can do the work you need them to do.
+
+  Evaluate specialists’ technical competence using criteria for:
+
+  - essential skills and experience
+  - nice-to-have skills and experience
+
+  ##Giving points for individual criteria (optional)
+  You can give points to individual criteria, for example: ‘have experience designing services for users with low digital literacy – 15 points’. If you choose to add points, you must do it for all individual criteria.
+
+  Unless you have asked for several examples, you should not score a supplier higher or lower because they give more or
+  less examples than another supplier.
+
+  The points you give for nice-to-have skills and experience must be lower than the points you give for
+  essential skills and experience.
+  Read [how to score individual criteria](https://www.gov.uk/guidance/how-to-set-your-evaluation-criteria-when-buying-digital-outcomes-and-specialists-services#giving-points-to-individual-criteria).
+
+
+optional: false
+type: multiquestion
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+questions:
+  - essentialRequirementsSpecialists
+  - niceToHaveRequirementsSpecialists
+
+empty_message: Set technical competence criteria

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalWeightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalWeightingOutcomes.yml
@@ -1,0 +1,30 @@
+id: technicalWeighting
+question: 'Technical competence'
+question_advice: |
+  Technical competence is how well the supplier can do the work you need them to do. It’s also known as
+  ‘technical merit and functional fit’. If a supplier has the right skills and experience, a good understanding
+  of your requirements, and works in an agile way, they should have the technical competence to do the work.
+
+hint: 'This can be between 10% and 75%'
+
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 10
+  max_value: 75
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 10 and 75.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalWeightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalWeightingParticipants.yml
@@ -1,0 +1,31 @@
+id: technicalWeighting
+question: 'Technical competence'
+question_advice: |
+  Technical competence is how well the supplier can do the work you need them to do. It’s also known as
+  ‘technical merit and functional fit’. If a supplier has the right skills and experience, a good
+  understanding of your requirements, and works in an agile way, they should have the technical competence
+  to do the work.
+
+hint: 'This can be between 10% and 70%'
+
+depends:
+  - "on": lot
+    being:
+      - user-research-participants
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 10
+  max_value: 70
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 10 and 70.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalWeightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/technicalWeightingSpecialists.yml
@@ -1,0 +1,31 @@
+id: technicalWeighting
+question: 'Technical competence'
+question_advice: |
+  Technical competence is how well the specialist can do the work you need them to do. It’s also known as
+  ‘technical merit and functional fit’. If a specialist has the right skills and experience, a good understanding
+  of your requirements, and works in an agile way, they should have the technical competence to do the work.
+
+  You must assess a supplier’s technical competence by reviewing their essential and nice-to-have skills and experience.
+hint: 'This can be between 10% and 75%'
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 10
+  max_value: 75
+  integer_only: true
+
+validations:
+  - name: answer_required
+    message: 'Enter a weighting.'
+  - name: not_a_number
+    message: 'Weighting must be between 10 and 75.'
+  - name: total_should_be_100
+    message: 'Total must add up to 100%.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/titleOutcomesParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/titleOutcomesParticipants.yml
@@ -1,0 +1,19 @@
+id: title
+name: Title
+question: What you want to call your requirements
+question_advice: This will help you refer to your requirements when talking to suppliers.
+hint: 100 characters maximum
+type: text
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - user-research-participants
+validations:
+  -
+    name: answer_required
+    message: 'Enter a title.'
+  -
+    name: under_character_limit
+    message: "Title must be 100 characters or fewer."
+empty_message: Add title

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/titleSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/titleSpecialists.yml
@@ -1,0 +1,24 @@
+id: title
+name: Title
+question: What you want to call your requirements
+question_advice: |
+  This will help you refer to your requirements when talking to suppliers.
+
+  You can only post requirements for 1 specialist role at a time, for example
+  if you want to find 3 developers, you must post 3 separate requirements – 1
+  for each developer.
+
+hint: 100 characters maximum
+type: text
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Enter a title.'
+  -
+    name: under_character_limit
+    message: "Title must be 100 characters or fewer."
+empty_message: Add title

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/weightingOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/weightingOutcomes.yml
@@ -1,0 +1,18 @@
+name: Evaluation weighting
+question: Evaluation weighting
+question_advice: |
+  Use the weightings to say how important each evaluation criteria is.
+
+  Total must add up to 100%
+optional: false
+type: multiquestion
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+questions:
+  - technicalWeightingOutcomes
+  - culturalWeightingOutcomes
+  - priceWeightingOutcomes
+
+empty_message: Set evaluation weighting

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/weightingParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/weightingParticipants.yml
@@ -1,0 +1,18 @@
+name: Evaluation weighting
+question: Evaluation weighting
+question_advice: |
+  Use the weightings to say how important each evaluation criteria is.
+
+  Total must add up to 100%
+optional: false
+type: multiquestion
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+questions:
+  - technicalWeightingParticipants
+  - culturalWeightingParticipants
+  - priceWeightingParticipants
+
+empty_message: Set evaluation weighting

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/weightingSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/weightingSpecialists.yml
@@ -1,0 +1,18 @@
+name: Evaluation weighting
+question: Evaluation weighting
+question_advice: |
+  Use the weightings to say how important each evaluation criteria is.
+
+  Total must add up to 100%
+optional: false
+type: multiquestion
+depends:
+  - "on": "lot"
+    being:
+      - digital-specialists
+questions:
+  - technicalWeightingSpecialists
+  - culturalWeightingSpecialists
+  - priceWeightingSpecialists
+
+empty_message: Set evaluation weighting

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/workAlreadyDone.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/workAlreadyDone.yml
@@ -1,0 +1,15 @@
+name: Any work that’s already been done
+question: Any work that’s already been done
+question_advice: If you’ve already done some work, for example, completed a discovery phase, you should describe it here.
+type: textbox_large
+optional: true
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+validations:
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Describe any work that has already been done

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/workingArrangements.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/workingArrangements.yml
@@ -1,0 +1,26 @@
+name: Working arrangements
+question: Working arrangements
+question_advice: |
+  Describe how you want to work with the individual or team.
+
+  Explain why you want to work with them in this way.
+
+  Include any limits on expenses.
+
+  For example: onsite 3 days a week for face-to-face team meetings
+
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Enter a description of the working arrangements.'
+  -
+    name: under_100_words
+    message: 'Description must be 100 words or fewer.'
+empty_message: Describe working arrangements

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/workplaceAddress.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/workplaceAddress.yml
@@ -1,0 +1,18 @@
+name: Address where the work will take place
+question: Address where the work will take place
+question_advice: You must include a specific town or city. You can add more than one.
+type: textbox_large
+max_length_in_words: 100
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Enter an address.'
+  -
+    name: under_100_words
+    message: 'Address must be 100 words or fewer.'
+empty_message: Describe where the supplier will work

--- a/frameworks/digital-outcomes-and-specialists-5/questions/clarification_question/answer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/clarification_question/answer.yml
@@ -1,0 +1,22 @@
+name: Your answer
+question: Your answer
+question_advice: |
+  **Publishing answers**
+
+  You must:
+
+  - answer all supplier questions
+  - give an individual response to each question even when questions are similar
+  - publish 1 answer at a time
+  - answer all questions at least 1 working day before the deadline to give suppliers time to decide if the work is
+    right for them
+  - answer questions within 2 to 3 working days
+  - answer questions more frequently when the deadline is approaching
+
+type: textbox_large
+max_length_in_words: 100
+validations:
+  - name: answer_required
+    message: Enter your answer.
+  - name: under_100_words
+    message: Your answer must be 100 words or fewer.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/clarification_question/question.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/clarification_question/question.yml
@@ -1,0 +1,18 @@
+name: Supplier question
+question: Supplier question
+question_advice: |
+  **Publishing supplier questions**
+
+  You must:
+
+  - publish all questions that suppliers ask
+  - publish 1 question at a time
+  - remove any reference to the supplier’s name or any confidential information about the supplier
+
+type: textbox_large
+max_length_in_words: 100
+validations:
+  - name: answer_required
+    message: Enter a supplier question.
+  - name: under_100_words
+    message: Supplier question must be 100 words or fewer.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/clarification_question/questionAndAnswer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/clarification_question/questionAndAnswer.yml
@@ -1,0 +1,18 @@
+name: Publish questions and answers
+question: Publish questions and answers
+question_advice: |
+  You must make sure that suppliers have access to the same information about the work.
+  This means all suppliers will have an equal opportunity to win the contract.
+
+  You must publish all questions and answers.
+
+  All published questions and answers will be public. They’ll appear at the bottom of your published requirements
+  page.
+
+  Read more about [how to manage supplier questions](https://www.gov.uk/guidance/how-to-answer-supplier-questions-about-your-digital-outcomes-and-specialists-requirements).
+
+type: multiquestion
+
+questions:
+  - question
+  - answer

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/10WorkingDays.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/10WorkingDays.yml
@@ -1,0 +1,8 @@
+name: Signing and returning the framework agreement
+question: >
+  Do you agree to sign and return the final framework agreement, without changing it, within 10 working days of it being issued by the Crown Commercial Service?
+
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/GAAR.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/GAAR.yml
@@ -1,0 +1,12 @@
+name: Why a tax return was incorrect
+question: >
+  Have any tax returns submitted by your organisation on or after 1 October 2012 been found to be incorrect on or after 1 April 2013 for any of these reasons:
+
+    - HMRC successfully challenged it under the General Anti-Abuse Rule (GAAR) or Halifax abuse principle
+    - a tax authority (in a jurisdiction in which your organisation is established) successfully challenged it under any tax rules or legislation that have an effect equivalent or similar to the GAAR or Halifax abuse principle
+    - an avoidance scheme that your organisation was involved with failed and was, or should have been, notified under the Disclosure of Tax Avoidance Scheme (DOTAS) or equivalent
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/MI.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/MI.yml
@@ -1,0 +1,8 @@
+name: Providing management information (MI)
+question: >
+  Do you confirm that you’re prepared to provide all the monthly Digital Outcomes and Specialists&nbsp;5-related management information (MI)
+  to CCS as outlined in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-5#reporting" target="_blank" rel="noopener noreferrer">reporting template (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/accurateInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/accurateInformation.yml
@@ -1,0 +1,7 @@
+name: Declaration accuracy
+question: >
+  Are all the answers in your supplier declaration truthful?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/accuratelyDescribed.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/accuratelyDescribed.yml
@@ -1,0 +1,6 @@
+name: Service description accuracy
+question: Will all the service descriptions you’re submitting for Digital Outcomes and Specialists&nbsp;5 on the Digital Marketplace be accurate and true representations?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/bankrupt.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/bankrupt.yml
@@ -1,0 +1,9 @@
+name: Bankruptcy or insolvency
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) been made bankrupt or the subject of insolvency or winding-up proceedings?
+
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/canProvideFromDayOne.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/canProvideFromDayOne.yml
@@ -1,0 +1,8 @@
+name: Providing services straight away
+question: >
+  If your application is successful, can you provide all the services you’re submitting to Digital Outcomes and Specialists&nbsp;5 from the first day you’re awarded a place on the framework?
+type: boolean
+hint: You must be ready to provide the services you’re submitting from October 2525.
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/civilServiceValues.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/civilServiceValues.yml
@@ -1,0 +1,7 @@
+name: Civil Service values
+question: >
+  Please confirm you will support the <a href="https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code" target="_blank" rel="noopener noreferrer">Civil Service values (link opens in a new tab)</a> and, if asked, provide evidence of how you do it.
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/confidentialInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/confidentialInformation.yml
@@ -1,0 +1,8 @@
+name: Obtaining confidential information
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) obtained confidential information that may give you undue advantages in the procurement procedure?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/conflictOfInterest.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/conflictOfInterest.yml
@@ -1,0 +1,8 @@
+name: Conflict of interest
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) had a conflict of interest as defined in <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/24/made" target="_blank" rel="noopener noreferrer">Regulation 24 of the Public Contracts Regulations 2015 (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/conspiracy.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/conspiracy.yml
@@ -1,0 +1,15 @@
+name: Organised crime or conspiracy convictions
+question: >
+  In the last 5 years, has anyone who represents, supervises or has control in your organisation (or a partner or parent organisation) been convicted of:
+
+    - a participation offence as defined by section 45 of the Serious Crime Act 2015
+    - conspiracy within the meaning of section 1 or 1A of the Criminal Law Act 1977 article
+    - conspiracy within the meaning of 9 or 9A of the Criminal Attempts and Conspiracy (Northern Ireland) Order 1983 where
+      that conspiracy relates to participation in a criminal organisation as defined in article 2 of Council Framework
+      Decision 2008/841/JHA on the fight against organised crime
+
+type: boolean
+hint: Answer ‘yes’ if anyone who represents, supervises or has control in your organisation or a partner or parent organisation has been convicted of any of the above.
+assessment:
+  passIfIn:
+    - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/contactEmailContractNotice.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/contactEmailContractNotice.yml
@@ -1,0 +1,4 @@
+name: Contract notice contact email
+question: If your Digital Outcomes and Specialists&nbsp;5 application is successful, what contact email should appear on the contract notice?
+type: text
+hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/contactNameContractNotice.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/contactNameContractNotice.yml
@@ -1,0 +1,4 @@
+name: Contract notice contact name
+question: If your Digital Outcomes and Specialists&nbsp;5 application is successful, what contact name should appear on the contract notice?
+type: text
+hint: The contract notice confirms the outcome of the framework competition and includes the names of all the successful suppliers.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/continuousProfessionalDevelopment.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/continuousProfessionalDevelopment.yml
@@ -1,0 +1,6 @@
+name: Continuous professional development
+question: Does your organisation practise continuous professional development for your employees, and can you provide evidence of this on request?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/corruptionBribery.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/corruptionBribery.yml
@@ -1,0 +1,16 @@
+name: Bribery or corruption convictions
+question: >
+  In the last 5 years, has anyone who represents, supervises or has control in your organisation (or a partner or parent organisation) been convicted of:
+
+    - corruption within the meaning of section 1(2) of the Public Bodies Corrupt Practices Act 1889 or section 1 of the Prevention of Corruption Act 1906
+    - the common law offence of bribery
+    - bribery within the meaning of sections 1, 2 or 6 of the Bribery Act 2010
+    - section 113 of the Representation of the People Act 1983
+    - any other offence within the meaning of article 57(1) of the Public Contracts Directive as defined by the law of any jurisdiction outside England and Wales and Northern Ireland
+    - any other offence within the meaning of article 57(1) of the Public Contracts Directive created after 26th February 2015 in England, Wales or Northern Ireland
+
+type: boolean
+hint: Answer ‘yes’ if anyone who represents, supervises or has control in your organisation or a partner or parent organisation has been convicted of any of the above.
+assessment:
+  passIfIn:
+    - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/customerSatisfactionProcess.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/customerSatisfactionProcess.yml
@@ -1,0 +1,6 @@
+name: Customer satisfaction measurement
+question: Do you have a process to measure customer satisfaction and can you provide evidence of that process on request?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/distortedCompetition.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/distortedCompetition.yml
@@ -1,0 +1,8 @@
+name: Unfair prior involvement in the procurement process
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) distorted competition prior involvement in the procurement procedure as described in <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/41/made" target="_blank" rel="noopener noreferrer">Regulation 41 of the Public Contracts Regulations 2015 (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/distortingCompetition.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/distortingCompetition.yml
@@ -1,0 +1,8 @@
+name: Distorting competition with other economic operators
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) entered into agreements with other economic operators with the aim of distorting competition?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/employersInsurance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/employersInsurance.yml
@@ -1,0 +1,16 @@
+name: Employer's liability insurance
+question: >
+  Does your organisation have, or will it have before the framework is awarded, employer’s liability insurance of at
+  least £5 million?
+hint: >
+  Employer’s liability insurance is a legal requirement except for businesses employing only the owner or close family
+  members. You must answer ‘Yes’ or ‘Not applicable’ to be eligible for consideration for the Digital Outcomes and Specialists&nbsp;5 framework.
+type: radios
+options:
+  - label: "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
+  - label: "No - your organisation does not have, and will not have in place, employer’s liability insurance of at least £5 million before the framework is awarded."
+  - label: "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."
+assessment:
+  passIfIn:
+    - "Yes – your organisation has, or will have in place, employer’s liability insurance of at least £5 million and you will provide certification before the framework is awarded."
+    - "Not applicable - your organisation does not need employer’s liability insurance because your organisation employs only the owner or close family members."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/employmentStatus.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/employmentStatus.yml
@@ -1,0 +1,12 @@
+name: Employment status
+question: >
+  Please confirm that you are aware that staff delivering services under this framework must be either:
+
+    - your employees
+    - your subcontractors’ employees
+    - contractors employed by you
+
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/environmentalSocialLabourLaw.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/environmentalSocialLabourLaw.yml
@@ -1,0 +1,18 @@
+name: Violations of environmental, social or labour law
+question: >
+  In the last 3 years, has your organisation (or a parent or partner organisation) violated your obilgations according to <a href="http://www.legislation.gov.uk/uksi/2015/102/part/2/chapter/2/crossheading/conduct-of-the-procedure-choice-of-participants-and-award-of-contracts/made" target="_blank" rel="noopener noreferrer">Regulation 56(2) of the Public Contracts Regulations 2015 (link opens in a new tab)</a> in any of these areas:
+
+    - environmental law
+    - social law
+    - labour law
+
+hint:
+  For example, if any finding of unlawful discrimination has been made against the organisation by an Employment Tribunal or Employment Appeal Tribunal.
+  
+  Read more about <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/551130/List_of_Mandatory_and_Discretionary_Exclusions.pdf" target="_blank" rel="noopener noreferrer">your obligations in the field of environment, social and labour law (link opens in a new tab)</a>
+
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/environmentallyFriendly.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/environmentallyFriendly.yml
@@ -1,0 +1,7 @@
+name: Environmentally-friendly working practices
+question: Do you work in an environmentally-friendly way?
+type: boolean
+hint: Answer ‘yes’ if your organisation engages in working practices like recycling or lowering your carbon footprint.
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/equalityAndDiversity.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/equalityAndDiversity.yml
@@ -1,0 +1,18 @@
+name: Equality and diversity obligations
+question: >
+  Please confirm that your organisation complies with legal equality and diversity obligations relating to:
+
+    - age
+    - disability
+    - gender reassignment
+    - marriage and civil partnership
+    - pregnancy and maternity
+    - race
+    - religion or belief
+    - sex
+    - sexual orientation
+
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/evidence.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/evidence.yml
@@ -1,0 +1,6 @@
+name: Providing evidence of experience
+question: If requested by a buyer, can you provide evidence of previous experience and comparable contracts?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/fraudAndTheft.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/fraudAndTheft.yml
@@ -1,0 +1,18 @@
+name: Fraud convictions
+question: >
+  In the last 5 years, has anyone anyone who represents, supervises or has control in your organisation (or a partner or parent organisation) been convicted of any offence that relates to fraud affecting the European Communities’ financial interests as defined by article 1 of the Convention on the Protection of the Financial Interests of the European Communities, including:
+
+    - the common law offence of cheating the Revenue (HMRC)
+    - the common law offence of conspiracy to defraud
+    - fraud or theft within the meaning of the Theft Act 1968, the Theft Act (Northern Ireland) 1969, the Theft Act 1978 or the Theft (Northern Ireland) Order 1978
+    - fraudulent trading within the meaning of section 458 of the Companies Act 1985, article 451 of the Companies (Northern Ireland) Order 1986 or section 993 of the Companies Act 2006
+    - fraudulent evasion within the meaning of section 170 of the Customs and Excise Management Act 1979 or section 72 of the Value Added Tax Act 1994
+    - an offence in connection with taxation in the European Union within the meaning of section 71 of the Criminal Justice Act 1993
+    - destroying, defacing or concealing of documents or procuring the execution of a valuable security within the meaning of section 20 of the Theft Act 1968 or section 19 of the Theft Act (Northern Ireland) 1969
+    - fraud within the meaning of section 2, 3 or 4 of the Fraud Act 2006
+    - the possession of articles for use in frauds within the meaning of section 6 of the Fraud Act 2006, or the making, adapting, supplying or offering to supply articles for use in frauds within the meaning of section 7 of that Act
+type: boolean
+hint: Answer ‘yes’ if anyone who represents, supervises or has control in your organisation or a partner or parent organisation has been convicted of any of the above.
+assessment:
+  passIfIn:
+    - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/fullAccountability.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/fullAccountability.yml
@@ -1,0 +1,8 @@
+name: Contractual responsibility and accountability
+question: >
+  Please confirm that your organisation will take direct contractual responsibility and full accountability for 
+  delivering the services you’re offering on the framework.
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/graveProfessionalMisconduct.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/graveProfessionalMisconduct.yml
@@ -1,0 +1,9 @@
+name: Professional misconduct
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) been guilty of grave professional misconduct?
+
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/helpBuyersComplyTechnologyCodesOfPractice.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/helpBuyersComplyTechnologyCodesOfPractice.yml
@@ -1,0 +1,7 @@
+name: Technology Code of Practice
+question: >
+  Do you agree to help the government work in ways which are consistent with the <a href="https://www.gov.uk/service-manual/technology/code-of-practice.html" target="_blank" rel="noopener noreferrer">Technology Code of Practice (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/influencedContractingAuthority.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/influencedContractingAuthority.yml
@@ -1,0 +1,8 @@
+name: Influencing the contracting authority
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) unduly influenced the decision-making process of the contracting authority?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/informationChanges.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/informationChanges.yml
@@ -1,0 +1,7 @@
+name: Changes to information
+question: >
+  Do you agree to inform the Crown Commercial Service as soon as possible if there are any changes to the information you’re providing in this supplier declaration?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/misleadingInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/misleadingInformation.yml
@@ -1,0 +1,8 @@
+name: Providing misleading information
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) provided misleading information that may have an influence on decisions concerning framework exclusion, selection or award?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/mitigatingFactors.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/mitigatingFactors.yml
@@ -1,0 +1,17 @@
+name: Mitigating factors for discretionary exclusion ([[taxEvasion]] to [[misleadingInformation]])
+question: >
+  If you responded ‘yes’ to any of the questions [[taxEvasion]] to [[misleadingInformation]], please provide details of
+  any mitigating factors that you think should be taken into consideration.
+type: textbox_large
+max_length_in_words: 500
+
+validations:
+  - 
+    name: answer_required
+    message: You need to answer this question because you answered ‘yes’ to one of questions [[taxEvasion]] to [[misleadingInformation]].
+  -
+    name: under_word_limit
+    message: "Your answer must be no more than 500 words."
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 5000 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/mitigatingFactors2.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/mitigatingFactors2.yml
@@ -1,0 +1,17 @@
+name: Mitigating factors for tax returns
+question: >
+  If you responded ‘yes’ to either question [[unspentTaxConvictions]] or question [[GAAR]], please provide details of 
+  any mitigating factors that you think should be taken into consideration.
+type: textbox_large
+max_length_in_words: 500
+
+validations:
+  - 
+    name: answer_required
+    message: You need to answer this question because you answered ‘yes’ to either [[unspentTaxConvictions]] or [[GAAR]].
+  -
+    name: under_word_limit
+    message: "Your answer must be no more than 500 words."
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 5000 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/mitigatingFactors3.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/mitigatingFactors3.yml
@@ -1,0 +1,17 @@
+name: Mitigating factors for Modern Slavery reporting requirements
+question: >
+  If your organisation does not meet the requirements, please explain why.
+type: textbox_large
+max_length_in_words: 500
+
+hidden: true
+validations:
+  -
+    name: answer_required
+    message: You need to answer this question because you answered ‘no’ to the Reporting Requirements question.
+  -
+    name: under_word_limit
+    message: "Your answer must be no more than 500 words."
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 5000 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryReportingRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryReportingRequirements.yml
@@ -1,0 +1,19 @@
+name: Modern slavery reporting requirements
+question: Does your organisation comply with the annual reporting requirements of section 54 of The Modern Slavery Act (2015)?
+
+hint: >
+  You must publish a slavery and human trafficking statement to comply with the act. Read the Home Office guidance for information about <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">how to write a statement and what information it must include (link opens in a new tab)</a>.
+
+hidden: true
+type: boolean
+
+validations:
+  - name: answer_required
+    message: You need to answer this question.
+
+assessment:
+  passIfIn:
+    - True
+  discretionary: True
+  # actually dependent, but it is not the assessment schema's responsibility to enforce that dependency
+  required: False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatement.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatement.yml
@@ -1,0 +1,17 @@
+name: Modern slavery statement required
+question: Upload a copy of your organisation’s slavery and human trafficking statement.
+
+hint: Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
+
+hidden: true
+type: upload
+
+validations:
+  - name: answer_required
+    message: You need to answer this question.
+  - name: file_is_open_document_format
+    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+  - name: file_is_less_than_5mb
+    message: Your document exceeds the 5MB limit. Please reduce file size.
+  - name: file_can_be_saved
+    message: Your document failed to upload. Please try again.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatementOptional.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatementOptional.yml
@@ -1,0 +1,18 @@
+name: Modern slavery statement optional
+question: >
+  You don’t need to publish a slavery and human trafficking statement to meet the modern slavery requirements for Digital Outcomes and Specialists 5.
+question_advice: >
+  You can choose to upload a statement. Read the Home Office guidance for information about <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">how to write a statement and what information it must include (link opens in a new tab)</a>.
+hint: >
+  Use an Open Document Format (ODF) or PDF/A (eg .pdf, .odt). (Maximum file size 5MB.)
+
+hidden: true
+type: upload
+
+validations:
+  - name: file_is_open_document_format
+    message: Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).
+  - name: file_is_less_than_5mb
+    message: Your document exceeds the 5MB limit. Please reduce file size.
+  - name: file_can_be_saved
+    message: Your document failed to upload. Please try again.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryTurnover.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryTurnover.yml
@@ -1,0 +1,13 @@
+name: Modern slavery turnover
+question: Does your organisation turnover £36 million or more a year?
+
+type: boolean
+followup:
+  modernSlaveryReportingRequirements:
+    - true
+  mitigatingFactors3:
+    - true
+  modernSlaveryStatement:
+    - true
+  modernSlaveryStatementOptional:
+    - false

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/multiqModernSlavery.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/multiqModernSlavery.yml
@@ -1,0 +1,11 @@
+id: multiqModernSlavery
+name: Modern slavery
+question: You must meet the reporting requirements of section 54 of The Modern Slavery Act (2015) if your organisations has a turnover of £36 million or more a year. Otherwise you can’t submit services on Digital Outcomes and Specialists 5.
+
+type: multiquestion
+questions:
+  - modernSlaveryTurnover
+  - modernSlaveryReportingRequirements
+  - modernSlaveryStatement
+  - mitigatingFactors3
+  - modernSlaveryStatementOptional

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/offerServicesYourselves.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/offerServicesYourselves.yml
@@ -1,0 +1,6 @@
+name: What your team will deliver
+question: Please confirm that you or your team will deliver the services you’re offering on the framework yourselves, and that your organisation does not solely source staff for others.
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/organisedCrime.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/organisedCrime.yml
@@ -1,0 +1,16 @@
+name: Organised crime convictions
+question: >
+  In the last 5 years, has anyone who represents, supervises or has control in your organisation (or a partner or parent organisation) been convicted of:
+
+    - money laundering within the meaning of sections 340(11) and 415 of the Proceeds of Crime Act 2002
+    - an offence in connection with the proceeds of criminal conduct within the meaning of section 93A, 93B or 93C of the Criminal Justice Act 1988 or article 45, 46 or 47 of the Proceeds of Crime (Northern Ireland) Order 1996
+    - an offence under section 4 of the Asylum and Immigration (Treatment of Claimants etc) Act 2004
+    - an offence under section 59A of the Sexual Offences Act 2003
+    - an offence under section 71 of the Coroners and Justice Act 2009
+    - an offence in connection with the proceeds of drug trafficking within the meaning of section 49, 50 or 51 of the Drug Trafficking Act 1994; or any other offence within the meaning of article 57(1) of the Directive
+    - an offence under section 2 or section 4 of the Modern Slavery Act 2015
+type: boolean
+hint: Answer ‘yes’ if anyone who represents, supervises or has control in your organisation or a partner or parent organisation has been convicted of any of the above.
+assessment:
+  passIfIn:
+    - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/outsideIR35.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/outsideIR35.yml
@@ -1,0 +1,10 @@
+name: Working outside IR35
+question: >
+  Will you (or workers you provide) meet the rules of working off-payroll ('outside IR35')?
+hint:
+  Read the guidance about <a href="https://www.gov.uk/guidance/ir35-find-out-if-it-applies" target="_blank" rel="noopener noreferrer">what work counts as outside IR35 (link opens in a new tab)</a>?
+
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/primaryContact.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/primaryContact.yml
@@ -1,0 +1,3 @@
+name: Primary contact name
+question: Who is the primary contact for the application?
+type: text

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/primaryContactEmail.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/primaryContactEmail.yml
@@ -1,0 +1,3 @@
+name: Primary contact email
+question: What is the primary contact’s email address?
+type: text

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/proofOfClaims.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/proofOfClaims.yml
@@ -1,0 +1,6 @@
+name: Proof of claims about services
+question: Are you prepared to provide proof of any claims made about the services you’re submitting to Digital Outcomes and Specialists&nbsp;5?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/publishContracts.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/publishContracts.yml
@@ -1,0 +1,7 @@
+name: Publishing contracts
+question: >
+  Are you prepared to <a href="https://www.gov.uk/government/publications/procurement-policy-note-0117-update-to-transparency-principles" target="_blank" rel="noopener noreferrer">publish contracts according to government policy (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/readUnderstoodGuidance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/readUnderstoodGuidance.yml
@@ -1,0 +1,9 @@
+name: Understanding the application process
+question: >
+  Do you understand the application process for Digital Outcomes and Specialists&nbsp;5 on the Digital Marketplace?
+hint: >
+  You can read about how to apply in the <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#how-to-apply" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists suppliers’ guide (link opens in a new tab)</a>.
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardOfficialInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardOfficialInformation.yml
@@ -1,0 +1,8 @@
+name: Safeguarding official information
+question: >
+  Do you agree to respect <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/715778/May-2018_Government-Security-Classifications-2.pdf" target="_blank" rel="noopener noreferrer">government security classifications (PDF, 528KB, link opens in a new tab)</a>
+  and protect official government information, eg by not revealing that government is the client when advertising for participants?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardPersonalData.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardPersonalData.yml
@@ -1,0 +1,8 @@
+name: Safeguarding personal data
+question: >
+  Do you agree to protect personal data according to the government guidance on <a href="https://www.gov.uk/data-protection-your-business" target="_blank" rel="noopener noreferrer">data protection and your business (link opens in a new tab)</a>?
+type: boolean
+hint: If you provide access to user research studios, for example, please confirm that you don’t share research videos with third parties.
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/seriousMisrepresentation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/seriousMisrepresentation.yml
@@ -1,0 +1,8 @@
+name: Serious misrepresentation of information
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) been guilty of serious misrepresentation of the information required for the fulfilment of the selection criteria?
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/serviceStandard.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/serviceStandard.yml
@@ -1,0 +1,8 @@
+name: Digital Service Standard
+question: >
+  Are you aware of, and will you comply with, the <a href="https://www.gov.uk/service-manual/service-standard" target="_blank" rel="noopener noreferrer">Digital Service Standard (link opens in a new tab)</a>
+  and the government’s latest <a href="https://www.gov.uk/design-principles" target="_blank" rel="noopener noreferrer">service design principles (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/significantOrPersistentDeficiencies.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/significantOrPersistentDeficiencies.yml
@@ -1,0 +1,10 @@
+name: Mismanaging a public contract
+question: >
+  In the last 3 years, has your organisation (or any partner organisation):
+
+    - shown significant or persistent deficiencies in the performance of a substantive requirement under a prior public contract, a prior contract with a contracting entity, or a prior concession contract, which led to early termination of the contract, damages or other comparable sanctions
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/skillsAndCapabilityAssessment.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/skillsAndCapabilityAssessment.yml
@@ -1,0 +1,6 @@
+name: Skills and capability assessment
+question: Do you assess the skills and capabilities of people you select to work for your company and could you provide evidence of how you do this, if requested?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/skillsAndResources.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/skillsAndResources.yml
@@ -1,0 +1,6 @@
+name: Skills and resources
+question: Does your organisation have the skills and resources to provide the services you’re submitting for Digital Outcomes and Specialists&nbsp;5?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
@@ -1,0 +1,10 @@
+name: Subcontractors or consortia
+question: "Please confirm whether you will provide Digital Outcomes and Specialists&nbsp;5 services:"
+type: checkboxes
+options:
+  - label: yourself without the use of third parties (subcontractors)
+  - label: as a prime contractor, using third parties (subcontractors) to provide some services
+  - label: as a prime contractor, using third parties (subcontractors) to provide all services
+  - label: as part of a consortium or special purpose vehicle, using members only to provide all services
+  - label: as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
+hint: Only include subcontractors whose products or services will be integral to the Digital Outcomes and Specialists&nbsp;5 services that you intend to provide.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/taxEvasion.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/taxEvasion.yml
@@ -1,0 +1,10 @@
+name: In breach of tax payments
+question: Have any members of your organisation or a partner organisation been legally found to be in breach of tax payments or social security contributions?
+type: boolean
+hint: >
+  ‘Legally found’ means any judicial or administrative decision, which has final or binding effect. Check that your organisation complies with 
+  <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/57/made" target="_blank" rel="noopener noreferrer">Regulation 57(3) of the Public Contracts Regulations 2015 (link opens in a new tab)</a>.
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsAndConditions.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsAndConditions.yml
@@ -1,0 +1,7 @@
+name: Terms and conditions
+question: >
+  Do you accept the terms and conditions in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-5#legal-documents" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsOfParticipation.yml
@@ -1,0 +1,7 @@
+name: Invitation to apply
+question: >
+  Do you agree to comply with the terms of the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-5#legal-documents" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists&nbsp;5 ‘invitation to apply’ (link opens in a new tab)</a>?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/terrorism.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/terrorism.yml
@@ -1,0 +1,13 @@
+name: Terrorism convictions
+question: >
+  In the last 5 years, has anyone who represents, supervises or has control in your organisation (or a partner or parent organisation) been convicted of any offence listed in:
+
+    - section 41 of the Counter Terrorism Act 2008
+    - schedule 2 of the Counter Terrorism Act 2008 where the court has determined that there is a terrorist connection
+    - sections 44 to 46 of the Serious Crime Act 2007
+
+type: boolean
+hint: Answer ‘yes’ if anyone who represents, supervises or has control in your organisation or a partner or parent organisation has been convicted of any of the above.
+assessment:
+  passIfIn:
+    - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/transparentContracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/transparentContracting.yml
@@ -1,0 +1,6 @@
+name: Transparent contracting
+question: Will you be transparent about your financial performance according to your contractual obligations?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/understandHowToAskQuestions.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/understandHowToAskQuestions.yml
@@ -1,0 +1,10 @@
+name: Asking questions
+question: >
+  Do you understand that you must ask ‘clarification’ questions on the <a href="https://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-5/updates" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists&nbsp;5 updates page (link opens in a new tab)</a> in your Digital Marketplace account?
+hint: >
+  You can ask clarification questions about Digital Outcomes and Specialists&nbsp;5 until 5pm BST 1 August 2525. All questions and answers will be posted regularly on the Digital Outcomes and Specialists&nbsp;5 updates page. You will be notified by email when new clarification questions and answers are available.
+
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/understandTool.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/understandTool.yml
@@ -1,0 +1,6 @@
+name: Completing the declaration and adding a service
+question: Do you understand that you must make the supplier declaration and mark at least one service as complete before your application to Digital Outcomes and Specialists&nbsp;5 can be considered?
+type: boolean
+assessment:
+  passIfIn:
+    - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/unfairCompetition.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/unfairCompetition.yml
@@ -1,0 +1,14 @@
+name: No unfair access to information
+question: >
+  Has any party involved in the application done any of the following:
+
+    - colluded to set prices with other suppliers or buyers
+    - entered into any arrangement with another person so that person refrains from submitting an application
+    - given access to information relating to the application to another person, or offered or given payment to another person in exchange for information
+    - given inducement or valuable consideration to another person (except where such communication takes place with people who are also participants in the application, or where disclosure is made in confidence to obtain necessary information or security for the application)
+    - canvassed, or attempted to buy information from, any government agent about this procurement
+
+type: boolean
+assessment:
+  passIfIn:
+    - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/unspentTaxConvictions.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/unspentTaxConvictions.yml
@@ -1,0 +1,11 @@
+name: If a tax return was incorrect
+question: >
+  Have any tax returns submitted by your organisation on or after 1 October 2012:
+
+    - been found to be incorrect as of 1 April 2013
+    - given rise to a criminal conviction for tax-related offences which is unspent, or to civil penalty for fraud or evasion
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/witheldSupportingDocuments.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/witheldSupportingDocuments.yml
@@ -1,0 +1,9 @@
+name: Withholding information
+question: >
+  In the last 3 years, has your organisation (or any partner organisation) withheld information or failed to submit supporting documents required under <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/59/made" target="_blank" rel="noopener noreferrer">Regulation 59 of the Public Contracts Regulations 2015 (link opens in a new tab)</a>?
+
+type: boolean
+assessment:
+  passIfIn:
+    - False
+  discretionary: True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/accessibleApplicationsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/accessibleApplicationsOutcomes.yml
@@ -1,0 +1,15 @@
+name: Designing and building accessible applications
+question: Will you design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoach.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoach.yml
@@ -1,0 +1,16 @@
+question: Agile coach
+name: Agile coach
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - agileCoachLocations
+  - agileCoachDayRate
+
+empty_message: You haven’t added an agile coach
+
+hint: Help individuals, teams and managers be as effective as possible by embedding an agile culture.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoachDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoachDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for an agile coach (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: agileCoachPriceMin
+  maximum_price: agileCoachPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: agileCoachPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: agileCoachPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: agileCoachPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: agileCoachPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: agileCoachPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoachLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoachLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your agile coach work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/anonymousRecruitment.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/anonymousRecruitment.yml
@@ -1,0 +1,11 @@
+name: Provide discreet recruitment
+question: Can you, if asked, recruit participants without revealing details of the organisation you’re recruiting for?
+type: boolean
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/bespokeSystemInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/bespokeSystemInformation.yml
@@ -1,0 +1,14 @@
+name: Share systems information
+question: Will you share bespoke system information from the service you’re working on, eg software performance data, to help the government continuously improve its services?
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalyst.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalyst.yml
@@ -1,0 +1,16 @@
+question: Business analyst
+name: Business analyst
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - businessAnalystLocations
+  - businessAnalystDayRate
+
+empty_message: You haven’t added a business analyst
+
+hint: Analyse a service or organisation’s business processes and systems. Specify, collect and present findings.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalystDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalystDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a business analyst (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: businessAnalystPriceMin
+  maximum_price: businessAnalystPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: businessAnalystPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: businessAnalystPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: businessAnalystPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: businessAnalystPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: businessAnalystPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalystLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalystLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your business analyst work? 
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManager.yml
@@ -1,0 +1,16 @@
+question: Communications manager
+name: Communications manager
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - communicationsManagerLocations
+  - communicationsManagerDayRate
+
+empty_message: You haven’t added a communications manager
+
+hint: Develop user-focused messages, measurement techniques and communication approaches. Establish integrated communication plans across a range of digital channels to ensure that communication is ongoing, open and clear.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManagerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a communications manager (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: communicationsManagerPriceMin
+  maximum_price: communicationsManagerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: communicationsManagerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: communicationsManagerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: communicationsManagerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: communicationsManagerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: communicationsManagerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManagerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your communications manager work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesigner.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesigner.yml
@@ -1,0 +1,17 @@
+question: Content designer
+name: Content designer
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - contentDesignerLocations
+  - contentDesignerDayRate
+  - contentDesignerAccessibleApplications
+
+empty_message: You haven’t added a content designer
+
+hint: Ensure content is as clear and simple as possible to meet user needs.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a content designer (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: contentDesignerPriceMin
+  maximum_price: contentDesignerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: contentDesignerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: contentDesignerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: contentDesignerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: contentDesignerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: contentDesignerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your content designer work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitect.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitect.yml
@@ -1,0 +1,16 @@
+question: Data architect
+name: Data architect
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - dataArchitectLocations
+  - dataArchitectDayRate
+
+empty_message: You haven’t added a data architect
+
+hint: Set the vision for the organisation’s use of data, through data design, to meet business needs.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitectDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitectDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a data architect (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: dataArchitectPriceMin
+  maximum_price: dataArchitectPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: dataArchitectPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dataArchitectPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: dataArchitectPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dataArchitectPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: dataArchitectPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitectLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitectLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your data architect work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineer.yml
@@ -1,0 +1,16 @@
+question: Data engineer
+name: Data engineer
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - dataEngineerLocations
+  - dataEngineerDayRate
+
+empty_message: You haven’t added a data engineer
+
+hint: Design, build, test and maintain data management systems, making sure they meet business requirements and user needs.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a data engineer (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: dataEngineerPriceMin
+  maximum_price: dataEngineerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: dataEngineerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dataEngineerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: dataEngineerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dataEngineerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: dataEngineerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your data engineer work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataProtocols.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataProtocols.yml
@@ -1,0 +1,14 @@
+name: Standard data protocols
+question: Will you use standard, accessible data protocols to ensure interoperability across government services?
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientist.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientist.yml
@@ -1,0 +1,16 @@
+question: Data scientist
+name: Data scientist
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - dataScientistLocations
+  - dataScientistDayRate
+
+empty_message: You haven’t added a data scientist
+
+hint: Identify complex business problems while working with policy and operations teams to understand where data can add value.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientistDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientistDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a data scientist (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: dataScientistPriceMin
+  maximum_price: dataScientistPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: dataScientistPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dataScientistPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: dataScientistPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: dataScientistPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: dataScientistPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientistLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientistLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your data scientist work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/delivery.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/delivery.yml
@@ -1,0 +1,13 @@
+question: Service delivery
+name: Service delivery
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - deliveryTypes
+
+empty_message: You haven’t added any service delivery capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManager.yml
@@ -1,0 +1,16 @@
+question: Delivery manager
+name: Delivery manager
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - deliveryManagerLocations
+  - deliveryManagerDayRate
+
+empty_message: You haven’t added a delivery manager
+
+hint: Set up a team for successful delivery. Remove obstacles, track progress, facilitate meetings and help the team organise itself.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManagerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a delivery manager (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: deliveryManagerPriceMin
+  maximum_price: deliveryManagerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: deliveryManagerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: deliveryManagerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: deliveryManagerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: deliveryManagerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: deliveryManagerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManagerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your delivery manager work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryTypes.yml
@@ -1,0 +1,27 @@
+question: What types of service delivery can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: Agile coaching
+    description: Help individuals, teams and managers to be effective by embedding an agile culture.
+  - label: Agile delivery
+    description: Support the delivery team by removing blockers to progress, facilitating discussion and helping the team to self-organise without imposing how work is done.
+  - label: Business analysis
+    description: Specify, collect and present performance data and analysis for a product or service.
+  - label: Digital communication and engagement
+    description: Develop or deliver a communications plan for a service or product which engages users across many channels.
+  - label: Product management
+    description: Lead the delivery and continuous improvement of one or more digital products or platforms.
+  - label: Programme management
+    description: Manage and organise groups of related projects so they work together to achieve a strategic objective.
+  - label: Project management
+    description: Motivate and manage a team, and plan and prioritise work to achieve project objectives.
+  - label: Service management
+    description: Develop and deliver an effective user-focused digital service. Manage the full product lifecycle including user research, design, delivery and the continuous improvement of one or more transactional services or platforms.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/designer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/designer.yml
@@ -1,0 +1,17 @@
+question: Designer
+name: Designer
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - designerLocations
+  - designerDayRate
+  - designerAccessibleApplications
+
+empty_message: You haven’t added a designer
+
+hint: Provide user-centred interaction design, service design and graphic design expertise.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/designerAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/designerAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/designerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/designerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a designer (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: designerPriceMin
+  maximum_price: designerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: designerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: designerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: designerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: designerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: designerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/designerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/designerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your designer work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/developer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/developer.yml
@@ -1,0 +1,17 @@
+question: Developer
+name: Developer
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - developerLocations
+  - developerDayRate
+  - developerAccessibleApplications
+
+empty_message: You haven’t added a developer
+
+hint: Build software that supports user needs. Continually improve the service by identifying new tools and techniques, removing technical bottlenecks, and adapting and maintaining code.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/developerAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/developerAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/developerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/developerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a developer (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: developerPriceMin
+  maximum_price: developerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: developerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: developerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: developerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: developerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: developerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/developerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/developerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your developer work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/helpGovernmentImproveServices.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/helpGovernmentImproveServices.yml
@@ -1,0 +1,14 @@
+name: Share non-personal data
+question: Will you share non-personal user and service data to help the government continuously improve its services?
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labAccessibility.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labAccessibility.yml
@@ -1,0 +1,22 @@
+name: How accessible is your studio?
+question: >
+  How accessible is your studio?
+
+  Describe the ways in which your lab is accessible or inaccessible, eg wheelchair access or hearing loops provided.
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: textbox_large
+max_length_in_words: 50
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must be no more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description must be no more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labAddressBuilding.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labAddressBuilding.yml
@@ -1,0 +1,18 @@
+question: Building and street
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: text
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Your answer must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 200 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labAddressPostcode.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labAddressPostcode.yml
@@ -1,0 +1,15 @@
+question: Postcode
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: text
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than than 10 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labAddressTown.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labAddressTown.yml
@@ -1,0 +1,18 @@
+question: Town or city
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: text
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_20_words
+    message: 'Your answer must be no more than 20 words.'
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 200 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labBabyChanging.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labBabyChanging.yml
@@ -1,0 +1,11 @@
+question: Do you provide baby-changing facilities?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: boolean
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labCarPark.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labCarPark.yml
@@ -1,0 +1,18 @@
+question: Where can visitors to your studio park?
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: textbox_large
+max_length_in_words: 50
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must be no more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description must be no more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labDesktopStreaming.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labDesktopStreaming.yml
@@ -1,0 +1,16 @@
+question: Do you stream a view of the desktop or laptop screen?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labDeviceStreaming.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labDeviceStreaming.yml
@@ -1,0 +1,16 @@
+question: Do you stream a view of a mobile or tablet device?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labEyeTracking.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labEyeTracking.yml
@@ -1,0 +1,16 @@
+question: Do you provide eye-tracking?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labHosting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labHosting.yml
@@ -1,0 +1,16 @@
+question: Do you welcome and host participants?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labPrice.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labPrice.yml
@@ -1,0 +1,24 @@
+question: What is the minimum amount of time your lab can be booked for and how much does it cost (excluding VAT)?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: pricing
+fields:
+  hours_for_price: labTimeMin
+  minimum_price: labPriceMin
+field_defaults:
+  price_unit: Lab
+
+validations:
+  - name: answer_required
+    field: labTimeMin
+    message: 'You need to answer this question.'
+  - name: answer_required
+    field: labPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: labPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labPublicTransport.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labPublicTransport.yml
@@ -1,0 +1,18 @@
+question: How do visitors get to your studio using public transport?
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: textbox_large
+max_length_in_words: 50
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_50_words
+    message: 'Your description must be no more than 50 words.'
+  -
+    name: under_character_limit
+    message: "Your description must be no more than 500 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labSize.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labSize.yml
@@ -1,0 +1,18 @@
+name: How many people can the lab accommodate?
+question: >
+  How many people can the lab accommodate?
+
+  This is the total number of people including participants and researchers.
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+type: text
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your answer must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labStreaming.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labStreaming.yml
@@ -1,0 +1,16 @@
+question: Do you provide remote streaming from the lab?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labTechAssistance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labTechAssistance.yml
@@ -1,0 +1,16 @@
+question: Do you provide help with studio equipment and streaming?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labToilets.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labToilets.yml
@@ -1,0 +1,11 @@
+question: Do you provide toilets?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: boolean
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labViewingArea.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labViewingArea.yml
@@ -1,0 +1,16 @@
+question: Do you have a viewing area?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labWaitingArea.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labWaitingArea.yml
@@ -1,0 +1,16 @@
+question: Do you provide a waiting area?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: Yes – included as standard
+  - label: Yes – for an additional cost
+  - label: "No"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labWiFi.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labWiFi.yml
@@ -1,0 +1,12 @@
+question: Do you provide Wi-Fi?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: boolean
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/lot.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/lot.yml
@@ -1,0 +1,25 @@
+question: 'Service type'
+type: radios
+options:
+  -
+    label: Apply to provide teams for digital outcomes
+    value: digital-outcomes
+    description: >
+      Examples of digital outcomes include the beta of an appointment booking system or the alpha of a billing application.
+  -
+    label: Apply to provide individual digital specialists
+    value: digital-specialists
+    description: >
+      Examples of digital specialists include content designers or technical architects.
+  -
+    label: Apply to provide user research studios
+    value: user-research-studios
+    description: >
+      User research studios sometimes have multiple labs, or rooms. Labs usually include a device to test a service
+      and a way to observe the session. Provide information on each lab you want buyers to use.
+  -
+    label: Apply to provide user research participant recruitment
+    value: user-research-participants
+    description: >
+      Examples of participant recruitment services include finding and managing research participants from specific
+      user groups.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/manageIncentives.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/manageIncentives.yml
@@ -1,0 +1,11 @@
+name: Manage incentives
+question: Do you agree to manage any incentives to user research participants?
+type: boolean
+depends:
+  - "on": "lot"
+    being:
+      - user-research-participants
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/openStandardsPrinciples.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/openStandardsPrinciples.yml
@@ -1,0 +1,16 @@
+name: Use of open standards
+question: |
+  Will you work according to the government’s [Open Standards Principles](https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles) and use the [open standards selected for use across government](http://standards.data.gov.uk/challenges/adopted)?
+hint: This includes publishing any software you build for the government under the appropriate open source licence.
+type: boolean
+required_value: true
+
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/outcomesLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/outcomesLocations.yml
@@ -1,0 +1,33 @@
+id: locations
+name: Where can you work on digital outcomes?
+question: |
+  Where can you work on digital outcomes?
+
+  Choose all the locations where you can work at buyers’ sites, and whether you can work offsite.
+
+  You can update the locations where you can provide services when the framework is live.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites.
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalysis.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalysis.yml
@@ -1,0 +1,13 @@
+question: Performance analysis and data
+name: Performance analysis and data
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - performanceAnalysisTypes
+
+empty_message: You haven’t added any performance analysis and data capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalysisTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalysisTypes.yml
@@ -1,0 +1,27 @@
+question: What types of performance analysis can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: A/B and multivariate testing
+    description: Improve product performance by agreeing a hypothesis, setting up or managing a testing framework, and evaluating the results.
+  - label: Data analysis
+    description: Examine, transform and model data to discover useful insights, suggest conclusions and support decision making.
+  - label: Data cleansing
+    description: Detect and correct inaccurate or corrupt records from a record set, table or database. Collate and manipulate data into a usable format.
+  - label: Data visualisation
+    description: Interpret data into meaningful graphics to help analyse and display data.
+  - label: Performance frameworks
+    description: Set up key performance indicators (KPIs) and measure the progress of an organisation, programme, service or product against its goals.
+  - label: Performance reporting
+    description: Present key performance data and analysis for a service or product.
+  - label: Statistical modelling
+    description: Create models to help understand relationships between different types of data and support decision making.
+  - label: Web analytics
+    description: Measure, collect, analyse and report data on how people use a web service so that it can be improved.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalyst.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalyst.yml
@@ -1,0 +1,16 @@
+question: Performance analyst
+name: Performance analyst
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - performanceAnalystLocations
+  - performanceAnalystDayRate
+
+empty_message: You haven’t added a performance analyst
+
+hint: Specify, collect and present the key performance data and analysis for a service.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalystDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalystDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a performance analyst (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: performanceAnalystPriceMin
+  maximum_price: performanceAnalystPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: performanceAnalystPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: performanceAnalystPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: performanceAnalystPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: performanceAnalystPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: performanceAnalystPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalystLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalystLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your performance analyst work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManager.yml
@@ -1,0 +1,16 @@
+question: Portfolio manager
+name: Portfolio manager
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - portfolioManagerLocations
+  - portfolioManagerDayRate
+
+empty_message: You haven’t added a portfolio manager
+
+hint: Lead a digital portfolio of projects and programmes.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManagerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a portfolio manager (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: portfolioManagerPriceMin
+  maximum_price: portfolioManagerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: portfolioManagerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: portfolioManagerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: portfolioManagerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: portfolioManagerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: portfolioManagerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManagerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your portfolio manager work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/productManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/productManager.yml
@@ -1,0 +1,16 @@
+question: Product manager
+name: Product manager
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - productManagerLocations
+  - productManagerDayRate
+
+empty_message: You haven’t added a product manager
+
+hint: Lead the delivery and continuous improvement of one or more digital products or platforms.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/productManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/productManagerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a product manager (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: productManagerPriceMin
+  maximum_price: productManagerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: productManagerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: productManagerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: productManagerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: productManagerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: productManagerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/productManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/productManagerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your product manager work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManager.yml
@@ -1,0 +1,16 @@
+question: Programme manager
+name: Programme manager
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - programmeManagerLocations
+  - programmeManagerDayRate
+
+empty_message: You haven’t added a programme manager
+
+hint: Manage and organise groups of related projects so they work together to achieve a strategic objective.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManagerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a programme manager (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: programmeManagerPriceMin
+  maximum_price: programmeManagerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: programmeManagerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: programmeManagerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: programmeManagerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: programmeManagerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: programmeManagerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManagerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your programme manager work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssurance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssurance.yml
@@ -1,0 +1,17 @@
+question: Quality assurance analyst
+name: Quality assurance analyst
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - qualityAssuranceLocations
+  - qualityAssuranceDayRate
+  - qualityAssuranceAccessibleApplications
+
+empty_message: You haven’t added a quality assurance analyst
+
+hint: Ensure the quality of the digital service by testing it manually and writing automated tests covering a range of conditions.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a quality assurance analyst (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: qualityAssurancePriceMin
+  maximum_price: qualityAssurancePriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: qualityAssurancePriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: qualityAssurancePriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: qualityAssurancePriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: qualityAssurancePriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: qualityAssurancePriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your quality assurance analyst work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/recruitFromList.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/recruitFromList.yml
@@ -1,0 +1,11 @@
+question: Are you willing to recruit participants based on a list provided to you by the buyer?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-participants
+type: boolean
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/recruitLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/recruitLocations.yml
@@ -1,0 +1,22 @@
+id: locations
+question: Where can you recruit participants from?
+hint: >
+depends:
+  - "on": lot
+    being:
+      - user-research-participants
+type: checkboxes
+options:
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+  - label: "International (outside the UK)"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/recruitMethods.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/recruitMethods.yml
@@ -1,0 +1,16 @@
+question: How do you recruit participants?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-participants
+
+type: checkboxes
+options:
+  - label: Entirely offline
+  - label: Initial recruitment offline, but then contact them online
+  - label: Entirely online
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/security.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/security.yml
@@ -1,0 +1,13 @@
+question: Security
+name: Security
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - securityTypes
+
+empty_message: You haven’t added any security capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultant.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultant.yml
@@ -1,0 +1,16 @@
+question: Cyber security consultant
+name: Cyber security consultant
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - securityConsultantLocations
+  - securityConsultantDayRate
+
+empty_message: You haven’t added a cyber security consultant
+
+hint: Minimise the chance of data or information systems security breaches. Ensure information is protected against unauthorised or unintended access. Put systems in place to prevent data destruction or disruption.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultantDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultantDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a cyber security consultant (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: securityConsultantPriceMin
+  maximum_price: securityConsultantPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: securityConsultantPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: securityConsultantPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: securityConsultantPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: securityConsultantPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: securityConsultantPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultantLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultantLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your cyber security consultant work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/securityTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/securityTypes.yml
@@ -1,0 +1,29 @@
+question: What types of security can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: CESG information assurance certification
+    description: Offer services as a CESG Certified Professional - the government’s approved standard for cyber security professionals.
+  - label: Firewall audit
+    description: Ensure deployed firewall rules match security policies, and identify where the rules should be changed.
+  - label: Incident response and forensics
+    description: Prepare for, and respond to a security incident. Determine what has gone wrong and how to resolve the incident. Understand and comply with forensic requirements.
+  - label: Infrastructure review
+    description: Review infrastructure to ensure the hardware and software meets security policies, and is appropriately configured and patched.
+  - label: IT health check
+    description: Conduct penetration testing using CESG-approved firms.
+  - label: Risk management
+    description: Identify, analyse, document, mitigate and monitor the risks of a system.
+  - label: Security policy
+    description: Evaluate and develop security plans and policies to protect digital assets.
+  - label: Threat modelling
+    description: Take a structured approach to analysing the security needs of a system or service.
+  - label: Vulnerability and penetration testing
+    description: Analyse and test a service for security problems.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManager.yml
@@ -1,0 +1,17 @@
+question: Service manager
+name: Service manager
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - serviceManagerLocations
+  - serviceManagerDayRate
+  - serviceManagerAccessibleApplications
+
+empty_message: You haven’t added a service manager
+
+hint: Develop and deliver an effective user-focused digital service. Manage the full product lifecycle, including user research, design, delivery and continuous improvement.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a service manager (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: serviceManagerPriceMin
+  maximum_price: serviceManagerPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: serviceManagerPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: serviceManagerPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: serviceManagerPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: serviceManagerPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: serviceManagerPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your service manager work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceName.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceName.yml
@@ -1,0 +1,20 @@
+name: What is the name of the lab?
+question: |
+  What is the name of the lab?
+
+  Provide the name of the room where participants and researchers carry out testing.
+type: text
+
+depends:
+  -
+    "on": lot
+    being:
+      - user-research-studios
+
+validations:
+  -
+    name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: under_character_limit
+    message: "Your studio name must be no more than 100 characters."

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/softwareDevelopment.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/softwareDevelopment.yml
@@ -1,0 +1,13 @@
+question: Software development
+name: Software development
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - softwareDevelopmentTypes
+
+empty_message: You haven’t added any software development capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/softwareDevelopmentTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/softwareDevelopmentTypes.yml
@@ -1,0 +1,43 @@
+question: What types of software development can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: API development
+    description: Design and evolve secure APIs.
+  - label: Cloud-based service development
+    description: Understand how using the cloud might change an application’s architecture. Develop, deploy and maintain applications in the cloud where appropriate.
+  - label: Content management system
+    description: Build, maintain, customise and extend a CMS.
+  - label: Customer relationship management
+    description: Build, maintain, customise and extend a CRM system.
+  - label: Database development
+    description: Build and maintain a persistent storage solution to meet the needs of the project or service.
+  - label: Desktop application development
+    description: Build and maintain applications for desktop computers based on user needs.
+  - label: Front-end web application development
+    description: Build and maintain the user interface of a web application based on user needs.
+  - label: Game development
+    description: Develop games, eg for education or training.
+  - label: Geographic information systems (GIS) development
+    description: Build and maintain GIS systems using open standards.
+  - label: Machine learning
+    description: Understand a variety of machine learning techniques and apply them appropriately.
+  - label: Mainframe
+    description: Implement and update mainframe technologies. Migrate away from mainframe applications and tools when appropriate.
+  - label: Message queues
+    description: Design and implement systems using message queues. Understand the benefits of message queues and how they fit within a larger architecture.
+  - label: Mobile application development
+    description: Build and maintain applications for mobile devices based on user needs.
+  - label: Search
+    description: Develop search systems that index content so users can find it. Structure search tools based on source data.
+  - label: Systems integration
+    description: Implement or update an architecture across multiple systems. Integrate core legacy systems where necessary.
+  - label: Web application development
+    description: Build and maintain web applications using front-end and server-side technologies to create accessible, user-centred digital services.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/supportAndOperations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/supportAndOperations.yml
@@ -1,0 +1,13 @@
+question: Support and operations
+name: Support and operations
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - supportAndOperationsTypes
+
+empty_message: You haven’t added any support and operations capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/supportAndOperationsTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/supportAndOperationsTypes.yml
@@ -1,0 +1,29 @@
+question: What types of support and operations can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: Customer support
+    description: Support user needs by providing help before, during and after people use a product or service.
+  - label: Firewall management
+    description: Provision, deploy, upgrade, patch, and monitor firewalls to reduce cyber attack and compliance risks.
+  - label: Hosting
+    description: Implement and manage cloud-hosted infrastructure or traditional datacentres.
+  - label: Incident management
+    description: Log, record and manage incidents on digital services.
+  - label: Monitoring
+    description: Monitor system performance and events. Ensure relevant alerts are set up.
+  - label: Network administration
+    description: Assemble, maintain and upgrade computer hardware and software systems that make up a network.
+  - label: Service desk
+    description: Provide first or second-line technical support to either internal or external users.
+  - label: Systems administration
+    description: Install, support and maintain computer systems. Manage user and security policies.
+  - label: Tooling
+    description: Set up and maintain tools for continuous integration and deployment of digital services.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitect.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitect.yml
@@ -1,0 +1,17 @@
+question: Technical architect
+name: Technical architect
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - technicalArchitectLocations
+  - technicalArchitectDayRate
+  - technicalArchitectAccessibleApplications
+
+empty_message: You haven’t added a technical architect
+
+hint: Break down complex problems and identify steps towards solutions. Coach individuals and engage with non-technical people at all levels of seniority. Write code as a senior member of the development team.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a technical architect (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: technicalArchitectPriceMin
+  maximum_price: technicalArchitectPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: technicalArchitectPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: technicalArchitectPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: technicalArchitectPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: technicalArchitectPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: technicalArchitectPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your technical architect work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/testingAndAuditing.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/testingAndAuditing.yml
@@ -1,0 +1,13 @@
+question: Testing and auditing
+name: Testing and auditing
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - testingAndAuditingTypes
+
+empty_message: You haven’t added any testing and auditing capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/testingAndAuditingTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/testingAndAuditingTypes.yml
@@ -1,0 +1,25 @@
+question: What types of testing and auditing can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: Accessibility testing
+    description: Test whether a product or service is easy to use for people using assistive technologies, eg screen readers, voice recognition software or trackball devices. Highlight problems and suggest changes where appropriate.
+  - label: Application testing
+    description: Ensure the integrity of the product by writing automated tests or conducting manual tests. Investigate the results, and report bugs or issues.
+  - label: Data auditing
+    description: Profile data to assess whether it’s fit for purpose. Measure the impact of poor quality data on service performance. Highlight problems and suggest changes where appropriate.
+  - label: Load and performance testing
+    description: Test sites and applications under realistic loads (traffic) to make sure that they’re stable and work well for users.
+  - label: Process auditing
+    description: Review how IT processes are managed, eg establish whether practices are compliant with payment card industry (PCI) standards. Highlight problems and suggest changes where appropriate.
+  - label: Software auditing
+    description: Provide independent examination of a software product or process to assess compliance with specifications, standards, contracts or other criteria. Highlight problems and suggest changes where appropriate.
+  - label: System auditing
+    description: Examine system controls within an IT architecture to test the suitability and validity of a system’s IT configurations, practices and operations. Highlight problems and suggest changes where appropriate.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userExperienceAndDesign.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userExperienceAndDesign.yml
@@ -1,0 +1,13 @@
+question: User experience and design
+name: User experience and design
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - userExperienceAndDesignTypes
+
+empty_message: You haven’t added any user experience and design capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userExperienceAndDesignTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userExperienceAndDesignTypes.yml
@@ -1,0 +1,31 @@
+question: What types of user experience and design can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: Accessibility
+    description: Ensure a digital service considers the needs of all possible users so that no one is excluded.
+  - label: Animation
+    description: Create moving images and effects which can be used on websites, videos or games.
+  - label: Brand development
+    description: Understand and design how an organisation, service or product is perceived and communicates its brand, whenever and wherever users interact with it.
+  - label: Content design and copywriting
+    description: Write content for a site or service to clearly, simply and quickly communicate information to users.
+  - label: Cross-platform design
+    description: Create experiences that cover all user interactions when they use a product or service. This will cross many channels, involve online and offline products and services, and include digital and face-to-face interactions.
+  - label: Information architecture
+    description: Organise, structure and label content to help users find information and complete tasks.
+  - label: Interaction design
+    description: Design a digital service so that it’s as simple as possible for users. Create user journeys and interaction patterns.
+  - label: Prototyping
+    description: Create a basic version of a product that can be quickly tested and iterated with users.
+  - label: Service design
+    description: Design online and offline services based on user needs and behaviour.
+  - label: User experience and design strategy
+    description: Conduct long-term planning to align every user interaction with a vision for user experience.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearch.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearch.yml
@@ -1,0 +1,13 @@
+question: User research
+name: User research
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: multiquestion
+any_of: capability
+questions:
+  - userResearchTypes
+
+empty_message: You haven’t added any user research capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearchTypes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearchTypes.yml
@@ -1,0 +1,21 @@
+question: What types of user research can you provide?
+depends:
+  - "on": lot
+    being:
+      - digital-outcomes
+type: checkboxes
+options:
+  - label: Creating personas
+    description: Create personas based on the characteristics of a group of users who use a service in a similar way.
+  - label: Quantitative research
+    description: Design, conduct and analyse surveys and online panels to understand user attitudes and behaviours on a service or product.
+  - label: Usability testing
+    description: Evaluate the usability of a product by testing it with representative users.
+  - label: User journey mapping
+    description: Create and work with user journey maps to help understand the user experience of a service throughout its lifecycle, across all channels and for each interaction.
+  - label: User needs and insights
+    description: Design, conduct and analyse user research to identify users of a service and their needs.
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcher.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcher.yml
@@ -1,0 +1,16 @@
+question: User researcher
+name: User researcher
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - userResearcherLocations
+  - userResearcherDayRate
+
+empty_message: You haven’t added a user researcher
+
+hint: Design, conduct and analyse user research using a range of techniques, eg one-to-one interviews or usability tests.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcherDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcherDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a user researcher (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: userResearcherPriceMin
+  maximum_price: userResearcherPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: userResearcherPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: userResearcherPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: userResearcherPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: userResearcherPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: userResearcherPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcherLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcherLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your user researcher work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperations.yml
@@ -1,0 +1,17 @@
+question: Web operations engineer
+name: Web operations engineer
+optional: true
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: multiquestion
+any_of: specialist
+questions:
+  - webOperationsLocations
+  - webOperationsDayRate
+  - webOperationsAccessibleApplications
+
+empty_message: You haven’t added a web operations engineer
+
+hint: Run the production systems to help the development team build software that is easy to operate, scale and secure.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsAccessibleApplications.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsAccessibleApplications.yml
@@ -1,0 +1,18 @@
+question: Designing and building accessible applications
+question_advice: Will this specialist design and build accessible applications that meet the 2018 accessibility regulations?
+hint:
+  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services</a>.
+type: boolean
+required_value: true
+
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'
+  -
+    name: not_required_value
+    message: 'The specialist must be able to meet the accessibility regulations.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsDayRate.yml
@@ -1,0 +1,30 @@
+question: How much do you charge per day for a web operations engineer (excluding VAT and expenses)?
+question_advice: You won’t be able to charge a higher rate when you apply for opportunities.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: pricing
+fields:
+  minimum_price: webOperationsPriceMin
+  maximum_price: webOperationsPriceMax
+field_defaults:
+  price_unit: Person
+  price_interval: Day
+
+validations:
+  - name: answer_required
+    field: webOperationsPriceMin
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: webOperationsPriceMin
+    message: "Minimum price must be a number, without units, eg 99.95"
+  - name: answer_required
+    field: webOperationsPriceMax
+    message: 'You need to answer this question.'
+  - name: not_money_format
+    field: webOperationsPriceMax
+    message: "Maximum price must be a number, without units, eg 99.95"
+  - name: max_less_than_min
+    field: webOperationsPriceMax
+    message: "Minimum price must be less than maximum price"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsLocations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsLocations.yml
@@ -1,0 +1,27 @@
+question: Where will your web operations engineer work?
+question_advice: Choose all the locations where the specialist can work at buyers’ sites, and whether they can work offsite.
+hint: >
+    ‘Offsite’ means the specialist will not be working at the buyer’s own sites. You can change where the specialist is available to work at any time during the framework.
+depends:
+  - "on": lot
+    being:
+      - digital-specialists
+type: checkboxes
+options:
+  - label: "Offsite"
+  - label: "Scotland"
+  - label: "North East England"
+  - label: "North West England"
+  - label: "Yorkshire and the Humber"
+  - label: "East Midlands"
+  - label: "West Midlands"
+  - label: "East of England"
+  - label: "Wales"
+  - label: "London"
+  - label: "South East England"
+  - label: "South West England"
+  - label: "Northern Ireland"
+
+validations:
+  - name: answer_required
+    message: 'You need to answer this question.'

--- a/frameworks/digital-outcomes-and-specialists-5/search_mappings/briefs.json
+++ b/frameworks/digital-outcomes-and-specialists-5/search_mappings/briefs.json
@@ -1,0 +1,224 @@
+{
+  "settings": {
+    "index": {
+      "max_result_window": 10000
+    },
+    "analysis": {
+      "analyzer": {
+        "stemming_analyzer": {
+          "tokenizer": "standard",
+          "filter": [
+            "standard",
+            "lowercase",
+            "possessive_english_stemmer",
+            "light_english_stemmer"
+          ]
+        }
+      },
+      "filter": {
+        "light_english_stemmer": {
+          "type": "stemmer",
+          "name": "light_english"
+        },
+        "possessive_english_stemmer": {
+          "type": "stemmer",
+          "name": "possessive_english"
+        }
+      },
+      "char_filter": {
+        "nonalpha_removal": {
+          "type": "pattern_replace",
+          "pattern": "\\W+",
+          "replacement": ""
+        }
+      },
+      "normalizer": {
+        "filter_normalizer": {
+          "type": "custom",
+          "char_filter": [
+            "nonalpha_removal"
+          ],
+          "filter": [
+            "lowercase"
+          ]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "briefs": {
+      "_meta": {
+        "dm_sort_clause": [
+          "sortonly_statusOrder",
+          {
+              "sortonly_publishedAt": "desc"
+          },
+          "sortonly_idHash"
+        ],
+        "transformations": [
+          {
+            "hash_to": {
+              "field": "id",
+              "target_field": "idHash"
+            }
+          },
+          {
+            "set_conditionally": {
+              "field": "status",
+              "target_field": "statusOpenClosed",
+              "any_of": [
+                "live"
+              ],
+              "set_value": "open"
+            }
+          },
+          {
+            "set_conditionally": {
+              "field": "status",
+              "target_field": "statusOpenClosed",
+              "any_of": [
+                "awarded",
+                "cancelled",
+                "closed",
+                "unsuccessful"
+              ],
+              "set_value": "closed"
+            }
+          },
+          {
+            "append_conditionally": {
+              "field": "status",
+              "target_field": "statusOrder",
+              "any_of": [
+                "live"
+              ],
+              "append_value": [
+                0
+              ]
+            }
+          },
+          {
+            "append_conditionally": {
+              "field": "status",
+              "target_field": "statusOrder",
+              "any_of": [
+                "closed",
+                "awarded",
+                "cancelled",
+                "unsuccessful"
+              ],
+              "append_value": [
+                1
+              ]
+            }
+          },
+          {
+            "append_conditionally": {
+              "field": "status",
+              "target_field": "statusOrder",
+              "any_of": [
+                "draft",
+                "withdrawn"
+              ],
+              "append_value": [
+                2
+              ]
+            }
+          }
+        ]
+      },
+      "dynamic": "strict",
+      "properties": {
+        "dmtext_id": {
+          "type": "keyword"
+        },
+        "sortonly_idHash": {
+          "type": "keyword"
+        },
+        "dmfilter_lot": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
+        },
+        "dmtext_lot": {
+          "type": "keyword"
+        },
+        "dmagg_lot": {
+          "type": "keyword"
+        },
+        "dmtext_withdrawnAt": {
+          "type": "keyword"
+        },
+        "dmtext_publishedAt": {
+          "type": "keyword"
+        },
+        "sortonly_publishedAt": {
+          "type": "date"
+        },
+        "dmtext_applicationsClosedAt": {
+          "type": "keyword"
+        },
+        "dmtext_clarificationQuestionsClosedAt": {
+          "type": "keyword"
+        },
+        "dmtext_cancelledAt": {
+          "type": "keyword"
+        },
+        "dmtext_unsuccessfulAt": {
+          "type": "keyword"
+        },
+        "dmtext_awardedBriefResponseId": {
+          "type": "keyword"
+        },
+        "dmtext_organisation": {
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_title": {
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_specialistRole": {
+          "type": "text"
+        },
+        "dmfilter_specialistRole": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
+        },
+        "dmtext_summary": {
+          "term_vector": "with_positions_offsets",
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_essentialRequirements": {
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_niceToHaveRequirements": {
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_status": {
+          "type": "keyword"
+        },
+        "dmfilter_status": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
+        },
+        "dmfilter_statusOpenClosed": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
+        },
+        "sortonly_statusOrder": {
+          "type": "byte"
+        },
+        "dmfilter_location": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
+        },
+        "dmtext_location": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.10.3",
+  "version": "17.11.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.10.3",
+  "version": "17.11.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schemas/metadata.json
+++ b/schemas/metadata.json
@@ -14,11 +14,21 @@
         "questions_to_copy": {
           "type": "array",
           "items": {"type": "string"}
+        },
+        "questions_to_exclude": {
+          "type": "array",
+          "items": {"type": "string"}
         }
       },
-      "required": [
-        "source_framework",
-        "questions_to_copy"
+      "oneOf": [
+        {"required": [
+            "source_framework",
+            "questions_to_copy"
+          ]},
+        {"required": [
+            "source_framework",
+            "questions_to_exclude"
+          ]}
       ],
       "additionalProperties": false
     },

--- a/tests/test_clone_latest_framework.py
+++ b/tests/test_clone_latest_framework.py
@@ -106,9 +106,9 @@ class TestUpdateCopyServicesMetadata:
             assert mock_open().write.call_args_list == [mock.call(x) for x in expected_yaml_dump_calls]
 
     def test_update_copy_services_metadata_clones_questions_if_matching_method(self):
-        cloner = FrameworkContentCloner('g-cloud', 13, 2020, question_copy_method='copy')
+        cloner = FrameworkContentCloner('g-cloud', 13, 2020, question_copy_method='exclude')
         mock_g12_copy_services_file = """
-            questions_to_copy:
+            questions_to_exclude:
               - question1
               - question2
             source_framework: "g-cloud-11"
@@ -121,7 +121,7 @@ class TestUpdateCopyServicesMetadata:
             ]
             # What yaml.dump() does under the hood...
             expected_yaml_dump_calls = [
-                'questions_to_copy', ':', '\n',
+                'questions_to_exclude', ':', '\n',
                 '-', ' ', 'question1', '\n',
                 '-', ' ', 'question2', '\n',
                 'source_framework', ':', ' ', 'g-cloud-12', '\n'

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,8 +5,8 @@ import yaml
 
 
 def test_copying_services_metadata():
-    """Make sure that every key listed under copy_services.questions_to_copy points to a valid
-    question file, id, or field and that the referenced historical framework exists."""
+    """Make sure that every key listed under copy_services.questions_to_copy or copy_services.questions_to_exclude
+    points to a valid question file, id, or field and that the referenced historical framework exists. """
     copying_services_filenames = glob.glob('frameworks/*/metadata/copy_services.yml')
     assert len(copying_services_filenames) > 0
     for copying_services_filename in copying_services_filenames:
@@ -30,8 +30,12 @@ def test_copying_services_metadata():
                         names_ids_fields.update([v for v in contents.get('fields').values()])
                     names_ids_fields.add(filename[:-4])
 
-            for question in copying_services_data['questions_to_copy']:
-                assert question in names_ids_fields
+            if 'questions_to_exclude' in copying_services_data:
+                for question in copying_services_data['questions_to_exclude']:
+                    assert question in names_ids_fields
+            else:
+                for question in copying_services_data['questions_to_copy']:
+                    assert question in names_ids_fields
 
 
 def test_g11_service_questions_to_scan_for_bad_words_metadata():


### PR DESCRIPTION
Trello: https://trello.com/c/tKvghe5l

- [x] Clone framework DOS 5 from DOS 4 using `clone-latest-framework.py`

- [x] Update tests to support the new field `questions_to_exclude` on `metadata`

- [ ] Confirm and update any service or declaration questions with Crown Commercial Services (CCS) and a GDS content designer before launch. It's advisable to keep any script-generated dates in the content to a far-future year (e.g. 1st March 2525) until they are confirmed with CCS.

- [ ] Add in new deadline dates, links to frameworks content and home page messages (the cloning script should have put in placeholders for these, currently 2525). This should be approved by a GDS content designer.

- [ ] Add service questions that shouldn't be copied between framework iterations (for example, because they have been  removed or changed significantly) to `questions_to_exclude` under `metadata/copy_services.yml`.

- [ ] Mark any significantly-changed declaration questions as `prefill: false` in ``manifests/declaration.yml``.

- [x] Update the version number in the `frameworks repository`_'s `package.json` file.

Co-Authored-By: @katstevens

Signed-off-by: Paula Valenca <paula.valenca@digital.cabinet-office.gov.uk>