### PR TITLE
Remove headings from Day Rate question advice

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/questions/brief-responses/dayRate.yml
@@ -2,15 +2,11 @@ name: Day rate
 question: What’s the specialist’s day rate?
 question_advice: |
   {% if "budgetRange" in brief %}
-
-  ## Buyer’s maximum day rate:
-  
+  Buyer’s maximum day rate:<br/>
   {{ brief.budgetRange }}
-
   {% endif %}
 
-  ## Your maximum day rate:
-  
+  Your maximum day rate:<br/>
   £{{ max_day_rate }}
 type: pricing
 fields:

--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/dayRate.yml
@@ -2,15 +2,11 @@ name: Day rate
 question: What’s the specialist’s day rate?
 question_advice: |
   {% if "budgetRange" in brief %}
-
-  ## Buyer’s maximum day rate:
-  
+  Buyer’s maximum day rate:<br/>
   {{ brief.budgetRange }}
-
   {% endif %}
 
-  ## Your maximum day rate:
-  
+  Your maximum day rate:<br/>
   £{{ max_day_rate }}
 type: pricing
 fields:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.4",
+  "version": "18.0.5",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.4",
+  "version": "18.0.5",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
The headings made the question difficult to parse at a glance. Removing them places more focus on the
question and the input, rather than so much emphasis on the advice.

## Before
<img width="580" alt="Screenshot 2020-12-14 at 10 11 09" src="https://user-images.githubusercontent.com/22524634/102080332-31227600-3e06-11eb-8164-2cdd2c21f835.png">

## After
![Screenshot 2020-12-14 at 11 41 12](https://user-images.githubusercontent.com/22524634/102080306-2667e100-3e06-11eb-8a3a-b2f6a811e4cd.png)
