### PR TITLE
Change DOS5 example dates to 2021 

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/availability.yml
@@ -1,6 +1,6 @@
 name: Earliest start date
 question: When is the earliest {% if brief.lotSlug == "digital-outcomes" %}the team can start?{% elif brief.lotSlug == "digital-specialists" %}the specialist can start work?{% else %}you can recruit participants?{% endif %}
-hint: "Enter a date like 31 12 2020"
+hint: "Enter a date like 31 12 2021"
 question_advice: >
   The buyer needs
   {%- if brief.lotSlug == "digital-outcomes" %}

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/awardedContractStartDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/awardedContractStartDate.yml
@@ -1,6 +1,6 @@
 name: What's the start date?
 question: What's the start date?
-hint: 'For example, 31 5 2020'
+hint: 'For example, 31 5 2021'
 type: date
 validations:
   - name: answer_required

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/startDate.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/startDate.yml
@@ -2,7 +2,7 @@ name: Latest start date
 question: Latest start date
 question_advice: |
   Say when you need suppliers to start work. When you shortlist, you can exclude suppliers who cannot start by this date.
-hint: 'For example, 31 5 2020'
+hint: 'For example, 31 5 2021'
 type: date
 depends:
   - "on": "lot"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.0.5",
+  "version": "18.1.7",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.6",
+  "version": "18.1.7",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
While testing DOS5 journeys before go-live we noticed that the example dates we give when creating or responding to a brief are in 2020. We want these dates to be relatable to our users, so change them to 2021.

https://trello.com/c/bQUiYaju/702-05-update-date-examples-to-2021