### PR TITLE
Change brief responses availability question to date type

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
@@ -1,6 +1,6 @@
 name: Earliest start date
 question: When is the earliest {% if brief.lotSlug == "digital-outcomes" %}the team can start?{% elif brief.lotSlug == "digital-specialists" %}the specialist can start work?{% else %}you can recruit participants?{% endif %}
-hint: 'eg 31/12/2020'
+hint: "For example, 31 12 2020"
 question_advice: >
   The buyer needs
   {%- if brief.lotSlug == "digital-outcomes" %}
@@ -10,13 +10,12 @@ question_advice: >
   {%- else %}
   participants: {{ brief.researchDates }}
   {%- endif %}
-type: text
-smaller: true
+type: date
 validations:
-  -
-    name: answer_required
-    message: 'Enter a start date'
-  -
-    name: under_character_limit
-    message: "Your start date must be 100 characters or fewer"
+  - name: answer_required
+    message: "Enter a start date"
+
+  - name: invalid_format
+    message: "Start date must be a real date"
+
 empty_message: Set date

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
Although this question asks for a simple date, it is a text question. It has been like this since it's initial commit to DOS1 [1]; I can find no evidence explaining why this question is not a date question.

To try and make it easier for users to enter a valid date this commit changes the question type to date for DOS5; this will not affect brief responses from previous frameworks and since DOS5 isn't live yet it shouldn't cause any issues with that framework (which is why I've called this a patch version change rather than a breaking change).

Hopefully this change will not be a problem going forward, although it will be interesting to see if anyone has been relying on this accepting input that is not a date.

[1]:
https://github.com/alphagov/digitalmarketplace-frameworks/commit/43edb2c4b64c93f33f34d6f5d33680ebb7357dc6#diff-1437d60cdf62bf2be98d263fe7b985e069f360262ee281719624776cf8618eb3