### PR TITLE
Brief response markdown tweaks

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/availability.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/availability.yml
@@ -1,6 +1,6 @@
 name: Earliest start date
 question: When is the earliest {% if brief.lotSlug == "digital-outcomes" %}the team can start?{% elif brief.lotSlug == "digital-specialists" %}the specialist can start work?{% else %}you can recruit participants?{% endif %}
-hint: 'eg 31/12/2020'
+hint: 'Enter a date like 31/12/2020'
 question_advice: >
   The buyer needs
   {%- if brief.lotSlug == "digital-outcomes" %}

--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/dayRate.yml
@@ -1,6 +1,12 @@
 name: Day rate
 question: What’s the specialist’s day rate?
-question_advice: "{% if 'budgetRange' in brief %}<h2>Buyer's maximum day rate:</h2><p>{{ brief.budgetRange }}</p>{% endif %}<h2>Your maximum day rate:</h2><p>£{{ max_day_rate }}</p>"
+question_advice: |
+  {% if "budgetRange" in brief %}
+    <h2 class="govuk-heading-m">Buyer’s maximum day rate:</h2>
+    <p class="govuk-body">{{ brief.budgetRange }}</p>
+  {% endif %}
+  <h2 class="govuk-heading-m">Your maximum day rate:</h2>
+  <p class="govuk-body">£{{ max_day_rate }}</p>'
 type: pricing
 fields:
   price: dayRate

--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/dayRate.yml
@@ -2,11 +2,16 @@ name: Day rate
 question: What’s the specialist’s day rate?
 question_advice: |
   {% if "budgetRange" in brief %}
-    <h2 class="govuk-heading-m">Buyer’s maximum day rate:</h2>
-    <p class="govuk-body">{{ brief.budgetRange }}</p>
+
+  ## Buyer’s maximum day rate:
+  
+  {{ brief.budgetRange }}
+
   {% endif %}
-  <h2 class="govuk-heading-m">Your maximum day rate:</h2>
-  <p class="govuk-body">£{{ max_day_rate }}</p>'
+
+  ## Your maximum day rate:
+  
+  £{{ max_day_rate }}
 type: pricing
 fields:
   price: dayRate

--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/essentialRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/essentialRequirements.yml
@@ -5,16 +5,13 @@ question_advice: |
 
   You’ll need to meet or exceed their requirements to get through to the next stage.
 
-  <h3>Evidence structure</h3>
-  <div class="explanation-list">
-    <p class="lead">When you write your evidence, you should be specific about:</p>
+  ## Evidence structure
+  
+  When you write your evidence, you should be specific about:
 
-    <ul class="list-bullet">
-      <li>what the situation was</li>
-      <li>the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did</li>
-      <li>what the results were</li>
-    </ul>
-  </div>
+  * what the situation was
+  * the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did
+  * what the results were
 
   You should only provide one example for each essential requirement (unless the buyer specifies otherwise).
 

--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/essentialRequirementsMet.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/essentialRequirementsMet.yml
@@ -1,7 +1,7 @@
 name: Essential skills and experience
 question: Do you have all the essential skills and experience?
 question_advice: >
-  <ul class="list-bullet">
+  <ul class="govuk-list govuk-list--bullet">
     {% for requirement in brief.essentialRequirements %}
       <li>{{ requirement }}</li>
     {% endfor %}

--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/niceToHaveRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/niceToHaveRequirements.yml
@@ -6,16 +6,13 @@ question_advice: |
 
   The buyer will assess and score your evidence to shortlist the best suppliers.
 
-  <h3>Evidence structure</h3>
-  <div class="explanation-list">
-    <p class="lead">When you write your evidence, you should be specific about:</p>
+  ## Evidence structure
+  
+  When you write your evidence, you should be specific about:
 
-    <ul class="list-bullet">
-      <li>what the situation was</li>
-      <li>the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did</li>
-      <li>what the results were</li>
-    </ul>
-  </div>
+  * what the situation was
+  * the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did
+  * what the results were
 
   You should only provide one example for each nice-to-have requirement (unless the buyer specifies otherwise).
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
@@ -1,6 +1,6 @@
 name: Earliest start date
 question: When is the earliest {% if brief.lotSlug == "digital-outcomes" %}the team can start?{% elif brief.lotSlug == "digital-specialists" %}the specialist can start work?{% else %}you can recruit participants?{% endif %}
