### PR TITLE
Add template logic to 'How evaluated' description

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-4/manifests/display_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-4/manifests/display_brief.yml
@@ -59,6 +59,7 @@
     - niceToHaveRequirementsParticipants
 -
   name: How suppliers will be evaluated
+  summary_page_description: "All suppliers will be asked to provide a {% if lotSlug == 'digital-specialists' %}work history{% else %}written proposal{% endif %}."
   questions:
     - numberOfSuppliersOutcomes
     - numberOfSuppliersSpecialists

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief.yml
@@ -59,6 +59,7 @@
     - niceToHaveRequirementsParticipants
 -
   name: How suppliers will be evaluated
+  summary_page_description: "All suppliers will be asked to provide a {% if lotSlug == 'digital-specialists' %}work history{% else %}written proposal{% endif %}."
   questions:
     - numberOfSuppliersOutcomes
     - numberOfSuppliersSpecialists

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.6",
+  "version": "18.1.7",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
https://trello.com/c/YZJhCqq2/238-3-dos5-public-brief-page-add-mandatory-assessment-method-to-summary-text

Rather than hardcoding this logic in the app, as previously in: https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/37f0d7da87b41843f809c107b7cd376d6487308f/app/main/helpers/brief_helpers.py#L33-L45 we want to move this to the frameworks repository.