### PR TITLE
Bump minor version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.15.0",
+  "version": "17.16.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.15.0",
+  "version": "17.16.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Trello: https://trello.com/c/yWkgqyPL/325-2-update-dos5-application-content-in-the-frameworks-repo

To allow us to release our changes to the declaration questions for DOS 5 (https://github.com/alphagov/digitalmarketplace-frameworks/pull/637)