### PR TITLE
Refactor metadata tests

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -52,6 +52,29 @@ class TestCopyServices:
         if "questions_to_copy" in copy_services:
             assert set(copy_services["questions_to_copy"]).issubset(names_ids_fields)
 
+    def test_keys_that_are_removed_are_excluded(self, framework, copy_services):
+        """Test that questions that have been removed in a framework iteration are not copied
+
+        We want to make sure that any questions that have been removed from one
+        framework iteration to another are included in questions_to_exclude,
+        otherwise the api will complain about unexpected properties when the
+        copied service is submitted.
+        """
+        if "questions_to_exclude" not in copy_services:
+            pytest.skip("this test only works for frameworks with questions_to_exclude")
+
+        source_framework_keys = get_framework_names_ids_fields(
+            copy_services["source_framework"]
+        )
+        new_framework_keys = get_framework_names_ids_fields(framework)
+
+        removed_keys = source_framework_keys - new_framework_keys
+        excluded_keys = set(copy_services["questions_to_exclude"])
+
+        assert removed_keys.issubset(
+            excluded_keys
+        ), f"removed keys {removed_keys - excluded_keys} not in questions_to_exclude"
+
 
 class TestServiceQuestionsToScanForBadWords:
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,70 +1,82 @@
-import glob
-import os
-import re
 import yaml
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
 
 
-def test_copying_services_metadata():
-    """Make sure that every key listed under copy_services.questions_to_copy or copy_services.questions_to_exclude
-    points to a valid question file, id, or field and that the referenced historical framework exists. """
-    copying_services_filenames = glob.glob('frameworks/*/metadata/copy_services.yml')
-    assert len(copying_services_filenames) > 0
-    for copying_services_filename in copying_services_filenames:
+@lru_cache(maxsize=None)  # memoize this function as it is slow
+def get_framework_names_ids_fields(framework):
+    names_ids_fields = set()
 
-        with open(copying_services_filename) as copying_services_file:
-            copying_services_data = yaml.safe_load(copying_services_file.read())
+    for p in Path("frameworks", framework, "questions", "services").iterdir():
+        if p.name.startswith("multiq"):
+            continue
+        contents = yaml.safe_load(p.read_text())
+        if "id" in contents:
+            names_ids_fields.add(contents["id"])
+        if "fields" in contents:
+            names_ids_fields.update(contents["fields"].values())
+        names_ids_fields.add(p.name[:-4])
 
-            old_framework_path = f'frameworks/{copying_services_data["source_framework"]}'
-            assert os.path.isdir(old_framework_path), f'`{old_framework_path}` is not a valid directory'
-
-            names_ids_fields = set()
-            for filename in os.listdir(f'{old_framework_path}/questions/services'):
-                if filename.startswith('multiq'):
-                    continue
-                with open(f'{old_framework_path}/questions/services/{filename}') as f:
-                    contents = yaml.safe_load(f)
-                    if contents.get('id'):
-                        names_ids_fields.add(contents['id'])
-                    if contents.get('fields'):
-                        names_ids_fields.update([v for v in contents.get('fields').values()])
-                    names_ids_fields.add(filename[:-4])
-
-            if 'questions_to_exclude' in copying_services_data:
-                for question in copying_services_data['questions_to_exclude']:
-                    assert question in names_ids_fields
-            else:
-                for question in copying_services_data['questions_to_copy']:
-                    assert question in names_ids_fields
+    return names_ids_fields
 
 
-def test_g11_service_questions_to_scan_for_bad_words_metadata():
-    """
-    Ensure every key listed under service_questions_to_scan_for_bad_words.service_questions points
-    to a valid question file, id or field.
-    """
-    service_question_filenames = glob.glob(
-        'frameworks/*/metadata/service_questions_to_scan_for_bad_words.yml'
+class TestCopyServices:
+    frameworks_with_copy_services = {
+        copy_services_file.parts[1]: yaml.safe_load(copy_services_file.read_text())
+        for copy_services_file in Path("frameworks").glob(
+            "*/metadata/copy_services.yml"
+        )
+    }
+
+    @pytest.fixture(params=frameworks_with_copy_services.keys())
+    def framework(self, request):
+        return request.param
+
+    @pytest.fixture
+    def copy_services(self, framework):
+        return self.frameworks_with_copy_services[framework]
+
+    def test_source_framework_exists(self, copy_services):
+        assert Path("frameworks", copy_services["source_framework"]).is_dir()
+
+    def test_keys_exist_in_source_framework(self, copy_services):
+        names_ids_fields = get_framework_names_ids_fields(
+            copy_services["source_framework"]
+        )
+
+        if "questions_to_exclude" in copy_services:
+            assert set(copy_services["questions_to_exclude"]).issubset(names_ids_fields)
+
+        if "questions_to_copy" in copy_services:
+            assert set(copy_services["questions_to_copy"]).issubset(names_ids_fields)
+
+
+class TestServiceQuestionsToScanForBadWords:
+
+    frameworks_with_service_questions_to_scan_for_bad_words = {
+        p.parts[1]: yaml.safe_load(p.read_text())
+        for p in Path("frameworks").glob(
+            "*/metadata/service_questions_to_scan_for_bad_words.yml"
+        )
+    }
+
+    @pytest.fixture(
+        params=frameworks_with_service_questions_to_scan_for_bad_words.keys()
     )
-    assert len(service_question_filenames) > 0
+    def framework(self, request):
+        return request.param
 
-    for service_question_filename in service_question_filenames:
-        framework = re.match(r'^frameworks/([^/]+)/.+$', service_question_filename).group(1)
-        # Build the list of service question fields to check against for this framework
-        names_ids_fields = set()
-        for filename in os.listdir(f'frameworks/{framework}/questions/services'):
-            # Ignore multiquestion files
-            if filename.startswith('multiq'):
-                continue
-            with open(f'frameworks/{framework}/questions/services/{filename}') as f:
-                contents = yaml.safe_load(f)
-                if contents.get('id'):
-                    names_ids_fields.add(contents['id'])
-                if contents.get('fields'):
-                    names_ids_fields.update([v for v in contents.get('fields').values()])
-                names_ids_fields.add(filename[:-4])
+    @pytest.fixture
+    def service_questions_to_scan_for_bad_words(self, framework):
+        return self.frameworks_with_service_questions_to_scan_for_bad_words[framework]
 
-        # Check all the fields in the 'bad words' list exist as service questions
-        with open(service_question_filename) as service_question_file:
-            service_question_data = yaml.safe_load(service_question_file.read())
-            for question in service_question_data['service_questions']:
-                assert question in names_ids_fields
+    def test_keys_in_framework(
+        self, framework, service_questions_to_scan_for_bad_words
+    ):
+        names_ids_fields = get_framework_names_ids_fields(framework)
+
+        assert set(
+            service_questions_to_scan_for_bad_words["service_questions"]
+        ).issubset(names_ids_fields)


### PR DESCRIPTION
Refactors the tests for copy service framework metadata, and adds a new test that checks if things are missing from questions_to_exclude that should be present. This should reduce the chances of the issues we saw in https://trello.com/c/rYwa42rs/1954-error-messages-dos5.