### PR TITLE
Backport mapping changes from alphagov/digitalmarketplace-search-api#272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Records breaking changes from major version bumps
 
+## 18.0.0
+
+The search mappings G-Cloud 12 and DOS4/5 and the search scheme generator will now
+work with Elasticsearch 7, but will no longer work with Elasticsearch 6.
+
 ## 17.0.0
 
 Removes the customer benefits record email from G-Cloud 11 manifest, as this is no longer used by CCS. This was only

--- a/frameworks/digital-outcomes-and-specialists-4/search_mappings/briefs.json
+++ b/frameworks/digital-outcomes-and-specialists-4/search_mappings/briefs.json
@@ -45,178 +45,176 @@
     }
   },
   "mappings": {
-    "briefs": {
-      "_meta": {
-        "dm_sort_clause": [
-          "sortonly_statusOrder",
-          {
-              "sortonly_publishedAt": "desc"
-          },
-          "sortonly_idHash"
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "idHash"
-            }
-          },
-          {
-            "set_conditionally": {
-              "field": "status",
-              "target_field": "statusOpenClosed",
-              "any_of": [
-                "live"
-              ],
-              "set_value": "open"
-            }
-          },
-          {
-            "set_conditionally": {
-              "field": "status",
-              "target_field": "statusOpenClosed",
-              "any_of": [
-                "awarded",
-                "cancelled",
-                "closed",
-                "unsuccessful"
-              ],
-              "set_value": "closed"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "live"
-              ],
-              "append_value": [
-                0
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "closed",
-                "awarded",
-                "cancelled",
-                "unsuccessful"
-              ],
-              "append_value": [
-                1
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "draft",
-                "withdrawn"
-              ],
-              "append_value": [
-                2
-              ]
-            }
+    "_meta": {
+      "dm_sort_clause": [
+        "sortonly_statusOrder",
+        {
+            "sortonly_publishedAt": "desc"
+        },
+        "sortonly_idHash"
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "idHash"
           }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
         },
-        "sortonly_idHash": {
-          "type": "keyword"
+        {
+          "set_conditionally": {
+            "field": "status",
+            "target_field": "statusOpenClosed",
+            "any_of": [
+              "live"
+            ],
+            "set_value": "open"
+          }
         },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+        {
+          "set_conditionally": {
+            "field": "status",
+            "target_field": "statusOpenClosed",
+            "any_of": [
+              "awarded",
+              "cancelled",
+              "closed",
+              "unsuccessful"
+            ],
+            "set_value": "closed"
+          }
         },
-        "dmtext_lot": {
-          "type": "keyword"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "live"
+            ],
+            "append_value": [
+              0
+            ]
+          }
         },
-        "dmagg_lot": {
-          "type": "keyword"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "closed",
+              "awarded",
+              "cancelled",
+              "unsuccessful"
+            ],
+            "append_value": [
+              1
+            ]
+          }
         },
-        "dmtext_withdrawnAt": {
-          "type": "keyword"
-        },
-        "dmtext_publishedAt": {
-          "type": "keyword"
-        },
-        "sortonly_publishedAt": {
-          "type": "date"
-        },
-        "dmtext_applicationsClosedAt": {
-          "type": "keyword"
-        },
-        "dmtext_clarificationQuestionsClosedAt": {
-          "type": "keyword"
-        },
-        "dmtext_cancelledAt": {
-          "type": "keyword"
-        },
-        "dmtext_unsuccessfulAt": {
-          "type": "keyword"
-        },
-        "dmtext_awardedBriefResponseId": {
-          "type": "keyword"
-        },
-        "dmtext_organisation": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_title": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_specialistRole": {
-          "type": "text"
-        },
-        "dmfilter_specialistRole": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmtext_summary": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_essentialRequirements": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_niceToHaveRequirements": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_status": {
-          "type": "keyword"
-        },
-        "dmfilter_status": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_statusOpenClosed": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "sortonly_statusOrder": {
-          "type": "byte"
-        },
-        "dmfilter_location": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmtext_location": {
-          "type": "text"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "draft",
+              "withdrawn"
+            ],
+            "append_value": [
+              2
+            ]
+          }
         }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_idHash": {
+        "type": "keyword"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_withdrawnAt": {
+        "type": "keyword"
+      },
+      "dmtext_publishedAt": {
+        "type": "keyword"
+      },
+      "sortonly_publishedAt": {
+        "type": "date"
+      },
+      "dmtext_applicationsClosedAt": {
+        "type": "keyword"
+      },
+      "dmtext_clarificationQuestionsClosedAt": {
+        "type": "keyword"
+      },
+      "dmtext_cancelledAt": {
+        "type": "keyword"
+      },
+      "dmtext_unsuccessfulAt": {
+        "type": "keyword"
+      },
+      "dmtext_awardedBriefResponseId": {
+        "type": "keyword"
+      },
+      "dmtext_organisation": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_title": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_specialistRole": {
+        "type": "text"
+      },
+      "dmfilter_specialistRole": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_summary": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_essentialRequirements": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_niceToHaveRequirements": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_status": {
+        "type": "keyword"
+      },
+      "dmfilter_status": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_statusOpenClosed": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "sortonly_statusOrder": {
+        "type": "byte"
+      },
+      "dmfilter_location": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_location": {
+        "type": "text"
       }
     }
   }

