### PR TITLE
Update DOS5 contract link to new legal documents landing page

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsOutcomesSpecialists.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsOutcomesSpecialists.yml
@@ -2,7 +2,7 @@ id: additionalTerms
 name: Additional terms and conditions
 question: Additional terms and conditions
 question_advice: |
-  You should use the [standard contract](https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-call-off-contract) unless your organisation needs to include additional terms and conditions.
+  You should use the [standard contract](https://www.gov.uk/guidance/digital-outcomes-and-specialists-5-legal-documents) unless your organisation needs to include additional terms and conditions.
 
   Read about [how the terms and conditions work](https://www.gov.uk/guidance/terms-and-conditions-of-digital-marketplace-frameworks).
 optional: true

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsParticipants.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/additionalTermsParticipants.yml
@@ -2,7 +2,7 @@ id: additionalTerms
 name: Additional terms and conditions
 question: Additional terms and conditions
 question_advice: |
-  You should use the [standard contract](https://www.gov.uk/government/publications/digital-outcomes-and-specialists-5-call-off-contract) unless your organisation needs to include additional terms and conditions.
+  You should use the [standard contract](https://www.gov.uk/guidance/digital-outcomes-and-specialists-5-legal-documents) unless your organisation needs to include additional terms and conditions.
 
   Read about [how the terms and conditions work](https://www.gov.uk/guidance/terms-and-conditions-of-digital-marketplace-frameworks).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.7",
+  "version": "18.1.8",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.7",
+  "version": "18.1.8",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk",


### PR DESCRIPTION
We have a new [landing page](https://www.gov.uk/guidance/digital-outcomes-and-specialists-5-legal-documents) for all DOS5 legal documents, so direct buyers to this on the additional terms questions.

https://trello.com/c/fjMThOjv/703-1-send-buyers-to-the-correct-dos5-standard-contract-link