### PR TITLE
Add GOV.UK Design System styles to HTML elements in DOS5 content

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/declaration.yml
@@ -4,7 +4,7 @@
   editable: True
   prefill: False
   description: |
-      You can read about how to apply in the <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#how-to-apply" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists suppliers’ guide (opens in new tab)</a>.
+      You can read about how to apply in the <a class="govuk-link" href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#how-to-apply" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists suppliers’ guide (opens in new tab)</a>.
   questions:
     - readUnderstoodGuidance
 
@@ -58,7 +58,7 @@
     The term ‘anyone who represents, supervises or has control in your organisation (or partner or parent organisation)’
     includes members of your group of economic operators, their proposed subcontractors, and any directors, partners, or
     any other person who has powers of representation, decision or control. Check that your organisation complies with
-    <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/57/made" target="_blank">Regulation 57(1) of the
+    <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/57/made" target="_blank">Regulation 57(1) of the
     Public Contracts Regulations 2015 (opens in new tab)</a>.
   questions:
     - conspiracy
@@ -81,13 +81,13 @@
     you provide to consider whether or not you will be able to proceed any further with this procurement.
 
     CCS can also exclude you if you are guilty of serious misrepresentation in providing any information referred to in
-    the <a href="http://www.legislation.gov.uk/uksi/2015/102/contents/made" target="_blank" rel="noopener noreferrer">Public Contracts Regulations 2015 (opens in new tab)</a>:
+    the <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/contents/made" target="_blank" rel="noopener noreferrer">Public Contracts Regulations 2015 (opens in new tab)</a>:
 
-      - <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/23/made" target="_blank" rel="noopener noreferrer">section 23 (opens in new tab)</a>
-      - <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/24/made" target="_blank" rel="noopener noreferrer">section 24 (opens in new tab)</a>
-      - <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/25/made" target="_blank" rel="noopener noreferrer">section 25 (opens in new tab)</a>
-      - <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/26/made" target="_blank" rel="noopener noreferrer">section 26 (opens in new tab)</a>
-      - <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/27/made" target="_blank" rel="noopener noreferrer">section 27 (opens in new tab)</a>
+      - <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/23/made" target="_blank" rel="noopener noreferrer">section 23 (opens in new tab)</a>
+      - <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/24/made" target="_blank" rel="noopener noreferrer">section 24 (opens in new tab)</a>
+      - <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/25/made" target="_blank" rel="noopener noreferrer">section 25 (opens in new tab)</a>
+      - <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/26/made" target="_blank" rel="noopener noreferrer">section 26 (opens in new tab)</a>
+      - <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/27/made" target="_blank" rel="noopener noreferrer">section 27 (opens in new tab)</a>
 
     CCS can also exclude you if you fail to provide any such information it requests.
 

--- a/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
@@ -1,38 +1,32 @@
 coming: |
-  <div class="explanation-list">
-    Digital Outcomes and Specialists is opening for applications.<br />
-    You will be able to apply to sell:
-    <ul class="list-bullet">
-      <li>digital outcomes, for example a team to build a service</li>
-      <li>digital specialists, for example an individual developer or user researcher</li>
-      <li>user research studios</li>
-      <li>user research participants</li>
-    </ul>
-  </div>
+  Digital Outcomes and Specialists is opening for applications.
+
+  You will be able to apply to sell:
+
+  - digital outcomes, for example a team to build a service
+  - digital specialists, for example an individual developer or user researcher
+  - user research studios
+  - user research participants
 
 open: |
-  <div class="explanation-list">
-    Digital Outcomes and Specialists is open for applications.<br />
-    You can apply to sell:
-    <ul class="list-bullet">
-      <li>digital outcomes, for example a team to build a service</li>
-      <li>digital specialists, for example an individual developer or user researcher</li>
-      <li>user research studios</li>
-      <li>user research participants</li>
-    </ul>
-  </div>
+  Digital Outcomes and Specialists is open for applications.
+
+  You can apply to sell:
+
+  - digital outcomes, for example a team to build a service
+  - digital specialists, for example an individual developer or user researcher
+  - user research studios
+  - user research participants
 
 pending: &can_not_apply |
