### PR TITLE
Update logic for subcontracting questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,18 +169,10 @@ ES multi-fields are for, but unfortunately those don't turn out to be quite flex
 Development
 -----------
 
-A local checkout of the frameworks repo can be shared with locally-running services (i.e. frontend applications)
-as follows:
+A local checkout of the frameworks repo can be shared with locally-running services (i.e. frontend applications). There are two ways of doing this:
 
-- from this repo, run `npm link`
-- from each app, run `npm link digitalmarketplace-frameworks`
-
-Your frontend apps will then be using your local copy of the framework data rather than the version specified
-in their `package.json` - for example, whenever you:
-
- - rebuild the app's `content` directory by running `make frontend-build`; or
- - run `npm run frontend-build:watch` to automatically rebuild the framework content whenever a framework YML file
-   changes.
+1. From this repo, run `npm link`; from each app, run `npm link digitalmarketplace-frameworks`. You can then run `npm run frontend-build:watch` to automatically rebuild the framework content whenever a framework YML file changes. Restart the app in dmrunner to pick up changes.
+2. From each app, run `npm install ../digitalmarketplace-frameworks`. Then rebuild the app.
 
 Don't forget that you may also need to generate schemas into the API's `json_schema` directory using the
 `scripts/generate-validation-schemas.py` script in this repo, or similarly update the Search API using the

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
@@ -172,7 +172,7 @@
   description: |
     The Crown Commercial Service will use this information to manage your participation in Digital Outcomes and Specialists&nbsp;5.
   questions:
-    - subcontracting
+    - multiqSubcontracting
     - employmentStatus
     - outsideIR35
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/multiqSubcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/multiqSubcontracting.yml
@@ -1,0 +1,8 @@
+id: multiqSubcontracting
+name: Subcontractors or consortia
+question: ""
+type: multiquestion
+questions:
+  - subcontracting
+  - subcontracting30DayPayments
+  - subcontractingInvoicesPaid

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
@@ -8,6 +8,9 @@ options:
   - label: as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
 hint: Only include subcontractors whose products or services will be integral to the Digital Outcomes and Specialists&nbsp;5 services that you intend to provide.
 followup:
-  foo:
+  subcontracting30DayPayments:
+    - as a prime contractor, using third parties (subcontractors) to provide some services
+    - as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
+  subcontractingInvoicesPaid:
     - as a prime contractor, using third parties (subcontractors) to provide some services
     - as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
@@ -1,6 +1,6 @@
 name: Subcontractors or consortia
 question: "Please confirm whether you will provide Digital Outcomes and Specialists&nbsp;5 services:"
-type: checkboxes
+type: radios
 options:
   - label: yourself without the use of third parties (subcontractors)
   - label: as a prime contractor, using third parties (subcontractors) to provide some services

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
@@ -7,3 +7,7 @@ options:
   - label: as part of a consortium or special purpose vehicle, using members only to provide all services
   - label: as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
 hint: Only include subcontractors whose products or services will be integral to the Digital Outcomes and Specialists&nbsp;5 services that you intend to provide.
+followup:
+  foo:
+    - as a prime contractor, using third parties (subcontractors) to provide some services
+    - as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting.yml
@@ -4,7 +4,6 @@ type: checkboxes
 options:
   - label: yourself without the use of third parties (subcontractors)
   - label: as a prime contractor, using third parties (subcontractors) to provide some services
-  - label: as a prime contractor, using third parties (subcontractors) to provide all services
   - label: as part of a consortium or special purpose vehicle, using members only to provide all services
   - label: as part of a consortium or special purpose vehicle, using third parties (subcontractors) to provide some services
 hint: Only include subcontractors whose products or services will be integral to the Digital Outcomes and Specialists&nbsp;5 services that you intend to provide.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
