### PR TITLE
Expand negative contractions in DOS5 content

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
@@ -19,7 +19,7 @@
     You must truthfully answer ‘yes’ to every question for your application to be considered eligible.
     The Crown Commercial Service may ask for proof after you’ve submitted your application.
 
-    If you can’t answer ‘yes’ to every question in this section, it’s very unlikely that your application will be accepted.
+    If you cannot answer ‘yes’ to every question in this section, it’s very unlikely that your application will be accepted.
 
   questions:
     - skillsAndResources
@@ -121,7 +121,7 @@
   description: |
     You must be able to truthfully answer ‘yes’ to every question on this page for your application to be considered eligible.
 
-    If you can’t answer ‘yes’ to every question in this section, it is unlikely your application will be accepted.
+    If you cannot answer ‘yes’ to every question in this section, it is unlikely your application will be accepted.
   questions:
     - environmentallyFriendly
     - equalityAndDiversity

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
@@ -65,7 +65,7 @@
     There are 3 stages to finding the supplier that best meets your needs.
 
     ##1\. View suppliers who applied
-    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who do not meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
@@ -102,7 +102,7 @@
     There are 3 stages to finding the specialist that best meets your needs.
 
     ##1\. View specialists who applied
-    When specialists apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Specialists who don’t meet your essential skills and experience are excluded.
+    When specialists apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Specialists who do not meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible specialists, you can exclude the specialists who:
@@ -135,7 +135,7 @@
     There are 3 stages to finding the supplier that best meets your needs.
 
     ##1\. View suppliers who applied
-    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+    When suppliers apply, they declare which of your essential and nice&#8209;to&#8209;have skills and experience they have. Suppliers who do not meet your essential skills and experience are excluded.
 
     ##2\. Create a shortlist
     Once you have a list of eligible suppliers, you can exclude the suppliers who:

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
@@ -71,7 +71,7 @@
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
 
     - have the least nice&#8209;to&#8209;have skills and experience
-    - can’t start when you need them to
+    - cannot start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many suppliers.
 
@@ -108,7 +108,7 @@
     Once you have a list of eligible specialists, you can exclude the specialists who:
 
     - have the least nice&#8209;to&#8209;have skills and experience
-    - can’t start when you need them to
+    - cannot start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many specialists.
 
@@ -141,7 +141,7 @@
     Once you have a list of eligible suppliers, you can exclude the suppliers who:
 
     - have the least nice&#8209;to&#8209;have skills and experience
-    - can’t start when you need them to
+    - cannot start when you need them to
 
     You may need to ask for evidence of skills and experience if you have too many suppliers.
 

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_submission.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_submission.yml
@@ -8,7 +8,7 @@
   editable: True
   description: >
     You must be able to truthfully answer ‘yes’ to every question  for your
-    bid to be considered eligible. If you can’t answer ‘yes’ to every question
+    bid to be considered eligible. If you cannot answer ‘yes’ to every question
     in this section, it’s very unlikely that your bid will be accepted.
   questions:
     - helpGovernmentImproveServices
@@ -21,7 +21,7 @@
   editable: True
   description: >
     You must be able to truthfully answer ‘yes’ to every question for your bid
-    to be considered eligible. If you can’t answer ‘yes’ to every question in
+    to be considered eligible. If you cannot answer ‘yes’ to every question in
     this section, it’s very unlikely that your bid will be accepted.
   questions:
     - anonymousRecruitment

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
@@ -17,6 +17,6 @@ validations:
     message: "Day rate must be in numbers and decimal points only, for example 99.95."
   - name: max_less_than_min
     field: dayRate
-    message: "This can't be more than the maximum day rate you've already provided."
+    message: "This cannot be more than the maximum day rate you've already provided."
 
 empty_message: Set rate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsParticipants.yml
@@ -9,7 +9,7 @@ question_advice: |
   The suppliers have already agreed that:
 
   - their prices must include all incentives, recruitment, and travel and subsistence costs paid to participants
-  - you don’t pay for participants who don’t attend on the day
+  - you do not pay for participants who do not attend on the day
   - they are responsible for paying participants directly
 optional: true
 type: textbox_large

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeSpecialists.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   You must have budget approval before you publish your requirements.
 
-  If you don’t provide a day rate, you won’t be able to exclude specialists that exceed your budget.
+  If you do not provide a day rate, you won’t be able to exclude specialists that exceed your budget.
 
   Suppliers will provide you with a day rate for the specialist.
 optional: true

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/budgetRangeSpecialists.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   You must have budget approval before you publish your requirements.
 
