### PR TITLE
Pull latest version of content loader and utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.14.0",
+  "version": "17.15.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.14.0",
+  "version": "17.15.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 git+https://github.com/madzak/python-json-logger.git@v0.1.11#egg=python-json-logger==v0.1.11
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.1.0#egg=digitalmarketplace-utils==50.1.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.22.0#egg=digitalmarketplace-content-loader==7.22.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.10.0#egg=digitalmarketplace-utils==52.10.0

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,4 +1,5 @@
 import glob
+import re
 
 import mock
 import pytest
@@ -107,7 +108,8 @@ def test_render_question(framework, question_id, question_set, question):
 
 
 def strip_paragraph_wrapper(value):
-    if value.startswith('<p>'):
-        value = value[3:-4]
+    match = re.fullmatch(r"^(<p.*?>)(.+?)(</p>)", value)
+    if match:
+        return match.group(2)
 
     return value


### PR DESCRIPTION
Supplier frontend is already using v7.22.0, so it should be safe to update the frameworks repo as well.

Modify test to be able to strip out more complex paragraph tags.