--- a/frameworks/digital-outcomes-and-specialists-4/search_mappings/briefs.json
+++ b/frameworks/digital-outcomes-and-specialists-4/search_mappings/briefs.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/frameworks/digital-outcomes-and-specialists-5/search_mappings/briefs.json
+++ b/frameworks/digital-outcomes-and-specialists-5/search_mappings/briefs.json
@@ -45,178 +45,176 @@
     }
   },
   "mappings": {
-    "briefs": {
-      "_meta": {
-        "dm_sort_clause": [
-          "sortonly_statusOrder",
-          {
-              "sortonly_publishedAt": "desc"
-          },
-          "sortonly_idHash"
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "idHash"
-            }
-          },
-          {
-            "set_conditionally": {
-              "field": "status",
-              "target_field": "statusOpenClosed",
-              "any_of": [
-                "live"
-              ],
-              "set_value": "open"
-            }
-          },
-          {
-            "set_conditionally": {
-              "field": "status",
-              "target_field": "statusOpenClosed",
-              "any_of": [
-                "awarded",
-                "cancelled",
-                "closed",
-                "unsuccessful"
-              ],
-              "set_value": "closed"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "live"
-              ],
-              "append_value": [
-                0
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "closed",
-                "awarded",
-                "cancelled",
-                "unsuccessful"
-              ],
-              "append_value": [
-                1
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "draft",
-                "withdrawn"
-              ],
-              "append_value": [
-                2
-              ]
-            }
+    "_meta": {
+      "dm_sort_clause": [
+        "sortonly_statusOrder",
+        {
+            "sortonly_publishedAt": "desc"
+        },
+        "sortonly_idHash"
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "idHash"
           }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
         },
-        "sortonly_idHash": {
-          "type": "keyword"
+        {
+          "set_conditionally": {
+            "field": "status",
+            "target_field": "statusOpenClosed",
+            "any_of": [
+              "live"
+            ],
+            "set_value": "open"
+          }
         },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+        {
+          "set_conditionally": {
+            "field": "status",
+            "target_field": "statusOpenClosed",
+            "any_of": [
+              "awarded",
+              "cancelled",
+              "closed",
+              "unsuccessful"
+            ],
+            "set_value": "closed"
+          }
         },
-        "dmtext_lot": {
-          "type": "keyword"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "live"
+            ],
+            "append_value": [
+              0
+            ]
+          }
         },
-        "dmagg_lot": {
-          "type": "keyword"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "closed",
+              "awarded",
+              "cancelled",
+              "unsuccessful"
+            ],
+            "append_value": [
+              1
+            ]
+          }
         },
-        "dmtext_withdrawnAt": {
-          "type": "keyword"
-        },
-        "dmtext_publishedAt": {
-          "type": "keyword"
-        },
-        "sortonly_publishedAt": {
-          "type": "date"
-        },
-        "dmtext_applicationsClosedAt": {
-          "type": "keyword"
-        },
-        "dmtext_clarificationQuestionsClosedAt": {
-          "type": "keyword"
-        },
-        "dmtext_cancelledAt": {
-          "type": "keyword"
-        },
-        "dmtext_unsuccessfulAt": {
-          "type": "keyword"
-        },
-        "dmtext_awardedBriefResponseId": {
-          "type": "keyword"
-        },
-        "dmtext_organisation": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_title": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_specialistRole": {
-          "type": "text"
-        },
-        "dmfilter_specialistRole": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmtext_summary": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_essentialRequirements": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_niceToHaveRequirements": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_status": {
-          "type": "keyword"
-        },
-        "dmfilter_status": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_statusOpenClosed": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "sortonly_statusOrder": {
-          "type": "byte"
-        },
-        "dmfilter_location": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmtext_location": {
-          "type": "text"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "draft",
+              "withdrawn"
+            ],
+            "append_value": [
+              2
+            ]
+          }
         }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_idHash": {
+        "type": "keyword"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_withdrawnAt": {
+        "type": "keyword"
+      },
+      "dmtext_publishedAt": {
+        "type": "keyword"
+      },
+      "sortonly_publishedAt": {
+        "type": "date"
+      },
+      "dmtext_applicationsClosedAt": {
+        "type": "keyword"
+      },
+      "dmtext_clarificationQuestionsClosedAt": {
+        "type": "keyword"
+      },
+      "dmtext_cancelledAt": {
+        "type": "keyword"
+      },
+      "dmtext_unsuccessfulAt": {
+        "type": "keyword"
+      },
+      "dmtext_awardedBriefResponseId": {
+        "type": "keyword"
+      },
+      "dmtext_organisation": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_title": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_specialistRole": {
+        "type": "text"
+      },
+      "dmfilter_specialistRole": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_summary": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_essentialRequirements": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_niceToHaveRequirements": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_status": {
+        "type": "keyword"
+      },
+      "dmfilter_status": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_statusOpenClosed": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "sortonly_statusOrder": {
+        "type": "byte"
+      },
+      "dmfilter_location": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_location": {
+        "type": "text"
       }
     }
   }

