### PR TITLE
Exclude fields from DOS5 copying

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/metadata/copy_services.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/metadata/copy_services.yml
@@ -27,4 +27,11 @@ questions_to_exclude:
   - technicalArchitectPriceMin
   - userResearcherPriceMin
   - webOperationsPriceMin
+  - developerAccessibleApplications
+  - contentDesignerAccessibleApplications
+  - qualityAssuranceAccessibleApplications
+  - technicalArchitectAccessibleApplications
+  - webOperationsAccessibleApplications
+  - serviceManagerAccessibleApplications
+  - designerAccessibleApplications
 source_framework: digital-outcomes-and-specialists-4

--- a/frameworks/digital-outcomes-and-specialists-5/metadata/copy_services.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/metadata/copy_services.yml
@@ -7,4 +7,24 @@ questions_to_exclude:
   - labTechAssistance
   - labViewingArea
   - labWaitingArea
+  - agileCoachPriceMin
+  - businessAnalystPriceMin
+  - communicationsManagerPriceMin
+  - contentDesignerPriceMin
+  - dataArchitectPriceMin
+  - dataEngineerPriceMin
+  - dataScientistPriceMin
+  - deliveryManagerPriceMin
+  - designerPriceMin
+  - developerPriceMin
+  - performanceAnalystPriceMin
+  - portfolioManagerPriceMin
+  - productManagerPriceMin
+  - programmeManagerPriceMin
+  - qualityAssurancePriceMin
+  - securityConsultantPriceMin
+  - serviceManagerPriceMin
+  - technicalArchitectPriceMin
+  - userResearcherPriceMin
+  - webOperationsPriceMin
 source_framework: digital-outcomes-and-specialists-4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.8",
+  "version": "17.17.9",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.8",
+  "version": "17.17.9",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,7 +10,6 @@ def test_copying_services_metadata():
     copying_services_filenames = glob.glob('frameworks/*/metadata/copy_services.yml')
     assert len(copying_services_filenames) > 0
     for copying_services_filename in copying_services_filenames:
-        framework = re.match(r'^frameworks/([^/]+)/.+$', copying_services_filename).group(1)
 
         with open(copying_services_filename) as copying_services_file:
             copying_services_data = yaml.safe_load(copying_services_file.read())
@@ -19,10 +18,10 @@ def test_copying_services_metadata():
             assert os.path.isdir(old_framework_path), f'`{old_framework_path}` is not a valid directory'
 
             names_ids_fields = set()
-            for filename in os.listdir(f'frameworks/{framework}/questions/services'):
+            for filename in os.listdir(f'{old_framework_path}/questions/services'):
                 if filename.startswith('multiq'):
                     continue
-                with open(f'frameworks/{framework}/questions/services/{filename}') as f:
+                with open(f'{old_framework_path}/questions/services/{filename}') as f:
                     contents = yaml.safe_load(f)
                     if contents.get('id'):
                         names_ids_fields.add(contents['id'])


### PR DESCRIPTION
https://trello.com/c/rYwa42rs/1954-error-messages-dos5
We were erroneously copying some questions from DOS4 which had been deleted in DOS5 which caused users to experience `400` errors when attempting to save services.