### PR TITLE
Change labPrice in DOS5 into two questions

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service.yml
@@ -112,6 +112,7 @@
 - name: Price
   editable: False
   questions:
+    - labTime
     - labPrice
 
 - name: Recruitment approach

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service_as_admin.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_service_as_admin.yml
@@ -113,6 +113,7 @@
 - name: Price
   editable: True
   questions:
+    - labTime
     - labPrice
 
 - name: Recruitment approach

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_submission.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_submission.yml
@@ -131,6 +131,7 @@
 - name: Price
   editable: True
   questions:
+    - labTime
     - labPrice
 
 - name: Recruitment approach

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labPrice.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labPrice.yml
@@ -1,4 +1,4 @@
-question: What is the minimum amount of time your lab can be booked for and how much does it cost (excluding VAT)?
+question: How much does it cost (excluding VAT) for the minimum booking time?
 
 depends:
   - "on": lot
@@ -7,15 +7,11 @@ depends:
 
 type: pricing
 fields:
-  hours_for_price: labTimeMin
   minimum_price: labPriceMin
 field_defaults:
   price_unit: Lab
 
 validations:
-  - name: answer_required
-    field: labTimeMin
-    message: 'Enter the minimum amount of time that your lab is available.'
   - name: answer_required
     field: labPriceMin
     message: 'Enter the cost of using your lab.'

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/labTime.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/labTime.yml
@@ -1,0 +1,23 @@
+id: labTimeMin
+question: What is the minimum amount of time your lab can be booked for?
+
+depends:
+  - "on": lot
+    being:
+      - user-research-studios
+
+type: radios
+options:
+  - label: 1 hour
+  - label: 2 hours
+  - label: 3 hours
+  - label: 4 hours
+  - label: 5 hours
+  - label: 6 hours
+  - label: 7 hours
+  - label: 8 hours
+
+validations:
+  - name: answer_required
+    field: labTimeMin
+    message: 'Enter the minimum amount of time that your lab is available.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.1",
+  "version": "17.17.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.1",
+  "version": "17.17.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Ticket: https://trello.com/c/7dN6Hpva/290-2-add-hoursforprice-field-to-pricing-input-component-in-supplier-frontend

See also this change https://docs.google.com/spreadsheets/d/1FNGwe56myW2ddO6XQUtex209TJQ2Ub99PTzcWxpejsQ/edit#gid=866429329&range=D109

`hours_for_price` for the pricing input doesn't work with the new pricing field from alphagov/digitalmarketplace-supplier-frontend#1222, so we instead make it two questions.

### Screenshot

![Screenshot of user research studios price section](https://user-images.githubusercontent.com/503614/95209818-aceabb80-07e2-11eb-9ed5-5777034e21a9.png)