-  <div class="explanation-list">
-    Digital Outcomes and Specialists is closed for applications.<br />
-    You will be able to apply to sell:
-    <ul class="list-bullet">
-      <li>digital outcomes, for example a team to build a service</li>
-      <li>digital specialists, for example an individual developer or user researcher</li>
-      <li>user research studios</li>
-      <li>user research participants</li>
-    </ul>
-  </div>
+  Digital Outcomes and Specialists is closed for applications.
+
+  You will be able to apply to sell:
+
+  - digital outcomes, for example a team to build a service
+  - digital specialists, for example an individual developer or user researcher
+  - user research studios
+  - user research participants
 
 standstill: *can_not_apply
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/MI.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/MI.yml
@@ -1,7 +1,7 @@
 name: Providing management information (MI)
 question: >
   Do you confirm that you’re prepared to provide all the monthly Digital Outcomes and Specialists&nbsp;5-related management information (MI)
-  to the Crown Commercial Service as outlined in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-5#reporting" target="_blank" rel="noopener noreferrer">reporting template (opens in new tab)</a>?
+  to the Crown Commercial Service as outlined in the <a class="govuk-link" href="/suppliers/frameworks/digital-outcomes-and-specialists-5#reporting" target="_blank" rel="noopener noreferrer">reporting template (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/civilServiceValues.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/civilServiceValues.yml
@@ -1,6 +1,6 @@
 name: Civil Service values
 question: >
-  Do you agree to support the <a href="https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code" target="_blank" rel="noopener noreferrer">Civil Service values (opens in new tab)</a> and if asked, provide evidence of how you do so?
+  Do you agree to support the <a class="govuk-link" href="https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code" target="_blank" rel="noopener noreferrer">Civil Service values (opens in new tab)</a> and if asked, provide evidence of how you do so?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/conflictOfInterest.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/conflictOfInterest.yml
@@ -1,6 +1,6 @@
 name: Conflict of interest
 question: >
-  In the last 3 years, has your organisation (or any partner organisation) had a conflict of interest as defined in <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/24/made" target="_blank" rel="noopener noreferrer">Regulation 24 of the Public Contracts Regulations 2015 (opens in new tab)</a>?
+  In the last 3 years, has your organisation (or any partner organisation) had a conflict of interest as defined in <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/24/made" target="_blank" rel="noopener noreferrer">Regulation 24 of the Public Contracts Regulations 2015 (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/distortedCompetition.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/distortedCompetition.yml
@@ -2,7 +2,7 @@ name: Unfair prior involvement in the procurement process
 question: >
   In the last 3 years, has your organisation (or any partner organisation) distorted competition through prior
   involvement in the procurement procedure as described in
-  <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/41/made" target="_blank" rel="noopener noreferrer">Regulation 41 of the Public Contracts Regulations 2015 (opens in new tab)</a>?
+  <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/41/made" target="_blank" rel="noopener noreferrer">Regulation 41 of the Public Contracts Regulations 2015 (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/environmentalSocialLabourLaw.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/environmentalSocialLabourLaw.yml
@@ -1,6 +1,6 @@
 name: Violations of environmental, social or labour law
 question: >
-  In the last 3 years, has your organisation (or a parent or partner organisation) violated your obilgations according to <a href="http://www.legislation.gov.uk/uksi/2015/102/part/2/chapter/2/crossheading/conduct-of-the-procedure-choice-of-participants-and-award-of-contracts/made" target="_blank" rel="noopener noreferrer">Regulation 56(2) of the Public Contracts Regulations 2015 (opens in new tab)</a> in any of these areas:
+  In the last 3 years, has your organisation (or a parent or partner organisation) violated your obilgations according to <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/part/2/chapter/2/crossheading/conduct-of-the-procedure-choice-of-participants-and-award-of-contracts/made" target="_blank" rel="noopener noreferrer">Regulation 56(2) of the Public Contracts Regulations 2015 (opens in new tab)</a> in any of these areas:
 
     - environmental law
     - social law
@@ -9,7 +9,7 @@ question: >
 hint:
   For example, if any finding of unlawful discrimination has been made against the organisation by an Employment Tribunal or Employment Appeal Tribunal.
   
-  Read more about <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/551130/List_of_Mandatory_and_Discretionary_Exclusions.pdf" target="_blank" rel="noopener noreferrer">your obligations in the field of environment, social and labour law (opens in new tab)</a>
+  Read more about <a class="govuk-link" href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/551130/List_of_Mandatory_and_Discretionary_Exclusions.pdf" target="_blank" rel="noopener noreferrer">your obligations in the field of environment, social and labour law (opens in new tab)</a>
 
 type: boolean
 assessment:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/helpBuyersComplyTechnologyCodesOfPractice.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/helpBuyersComplyTechnologyCodesOfPractice.yml
@@ -1,6 +1,6 @@
 name: Technology Code of Practice
 question: >
-  Do you agree to help the government work in ways which are consistent with the <a href="https://www.gov.uk/service-manual/technology/code-of-practice.html" target="_blank" rel="noopener noreferrer">Technology Code of Practice (opens in new tab)</a>?
+  Do you agree to help the government work in ways which are consistent with the <a class="govuk-link" href="https://www.gov.uk/service-manual/technology/code-of-practice.html" target="_blank" rel="noopener noreferrer">Technology Code of Practice (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatement.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatement.yml
@@ -7,9 +7,9 @@ question_advice: |
   - have a maximum file size of 5MB
   - meet accessibility standards
 hint: |
-  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs" target="_blank" rel="noopener noreferrer">Read the guidance on accessible documents (opens in new tab)</a>.
+  <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs" target="_blank" rel="noopener noreferrer">Read the guidance on accessible documents (opens in new tab)</a>.
 
-  <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">Read the Home Office guidance about how to write a statement and what information to include (opens in new tab)</a>.
+  <a class="govuk-link" href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">Read the Home Office guidance about how to write a statement and what information to include (opens in new tab)</a>.
 
 hidden: true
 type: upload

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatementOptional.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatementOptional.yml
@@ -10,9 +10,9 @@ question_advice: |
   - have a maximum file size of 5MB
   - meet accessibility standards
 hint: |
-  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs" target="_blank" rel="noopener noreferrer">Read the guidance on accessible documents (opens in new tab)</a>.
+  <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs" target="_blank" rel="noopener noreferrer">Read the guidance on accessible documents (opens in new tab)</a>.
 
-  <a href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">Read the Home Office guidance about how to write a statement and what information to include (opens in new tab)</a>.
+  <a class="govuk-link" href="https://www.gov.uk/government/publications/transparency-in-supply-chains-a-practical-guide" target="_blank" rel="noopener noreferrer">Read the Home Office guidance about how to write a statement and what information to include (opens in new tab)</a>.
 
 hidden: true
 type: upload

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/publishContracts.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/publishContracts.yml
@@ -1,6 +1,6 @@
 name: Publishing contracts
 question: >
-  Are you prepared to <a href="https://www.gov.uk/government/publications/procurement-policy-note-0117-update-to-transparency-principles" target="_blank" rel="noopener noreferrer">publish contracts according to government policy (opens in new tab)</a>?
+  Are you prepared to <a class="govuk-link" href="https://www.gov.uk/government/publications/procurement-policy-note-0117-update-to-transparency-principles" target="_blank" rel="noopener noreferrer">publish contracts according to government policy (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardOfficialInformation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardOfficialInformation.yml
@@ -1,6 +1,6 @@
 name: Safeguarding official information
 question: >
-  Do you agree to respect <a href="https://www.gov.uk/government/publications/government-security-classifications" target="_blank" rel="noopener noreferrer">government security classifications (opens in new tab)</a>
+  Do you agree to respect <a class="govuk-link" href="https://www.gov.uk/government/publications/government-security-classifications" target="_blank" rel="noopener noreferrer">government security classifications (opens in new tab)</a>
   and protect official government information, for example by not revealing that government is the client when advertising for participants?
 type: boolean
 assessment:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardPersonalData.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/safeguardPersonalData.yml
@@ -1,6 +1,6 @@
 name: Safeguarding personal data
 question: >
-  Do you agree to protect personal data according to the government guidance on <a href="https://www.gov.uk/data-protection-your-business" target="_blank" rel="noopener noreferrer">data protection and your business (opens in new tab)</a>?
+  Do you agree to protect personal data according to the government guidance on <a class="govuk-link" href="https://www.gov.uk/data-protection-your-business" target="_blank" rel="noopener noreferrer">data protection and your business (opens in new tab)</a>?
 type: boolean
 hint: If you provide access to user research studios, for example, can you confirm that you do not share research videos with third parties.
 assessment:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/serviceStandard.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/serviceStandard.yml
@@ -1,7 +1,7 @@
 name: Digital Service Standard
 question: >
-  Are you aware of, and will you comply with, the <a href="https://www.gov.uk/service-manual/service-standard" target="_blank" rel="noopener noreferrer">Digital Service Standard (opens in new tab)</a>
-  and the government’s latest <a href="https://www.gov.uk/design-principles" target="_blank" rel="noopener noreferrer">service design principles (opens in new tab)</a>?
+  Are you aware of, and will you comply with, the <a class="govuk-link" href="https://www.gov.uk/service-manual/service-standard" target="_blank" rel="noopener noreferrer">Digital Service Standard (opens in new tab)</a>
+  and the government’s latest <a class="govuk-link" href="https://www.gov.uk/design-principles" target="_blank" rel="noopener noreferrer">service design principles (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/subcontracting30DayPayments.yml
@@ -1,7 +1,7 @@
 name: Subcontracting 30 day payment terms
 question: Can you confirm that for public sector contracts awarded under the Public Contract Regulations 2015 you have systems in place to include (as a minimum) 30-day payment terms in all of your supply chain contracts and require that such terms are passed down through your supply chain?
 
-hint: Contracts awarded under the Public Contracts Regulations 2015 must comply with <a href="https://www.legislation.gov.uk/uksi/2015/102/regulation/113/made" target="_blank" rel="noopener noreferrer">Regulation 113 for prompt payment of all subcontractors (opens in new tab)</a>. The Crown Commercial Service reserves the right to audit any supplier for compliance, where an awarded contract has a value of £2 million or more a year.
+hint: Contracts awarded under the Public Contracts Regulations 2015 must comply with <a class="govuk-link" href="https://www.legislation.gov.uk/uksi/2015/102/regulation/113/made" target="_blank" rel="noopener noreferrer">Regulation 113 for prompt payment of all subcontractors (opens in new tab)</a>. The Crown Commercial Service reserves the right to audit any supplier for compliance, where an awarded contract has a value of £2 million or more a year.
 
 type: boolean
 hidden: true

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/taxEvasion.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/taxEvasion.yml
@@ -3,7 +3,7 @@ question: Have any members of your organisation or a partner organisation been l
 type: boolean
 hint: >
   ‘Legally found’ means any judicial or administrative decision, which has final or binding effect. Check that your organisation complies with 
-  <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/57/made" target="_blank" rel="noopener noreferrer">Regulation 57(3) of the Public Contracts Regulations 2015 (opens in new tab)</a>.
+  <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/57/made" target="_blank" rel="noopener noreferrer">Regulation 57(3) of the Public Contracts Regulations 2015 (opens in new tab)</a>.
 assessment:
   passIfIn:
     - False

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsAndConditions.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsAndConditions.yml
@@ -1,6 +1,6 @@
 name: Terms and conditions
 question: >
-  Do you accept the terms and conditions in the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-5#legal-documents" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (opens in new tab)</a>?
+  Do you accept the terms and conditions in the <a class="govuk-link" href="/suppliers/frameworks/digital-outcomes-and-specialists-5#legal-documents" target="_blank" rel="noopener noreferrer">framework agreement and call-off contract documents (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsOfParticipation.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/termsOfParticipation.yml
@@ -1,6 +1,6 @@
 name: Invitation to apply
 question: >
-  Do you agree to comply with the terms of the <a href="/suppliers/frameworks/digital-outcomes-and-specialists-5#legal-documents" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists&nbsp;5 ‘invitation to apply’ (opens in new tab)</a>?
+  Do you agree to comply with the terms of the <a class="govuk-link" href="/suppliers/frameworks/digital-outcomes-and-specialists-5#legal-documents" target="_blank" rel="noopener noreferrer">Digital Outcomes and Specialists&nbsp;5 ‘invitation to apply’ (opens in new tab)</a>?
 type: boolean
 assessment:
   passIfIn:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/declaration/witheldSupportingDocuments.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/declaration/witheldSupportingDocuments.yml
@@ -1,6 +1,6 @@
 name: Withholding information
 question: >
-  In the last 3 years, has your organisation (or any partner organisation) withheld information or failed to submit supporting documents required under <a href="http://www.legislation.gov.uk/uksi/2015/102/regulation/59/made" target="_blank" rel="noopener noreferrer">Regulation 59 of the Public Contracts Regulations 2015 (opens in new tab)</a>?
+  In the last 3 years, has your organisation (or any partner organisation) withheld information or failed to submit supporting documents required under <a class="govuk-link" href="http://www.legislation.gov.uk/uksi/2015/102/regulation/59/made" target="_blank" rel="noopener noreferrer">Regulation 59 of the Public Contracts Regulations 2015 (opens in new tab)</a>?
 
 type: boolean
 assessment:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/accessibleApplicationsOutcomes.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/accessibleApplicationsOutcomes.yml
@@ -2,7 +2,7 @@ name: Designing and building accessible applications
 question: >
   Will you design and build accessible applications that meet the 2018 accessibility regulations?
 hint:
-  Read guidance about how to meet the regulations and <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services (opens in new tab)</a>.
+  Read guidance about how to meet the regulations and <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">design and build accessible services (opens in new tab)</a>.
 type: boolean
 required_value: true
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/services/openStandardsPrinciples.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/services/openStandardsPrinciples.yml
@@ -1,7 +1,7 @@
 name: Use of open standards
 question: >
-  Will you work according to the government’s <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles">Open Standards Principles (opens in new tab)</a> and use the
-  <a target="_blank" rel="noopener noreferrer" href="http://standards.data.gov.uk/challenges/adopted">open standards selected for use across government (opens in new tab)</a>?
+  Will you work according to the government’s <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles">Open Standards Principles (opens in new tab)</a> and use the
+  <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="http://standards.data.gov.uk/challenges/adopted">open standards selected for use across government (opens in new tab)</a>?
 hint: This includes publishing any software you build for the government under the appropriate open source licence.
 type: boolean
 required_value: true

--- a/frameworks/g-cloud-12/messages/become-a-supplier.yml
+++ b/frameworks/g-cloud-12/messages/become-a-supplier.yml
@@ -1,35 +1,29 @@
 coming: |
-  <div class="explanation-list">
-    G-Cloud is opening for applications.<br />
-    You will be able to apply to sell:
-    <ul class="list-bullet">
-      <li>cloud hosting</li>
-      <li>cloud software</li>
-      <li>cloud support</li>
-    </ul>
-  </div>
+  G-Cloud is opening for applications.
+
+  You will be able to apply to sell:
+
+  - cloud hosting
+  - cloud software
+  - cloud support
 
 open: |
- <div class="explanation-list">
-    G-Cloud is open for applications.<br />
-    You can apply to sell:
-    <ul class="list-bullet">
-      <li>cloud hosting</li>
-      <li>cloud software</li>
-      <li>cloud support</li>
-    </ul>
-  </div>
+  G-Cloud is open for applications.
+
+  You can apply to sell:
+
+  - cloud hosting
+  - cloud software
+  - cloud support
 
 pending: &can_not_apply |
-  <div class="explanation-list">
-    G-Cloud is closed for applications.<br />
-    You will be able to apply to sell:
-    <ul class="list-bullet">
-      <li>cloud hosting</li>
-      <li>cloud software</li>
-      <li>cloud support</li>
-    </ul>
-  </div>
+  G-Cloud is closed for applications.
+
+  You will be able to apply to sell:
+
+  - cloud hosting
+  - cloud software
+  - cloud support
 
 standstill: *can_not_apply
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.4",
+  "version": "17.17.5",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.4",
+  "version": "17.17.5",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Ticket: https://trello.com/c/dz7qu083/425-2-ensure-hardcoded-html-in-dos-framework-application-content-has-appropriate-design-system-styles

Makes sure we're using [GOV.UK Design System styles](https://design-system.service.gov.uk/styles/typography/) in DOS5 application content. Mostly making sure that links have the proper class. We should look at if there's some way we can make this easier by having the content loader add all the open in new tab attributes, instead of having to copy and paste for each link.

I also updated the 'become a supplier' message for G12 to make sure the content on that page is consistent.

There are still a few HTML elements in DOS5 brief responses content which I didn't update because it's hard to test that at this point.