-hint: "For example, 31 12 2020"
+hint: "Enter a date like 31 12 2020"
 question_advice: >
   The buyer needs
   {%- if brief.lotSlug == "digital-outcomes" %}

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
@@ -1,6 +1,12 @@
 name: Day rate
 question: What’s the specialist’s day rate?
-question_advice: "{% if 'budgetRange' in brief %}<h2>Buyer's maximum day rate:</h2><p>{{ brief.budgetRange }}</p>{% endif %}<h2>Your maximum day rate:</h2><p>£{{ max_day_rate }}</p>"
+question_advice: |
+  {% if "budgetRange" in brief %}
+    <h2 class="govuk-heading-m">Buyer’s maximum day rate:</h2>
+    <p class="govuk-body">{{ brief.budgetRange }}</p>
+  {% endif %}
+  <h2 class="govuk-heading-m">Your maximum day rate:</h2>
+  <p class="govuk-body">£{{ max_day_rate }}</p>'
 type: pricing
 fields:
   price: dayRate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
@@ -2,11 +2,16 @@ name: Day rate
 question: What’s the specialist’s day rate?
 question_advice: |
   {% if "budgetRange" in brief %}
-    <h2 class="govuk-heading-m">Buyer’s maximum day rate:</h2>
-    <p class="govuk-body">{{ brief.budgetRange }}</p>
+
+  ## Buyer’s maximum day rate:
+  
+  {{ brief.budgetRange }}
+
   {% endif %}
-  <h2 class="govuk-heading-m">Your maximum day rate:</h2>
-  <p class="govuk-body">£{{ max_day_rate }}</p>'
+
+  ## Your maximum day rate:
+  
+  £{{ max_day_rate }}
 type: pricing
 fields:
   price: dayRate

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirements.yml
@@ -5,16 +5,13 @@ question_advice: |
 
   You’ll need to meet or exceed their requirements to get through to the next stage.
 
-  <h3>Evidence structure</h3>
-  <div class="explanation-list">
-    <p class="lead">When you write your evidence, you should be specific about:</p>
+  ## Evidence structure
+  
+  When you write your evidence, you should be specific about:
 
-    <ul class="list-bullet">
-      <li>what the situation was</li>
-      <li>the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did</li>
-      <li>what the results were</li>
-    </ul>
-  </div>
+  * what the situation was
+  * the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did
+  * what the results were
 
   You should only provide one example for each essential requirement (unless the buyer specifies otherwise).
 

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirementsMet.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirementsMet.yml
@@ -1,7 +1,7 @@
 name: Essential skills and experience
 question: Do you have all the essential skills and experience?
 question_advice: >
-  <ul class="list-bullet">
+  <ul class="govuk-list govuk-list--bullet">
     {% for requirement in brief.essentialRequirements %}
       <li>{{ requirement }}</li>
     {% endfor %}

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/niceToHaveRequirements.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/niceToHaveRequirements.yml
@@ -6,16 +6,13 @@ question_advice: |
 
   The buyer will assess and score your evidence to shortlist the best suppliers.
 
-  <h3>Evidence structure</h3>
-  <div class="explanation-list">
-    <p class="lead">When you write your evidence, you should be specific about:</p>
+  ## Evidence structure
+  
+  When you write your evidence, you should be specific about:
 
-    <ul class="list-bullet">
-      <li>what the situation was</li>
-      <li>the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did</li>
-      <li>what the results were</li>
-    </ul>
-  </div>
+  * what the situation was
+  * the work {% if brief.lotSlug == 'digital-outcomes' %}the team{% elif brief.lotSlug == 'digital-specialists' %}the specialist{% elif brief.lotSlug == 'user-research-participants' %}you{% endif %} did
+  * what the results were
 
   You should only provide one example for each nice-to-have requirement (unless the buyer specifies otherwise).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.3",
+  "version": "18.0.4",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.3",
+  "version": "18.0.4",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/13tOvxuu/285-2-replace-content-loader-form-macros-in-brief-responses-frontend

We're trying to remove as much hard-coded HTML from these questions as we can.

In some instances, it is unavoidable, and this is causing a bug: https://trello.com/c/OMcXpf8k/1476-content-loader-can-generate-invalid-html

However, that is out of scope for this ticket.