@@ -1,0 +1,6 @@
+name: Subcontracting 30 day payment terms
+question: Can you confirm that for public sector contracts awarded under the Public Contract Regulations 2015 you have systems in place to include (as a minimum) 30-day payment terms in all of your supply chain contracts and require that such terms are passed down through your supply chain?
+
+hint: Contracts awarded under the Public Contracts Regulations 2015 must comply with Regulation 113 for prompt payment of all subcontractors (https://www.legislation.gov.uk/uksi/2015/102/regulation/113/made) (opens in new tab). The Crown Commercial Service reserves the right to audit any supplier for compliance, where an awarded contract has a value of £2 million or more a year.
+
+type: boolean

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
@@ -1,7 +1,7 @@
 name: Subcontracting 30 day payment terms
 question: Can you confirm that for public sector contracts awarded under the Public Contract Regulations 2015 you have systems in place to include (as a minimum) 30-day payment terms in all of your supply chain contracts and require that such terms are passed down through your supply chain?
 
-hint: Contracts awarded under the Public Contracts Regulations 2015 must comply with Regulation 113 for prompt payment of all subcontractors (https://www.legislation.gov.uk/uksi/2015/102/regulation/113/made) (opens in new tab). The Crown Commercial Service reserves the right to audit any supplier for compliance, where an awarded contract has a value of £2 million or more a year.
+hint: Contracts awarded under the Public Contracts Regulations 2015 must comply with <a href="https://www.legislation.gov.uk/uksi/2015/102/regulation/113/made" target="_blank" rel="noopener noreferrer">Regulation 113 for prompt payment of all subcontractors (opens in new tab)</a>. The Crown Commercial Service reserves the right to audit any supplier for compliance, where an awarded contract has a value of £2 million or more a year.
 
 type: boolean
 hidden: true

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
@@ -4,3 +4,8 @@ question: Can you confirm that for public sector contracts awarded under the Pub
 hint: Contracts awarded under the Public Contracts Regulations 2015 must comply with Regulation 113 for prompt payment of all subcontractors (https://www.legislation.gov.uk/uksi/2015/102/regulation/113/made) (opens in new tab). The Crown Commercial Service reserves the right to audit any supplier for compliance, where an awarded contract has a value of £2 million or more a year.
 
 type: boolean
+hidden: true
+
+validations:
+  - name: answer_required
+    message: You need to answer this question.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontractingInvoicesPaid.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontractingInvoicesPaid.yml
@@ -15,3 +15,5 @@ limits:
 validations:
   - name: answer_required
     message: You need to answer this question.
+  - name: not_a_number
+    message: Percentage of invoices paid must be a number between 0 and 100.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontractingInvoicesPaid.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontractingInvoicesPaid.yml
@@ -1,6 +1,8 @@
 name: Subcontracting invoices paid
 question: In the past 12 months, what percentage of invoices did you pay in 60 days to those in your immediate supply chain?
 
+hidden: true
+
 type: number
 unit: "%"
 unit_in_full: "percent"
@@ -9,3 +11,7 @@ limits:
   min_value: 0
   max_value: 100
   integer_only: true
+
+validations:
+  - name: answer_required
+    message: You need to answer this question.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontractingInvoicesPaid.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontractingInvoicesPaid.yml
@@ -1,0 +1,11 @@
+name: Subcontracting invoices paid
+question: In the past 12 months, what percentage of invoices did you pay in 60 days to those in your immediate supply chain?
+
+type: number
+unit: "%"
+unit_in_full: "percent"
+unit_position: "after"
+limits:
+  min_value: 0
+  max_value: 100
+  integer_only: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.13.1",
+  "version": "17.14.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.13.1",
+  "version": "17.14.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/Oqg9AUup/328-3-update-conditional-logic-for-declaration-question-q53-for-dos5

CCS wanted us to make some changes to this question for DOS 5. If a supplier says they use subcontractors, show them two additional questions.

We've manually checked that the questions seem to appear when expected.

Known issues outstanding (to solve in future PRs):
1. The number field isn't being validated
2. The grey bar next to the second condition question is over-long
3. We don't yet know what the pass condition is (if any) for the two new questions

![image](https://user-images.githubusercontent.com/15256121/93621094-fd84ab00-f9d2-11ea-800b-c492061f2d4f.png)