--- a/frameworks/digital-outcomes-and-specialists-5/search_mappings/briefs.json
+++ b/frameworks/digital-outcomes-and-specialists-5/search_mappings/briefs.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/frameworks/g-cloud-12/search_mappings/services.json
+++ b/frameworks/g-cloud-12/search_mappings/services.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/frameworks/g-cloud-12/search_mappings/services.json
+++ b/frameworks/g-cloud-12/search_mappings/services.json
@@ -45,205 +45,203 @@
     }
   },
   "mappings": {
-    "services": {
-      "_meta": {
-        "dm_sort_clause": [
-          "_score",
-          {
-            "sortonly_serviceIdHash": "desc"
-          }
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "serviceIdHash"
-            }
-          }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
-        },
-        "sortonly_serviceIdHash": {
-          "type": "keyword"
-        },
-        "dmagg_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lotName": {
-          "type": "text"
-        },
-        "dmtext_frameworkName": {
-          "type": "keyword"
-        },
-        "dmtext_serviceName": {
-          "type": "text"
-        },
-        "dmtext_serviceDescription": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceBenefits": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceFeatures": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_supplierName": {
-          "type": "text"
-        },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmagg_serviceCategories": {
-          "type": "keyword"
-        },
-        "dmtext_serviceCategories": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmfilter_serviceCategories": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_cloudDeploymentModel": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_resellingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_emailOrTicketingSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_phoneSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_webChatSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_onsiteSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_browsersAccess": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_installation": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_mobile": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_APISoftware": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsHow": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsWhat": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_scalingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_usageNotifications": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backup": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backupDatacentre": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_publicSectorNetworksTypes": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionBetweenNetworks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionWithinNetwork": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataStorageAndProcessingLocations": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_userAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_managementAccessAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISOIEC27001": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISO28000": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsCSASTAR": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsPCI": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_securityGovernanceStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_datacentreSecurityStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_staffSecurityClearanceChecks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_governmentSecurityClearances": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_educationPricing": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_freeVersionTrialOption": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+    "_meta": {
+      "dm_sort_clause": [
+        "_score",
+        {
+          "sortonly_serviceIdHash": "desc"
         }
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "serviceIdHash"
+          }
+        }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_serviceIdHash": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lotName": {
+        "type": "text"
+      },
+      "dmtext_frameworkName": {
+        "type": "keyword"
+      },
+      "dmtext_serviceName": {
+        "type": "text"
+      },
+      "dmtext_serviceDescription": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceBenefits": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceFeatures": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_supplierName": {
+        "type": "text"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmagg_serviceCategories": {
+        "type": "keyword"
+      },
+      "dmtext_serviceCategories": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmfilter_serviceCategories": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_cloudDeploymentModel": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_resellingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_emailOrTicketingSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_phoneSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_webChatSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_onsiteSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_browsersAccess": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_installation": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_mobile": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_APISoftware": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsHow": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsWhat": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_scalingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_usageNotifications": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backup": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backupDatacentre": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_publicSectorNetworksTypes": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionBetweenNetworks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionWithinNetwork": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataStorageAndProcessingLocations": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_userAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_managementAccessAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISOIEC27001": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISO28000": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsCSASTAR": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsPCI": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_securityGovernanceStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_datacentreSecurityStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_staffSecurityClearanceChecks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_governmentSecurityClearances": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_educationPricing": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_freeVersionTrialOption": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.10",
+  "version": "18.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "17.17.10",
+  "version": "18.0.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",

--- a/scripts/generate-search-config.py
+++ b/scripts/generate-search-config.py
@@ -50,6 +50,7 @@ if __name__ == '__main__':
             ('_', 'DO NOT UPDATE BY HAND'),
             ('version', json.load(version_handle)['version']),
             ('generated_from_framework', framework_slug),
+            ('doc_type', doc_type),
             ('generated_by', os.path.abspath(__file__)),
             ('generated_time', datetime.utcnow().isoformat()),
         ))


### PR DESCRIPTION
Ticket: https://trello.com/c/Yh8uyxvF/2102-migrate-elasticsearch-on-preview

We want to be able to generate search mappings from the frameworks repo with the changes needed for Elasticsearch 7.

New features
------------

- You can now use the G-Cloud 12 and DOS4/5 search mappings with Elasticsearch 7

Breaking changes
----------------

- You can no longer use G-Cloud 12 and DOS4/5 search mappings with Elasticsearch 6