### PR TITLE
Add DOS 5 validation schemata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.12.1",
+  "version": "17.13.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.12.1",
+  "version": "17.13.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -67,6 +67,11 @@ FRAMEWORKS_AND_LOTS = {
             'framework_name': "Digital Outcomes and Specialists 4",
             'lots': DOS_LOTS
         },
+        {
+            'framework_slug': 'digital-outcomes-and-specialists-5',
+            'framework_name': "Digital Outcomes and Specialists 5",
+            'lots': DOS_LOTS
+        },
     ]
 }
 

--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -42,9 +42,9 @@ FRAMEWORKS_AND_LOTS = {
         {'framework_slug': 'g-cloud-7', 'framework_name': "G-Cloud 7", 'lots': LEGACY_GCLOUD_LOTS},
         {'framework_slug': 'g-cloud-8', 'framework_name': "G-Cloud 8", 'lots': LEGACY_GCLOUD_LOTS},
         {'framework_slug': 'g-cloud-9', 'framework_name': "G-Cloud 9", 'lots': G_CLOUD_LOTS},
-        {'framework_slug': 'g-cloud-10', 'framework_name': "G-Cloud 9", 'lots': G_CLOUD_LOTS},
-        {'framework_slug': 'g-cloud-11', 'framework_name': "G-Cloud 9", 'lots': G_CLOUD_LOTS},
-        {'framework_slug': 'g-cloud-12', 'framework_name': "G-Cloud 9", 'lots': G_CLOUD_LOTS},
+        {'framework_slug': 'g-cloud-10', 'framework_name': "G-Cloud 10", 'lots': G_CLOUD_LOTS},
+        {'framework_slug': 'g-cloud-11', 'framework_name': "G-Cloud 11", 'lots': G_CLOUD_LOTS},
+        {'framework_slug': 'g-cloud-12', 'framework_name': "G-Cloud 12", 'lots': G_CLOUD_LOTS},
     ],
     "digital-outcomes-and-specialists": [
         {


### PR DESCRIPTION
Trello: https://trello.com/c/lwJW7PvN/288-2-create-dos5-service-schemas

Prepare for DOS 5. I have assumed the same lots as for DOS 4.

Output: https://github.com/alphagov/digitalmarketplace-api/pull/1055

Following the [proper procedure](https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/adding-frameworks.html#generate-service-validation-schemas-and-add-them-to-the-api) and [precedent](https://github.com/alphagov/digitalmarketplace-frameworks/pull/572)