### PR TITLE
Fix bug in validation schema generator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ jobs:
   unit_test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
@@ -19,7 +20,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
       - name: Install dependencies
         run: make requirements-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Ubuntu packages
-        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -44,9 +41,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install Ubuntu packages
-        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,38 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  functional_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+        script:
+          - scripts/generate-assessment-schema.py g-cloud-12
+          - scripts/generate-assessment-schema.py digital-outcomes-and-specialists-5
+          - scripts/generate-search-config.py g-cloud-12 services --output-path=/tmp
+          - scripts/generate-search-config.py digital-outcomes-and-specialists-5 briefs --output-path=/tmp
+          - scripts/generate-validation-schemas.py --output-path=/tmp
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ubuntu packages
+        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup Python cache
+        uses: actions/cache@v2
+        with:
+          path: venv
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}
+
+      - name: Install dependencies
+        run: make requirements-dev
+
+      - name: Test script
+        run: venv/bin/python ${{ matrix.script }}

--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -402,6 +402,12 @@ def multiquestion(question):
 
 
 def _dynamic_list(question):
+    # Some dynamic list questions use `{{ item }}` in temlate fields.
+    # This call to filter ensures that `item` is in the template context
+    # (yes, filter() can mutate objects, go figure).
+    # Replacing `item` with something random shouldn't really matter,
+    # because we don't expect any template fields to show up in the schema.
+    question = question.filter({"item": "{{ item }}"}, dynamic=False)
     return {
         question['id']: {
             "type": "array",


### PR DESCRIPTION
Ticket: https://trello.com/c/LY1lCPUt/291-1-fix-schema-generator-in-frameworks-repo

Adding `{{ item }}` to dynamic list question error messages in #656 caused validation schema generation to fail because `item` was not present in the template context.

This PR adds `item` to the context for all questions; it is a bit of a hack but is the only fix I could think of.

Also, it was a bit worrying that we didn't notice that the schema generator was broken when we merged #656, so I've also added some functional tests of the schema generation scripts. I tested that this functional test fails as expected if the fix is not present.