-  If you do not provide a day rate, you won’t be able to exclude specialists that exceed your budget.
+  If you do not provide a day rate, you will not be able to exclude specialists that exceed your budget.
 
   Suppliers will provide you with a day rate for the specialist.
 optional: true

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/contractLength.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/contractLength.yml
@@ -1,6 +1,6 @@
 name: Expected contract length
 question: Expected contract length
-question_advice: Contracts can’t last for more than 2 years.
+question_advice: Contracts cannot last for more than 2 years.
 type: text
 optional: true
 depends:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaOutcomes.yml
@@ -12,7 +12,7 @@ question_advice: |
   - how the supplier shares knowledge and experience
   - the supplier’s attitude to making mistakes
 
-  ##Cultural fit isn’t:
+  ##Cultural fit is not:
   - whether the supplier looks, talks or behaves in the same way as you
   - about having agile skills – that’s technical competence
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/culturalFitCriteriaSpecialists.yml
@@ -12,7 +12,7 @@ question_advice: |
   - how the specialist shares knowledge and experience
   - the specialist’s attitude to making mistakes
 
-  ##Cultural fit isn’t:
+  ##Cultural fit is not:
   - whether the specialist looks, talks or behaves in the same way as you
   - about having agile skills – that’s technical competence
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsOutcomes.yml
@@ -2,7 +2,7 @@ name: 'Essential skills and experience'
 id: essentialRequirements
 question: 'Essential skills and experience'
 question_advice: |
-  When suppliers apply they declare which of your essential skills and experience they have. Suppliers who don’t meet your essential skills and experience are excluded.
+  When suppliers apply they declare which of your essential skills and experience they have. Suppliers who do not meet your essential skills and experience are excluded.
 
   List all the specific skills or experience the supplier must have.
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsParticipants.yml
@@ -2,7 +2,7 @@ name: 'Essential skills and experience'
 id: essentialRequirements
 question: 'Essential skills and experience'
 question_advice: |
-  Suppliers who don’t have all the essential skills you list here will be automatically notified that their application was unsuccessful.
+  Suppliers who do not have all the essential skills you list here will be automatically notified that their application was unsuccessful.
 
   List all the specific skills or experience the supplier must have.
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/essentialRequirementsSpecialists.yml
@@ -2,7 +2,7 @@ name: 'Essential skills and experience'
 id: essentialRequirements
 question: 'Essential skills and experience'
 question_advice: |
-  Suppliers who don’t have all the essential skills you list here will be automatically notified that their application was unsuccessful.
+  Suppliers who do not have all the essential skills you list here will be automatically notified that their application was unsuccessful.
 
   List all the specific skills or experience the specialist must have.
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeOutcomes.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   Choose additional ways to assess suppliers.
 
-  You can only use the methods you choose here, so if you don’t select a case study now, you won’t be able to ask for one later.
+  You can only use the methods you choose here, so if you do not select a case study now, you won’t be able to ask for one later.
 
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeOutcomes.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   Choose additional ways to assess suppliers.
 
-  You can only use the methods you choose here, so if you do not select a case study now, you won’t be able to ask for one later.
+  You can only use the methods you choose here, so if you do not select a case study now, you will not be able to ask for one later.
 
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeParticipants.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   Choose additional ways to assess suppliers.
 
-  You can only use the methods you choose here, so if you do not select a reference now, you won’t be able to ask for one later.
+  You can only use the methods you choose here, so if you do not select a reference now, you will not be able to ask for one later.
 
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeParticipants.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   Choose additional ways to assess suppliers.
 
-  You can only use the methods you choose here, so if you don’t select a reference now, you won’t be able to ask for one later.
+  You can only use the methods you choose here, so if you do not select a reference now, you won’t be able to ask for one later.
 
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeSpecialists.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   Choose additional ways to assess specialists.
 
-  You can only use the methods you choose here, so if you don’t select an interview, you won’t be able to interview specialists.
+  You can only use the methods you choose here, so if you do not select an interview, you won’t be able to interview specialists.
 
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/evaluationTypeSpecialists.yml
@@ -6,7 +6,7 @@ question_advice: |
 
   Choose additional ways to assess specialists.
 
