### PR TITLE
Update DOS5 URLs

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/messages/urls.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/urls.yml
@@ -1,4 +1,3 @@
-call_off_contract_url: https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-call-off-contract/__placeholder__
-framework_agreement_pdf_url: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/738942/digital-outcomes-and-specialists-5-framework-agreement.pdf/__placeholder__
-framework_agreement_url: https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-framework-agreement/__placeholder__
-supplier_guide_url: https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#how-to-apply-to-the-framework/__placeholder__
+framework_agreement_pdf_url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/947688/DOS5-framework-award-form.odt
+framework_agreement_url: https://www.gov.uk/guidance/digital-outcomes-and-specialists-5-legal-documents
+supplier_guide_url: https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#how-to-apply

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.5",
+  "version": "18.1.6",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/75hbcRW8/607-2-implement-dos-5-e-signature
N.B. There is no call off contract URL for this framework. I think this is not linked to so _should_ be OK.