-  You can only use the methods you choose here, so if you do not select an interview, you won’t be able to interview specialists.
+  You can only use the methods you choose here, so if you do not select an interview, you will not be able to interview specialists.
 
   Read about [assessment methods](https://www.gov.uk/guidance/ways-to-assess-digital-outcomes-and-specialists-suppliers).
 type: checkboxes

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/outcome.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/outcome.yml
@@ -1,7 +1,7 @@
 name: Problem to be solved
 question: Problem to be solved
 question_advice: >
-  For example: patients can’t access their medical records
+  For example: patients cannot access their medical records
 type: textbox_large
 max_length_in_words: 200
 depends:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/phase.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/phase.yml
@@ -33,7 +33,7 @@ options:
     label: Live
     value: live
     description: >
-      The work doesn’t stop once your service is live. You’ll be iteratively improving your service,
+      The work does not stop once your service is live. You’ll be iteratively improving your service,
       reacting to new needs and demands, and meeting targets set during its development.
 depends:
   - "on": "lot"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchDates.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/researchDates.yml
@@ -1,6 +1,6 @@
 name: Research dates
 question: Research dates
-question_advice: If you don’t have exact dates, say when you expect research to start and end.
+question_advice: If you do not have exact dates, say when you expect research to start and end.
 type: text
 depends:
   - "on": "lot"

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/securityClearance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/securityClearance.yml
@@ -3,7 +3,7 @@ question: Security clearance
 question_advice: |
   Describe any security clearance the individual or team must have when they start work.
 
-  You shouldn’t exclude suppliers if they don’t currently have the security clearance you need.
+  You shouldn’t exclude suppliers if they do not currently have the security clearance you need.
 
   You may need to organise security clearance.
 type: textbox_large

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/securityClearance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/securityClearance.yml
@@ -3,7 +3,7 @@ question: Security clearance
 question_advice: |
   Describe any security clearance the individual or team must have when they start work.
 
-  You shouldn’t exclude suppliers if they do not currently have the security clearance you need.
+  You should not exclude suppliers if they do not currently have the security clearance you need.
 
   You may need to organise security clearance.
 type: textbox_large

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/startDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/startDate.yml
@@ -1,7 +1,7 @@
 name: Latest start date
 question: Latest start date
 question_advice: |
-  Say when you need suppliers to start work. When you shortlist, you can exclude suppliers who can’t start by this date.
+  Say when you need suppliers to start work. When you shortlist, you can exclude suppliers who cannot start by this date.
 hint: 'For example, 31 5 2020'
 type: date
 depends:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatementOptional.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatementOptional.yml
@@ -1,6 +1,6 @@
 name: Modern slavery statement optional
 question: |
-  You don’t need to publish a slavery and human trafficking statement to meet the modern slavery requirements for Digital Outcomes and Specialists&nbsp;5.
+  You do not need to publish a slavery and human trafficking statement to meet the modern slavery requirements for Digital Outcomes and Specialists&nbsp;5.
 
   You can choose to upload a statement.
 question_advice: |

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardPersonalData.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardPersonalData.yml
@@ -2,7 +2,7 @@ name: Safeguarding personal data
 question: >
   Do you agree to protect personal data according to the government guidance on <a href="https://www.gov.uk/data-protection-your-business" target="_blank" rel="noopener noreferrer">data protection and your business (opens in new tab)</a>?
 type: boolean
-hint: If you provide access to user research studios, for example, please confirm that you don’t share research videos with third parties.
+hint: If you provide access to user research studios, for example, please confirm that you do not share research videos with third parties.
 assessment:
   passIfIn:
     - True

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoach.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoach.yml
@@ -11,6 +11,6 @@ questions:
   - agileCoachLocations
   - agileCoachDayRate
 
-empty_message: You haven’t added an agile coach
+empty_message: You have not added an agile coach
 
 hint: Help individuals, teams and managers be as effective as possible by embedding an agile culture.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoachDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/agileCoachDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for an agile coach (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalyst.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalyst.yml
@@ -11,6 +11,6 @@ questions:
   - businessAnalystLocations
   - businessAnalystDayRate
 
-empty_message: You haven’t added a business analyst
+empty_message: You have not added a business analyst
 
 hint: Analyse a service or organisation’s business processes and systems. Specify, collect and present findings.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalystDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/businessAnalystDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a business analyst (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManager.yml
@@ -11,6 +11,6 @@ questions:
   - communicationsManagerLocations
   - communicationsManagerDayRate
 
-empty_message: You haven’t added a communications manager
+empty_message: You have not added a communications manager
 
 hint: Develop user-focused messages, measurement techniques and communication approaches. Establish integrated communication plans across a range of digital channels to ensure that communication is ongoing, open and clear.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/communicationsManagerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a communications manager (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesigner.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesigner.yml
@@ -11,6 +11,6 @@ questions:
   - contentDesignerLocations
   - contentDesignerDayRate
 
-empty_message: You haven’t added a content designer
+empty_message: You have not added a content designer
 
 hint: Ensure content is as clear and simple as possible to meet user needs.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/contentDesignerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a content designer (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitect.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitect.yml
@@ -11,6 +11,6 @@ questions:
   - dataArchitectLocations
   - dataArchitectDayRate
 
-empty_message: You haven’t added a data architect
+empty_message: You have not added a data architect
 
 hint: Set the vision for the organisation’s use of data, through data design, to meet business needs.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitectDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataArchitectDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a data architect (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineer.yml
@@ -11,6 +11,6 @@ questions:
   - dataEngineerLocations
   - dataEngineerDayRate
 
-empty_message: You haven’t added a data engineer
+empty_message: You have not added a data engineer
 
 hint: Design, build, test and maintain data management systems, making sure they meet business requirements and user needs.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataEngineerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a data engineer (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientist.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientist.yml
@@ -11,6 +11,6 @@ questions:
   - dataScientistLocations
   - dataScientistDayRate
 
-empty_message: You haven’t added a data scientist
+empty_message: You have not added a data scientist
 
 hint: Identify complex business problems while working with policy and operations teams to understand where data can add value.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientistDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/dataScientistDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a data scientist (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/delivery.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/delivery.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - deliveryTypes
 
-empty_message: You haven’t added any service delivery capabilities
+empty_message: You have not added any service delivery capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManager.yml
@@ -11,6 +11,6 @@ questions:
   - deliveryManagerLocations
   - deliveryManagerDayRate
 
-empty_message: You haven’t added a delivery manager
+empty_message: You have not added a delivery manager
 
 hint: Set up a team for successful delivery. Remove obstacles, track progress, facilitate meetings and help the team organise itself.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/deliveryManagerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a delivery manager (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/designer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/designer.yml
@@ -11,6 +11,6 @@ questions:
   - designerLocations
   - designerDayRate
 
-empty_message: You haven’t added a designer
+empty_message: You have not added a designer
 
 hint: Provide user-centred interaction design, service design and graphic design expertise.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/designerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/designerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a designer (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/developer.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/developer.yml
@@ -11,6 +11,6 @@ questions:
   - developerLocations
   - developerDayRate
 
-empty_message: You haven’t added a developer
+empty_message: You have not added a developer
 
 hint: Build software that supports user needs. Continually improve the service by identifying new tools and techniques, removing technical bottlenecks, and adapting and maintaining code.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/developerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/developerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a developer (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalysis.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalysis.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - performanceAnalysisTypes
 
-empty_message: You haven’t added any performance analysis and data capabilities
+empty_message: You have not added any performance analysis and data capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalyst.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalyst.yml
@@ -11,6 +11,6 @@ questions:
   - performanceAnalystLocations
   - performanceAnalystDayRate
 
-empty_message: You haven’t added a performance analyst
+empty_message: You have not added a performance analyst
 
 hint: Specify, collect and present the key performance data and analysis for a service.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalystDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/performanceAnalystDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a performance analyst (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManager.yml
@@ -11,6 +11,6 @@ questions:
   - portfolioManagerLocations
   - portfolioManagerDayRate
 
-empty_message: You haven’t added a portfolio manager
+empty_message: You have not added a portfolio manager
 
 hint: Lead a digital portfolio of projects and programmes.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/portfolioManagerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a portfolio manager (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/productManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/productManager.yml
@@ -11,6 +11,6 @@ questions:
   - productManagerLocations
   - productManagerDayRate
 
-empty_message: You haven’t added a product manager
+empty_message: You have not added a product manager
 
 hint: Lead the delivery and continuous improvement of one or more digital products or platforms.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/productManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/productManagerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a product manager (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManager.yml
@@ -11,6 +11,6 @@ questions:
   - programmeManagerLocations
   - programmeManagerDayRate
 
-empty_message: You haven’t added a programme manager
+empty_message: You have not added a programme manager
 
 hint: Manage and organise groups of related projects so they work together to achieve a strategic objective.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/programmeManagerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a programme manager (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssurance.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssurance.yml
@@ -11,6 +11,6 @@ questions:
   - qualityAssuranceLocations
   - qualityAssuranceDayRate
 
-empty_message: You haven’t added a quality assurance analyst
+empty_message: You have not added a quality assurance analyst
 
 hint: Ensure the quality of the digital service by testing it manually and writing automated tests covering a range of conditions.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/qualityAssuranceDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a quality assurance analyst (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/security.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/security.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - securityTypes
 
-empty_message: You haven’t added any security capabilities
+empty_message: You have not added any security capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultant.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultant.yml
@@ -11,6 +11,6 @@ questions:
   - securityConsultantLocations
   - securityConsultantDayRate
 
-empty_message: You haven’t added a cyber security consultant
+empty_message: You have not added a cyber security consultant
 
 hint: Minimise the chance of data or information systems security breaches. Ensure information is protected against unauthorised or unintended access. Put systems in place to prevent data destruction or disruption.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultantDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/securityConsultantDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a cyber security consultant (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManager.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManager.yml
@@ -11,6 +11,6 @@ questions:
   - serviceManagerLocations
   - serviceManagerDayRate
 
-empty_message: You haven’t added a service manager
+empty_message: You have not added a service manager
 
 hint: Develop and deliver an effective user-focused digital service. Manage the full product lifecycle, including user research, design, delivery and continuous improvement.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/serviceManagerDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a service manager (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/softwareDevelopment.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/softwareDevelopment.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - softwareDevelopmentTypes
 
-empty_message: You haven’t added any software development capabilities
+empty_message: You have not added any software development capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/supportAndOperations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/supportAndOperations.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - supportAndOperationsTypes
 
-empty_message: You haven’t added any support and operations capabilities
+empty_message: You have not added any support and operations capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitect.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitect.yml
@@ -11,6 +11,6 @@ questions:
   - technicalArchitectLocations
   - technicalArchitectDayRate
 
-empty_message: You haven’t added a technical architect
+empty_message: You have not added a technical architect
 
 hint: Break down complex problems and identify steps towards solutions. Coach individuals and engage with non-technical people at all levels of seniority. Write code as a senior member of the development team.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/technicalArchitectDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a technical architect (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/testingAndAuditing.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/testingAndAuditing.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - testingAndAuditingTypes
 
-empty_message: You haven’t added any testing and auditing capabilities
+empty_message: You have not added any testing and auditing capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userExperienceAndDesign.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userExperienceAndDesign.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - userExperienceAndDesignTypes
 
-empty_message: You haven’t added any user experience and design capabilities
+empty_message: You have not added any user experience and design capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearch.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearch.yml
@@ -10,4 +10,4 @@ any_of: capability
 questions:
   - userResearchTypes
 
-empty_message: You haven’t added any user research capabilities
+empty_message: You have not added any user research capabilities

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcher.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcher.yml
@@ -11,6 +11,6 @@ questions:
   - userResearcherLocations
   - userResearcherDayRate
 
-empty_message: You haven’t added a user researcher
+empty_message: You have not added a user researcher
 
 hint: Design, conduct and analyse user research using a range of techniques, eg one-to-one interviews or usability tests.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcherDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/userResearcherDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a user researcher (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperations.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperations.yml
@@ -11,6 +11,6 @@ questions:
   - webOperationsLocations
   - webOperationsDayRate
 
-empty_message: You haven’t added a web operations engineer
+empty_message: You have not added a web operations engineer
 
 hint: Run the production systems to help the development team build software that is easy to operate, scale and secure.

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsDayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/webOperationsDayRate.yml
@@ -1,5 +1,5 @@
 question: What is the maximum you charge a day for a web operations engineer (excluding VAT and expenses)?
-question_advice: The maximum price will be fixed for the duration of the framework agreement. You won’t be able to charge a higher rate when you apply for opportunities.
+question_advice: The maximum price will be fixed for the duration of the framework agreement. You will not be able to charge a higher rate when you apply for opportunities.
 depends:
   - "on": lot
     being:


### PR DESCRIPTION
Negative contractions (words ending in -n't) are not considered GDS style, so we should remove them.

- haven't -> have not
- shouldn't -> should not
- isn't -> is not
- won't -> will not
- don't -> do not
- doesn't -> does not
- can't -> cannot