### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ max-complexity = 12
 max-line-length = 120
 per-file-ignores =
     scripts/* : E402
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,14 @@ jobs:
           path: venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
+      - name: Install developer tools
+        run: make bootstrap
+
       - name: Install dependencies
-        run: make requirements-dev
+        run: invoke requirements-dev
 
       - name: Run tests
-        run: make test
+        run: invoke test
 
   functional_test:
     runs-on: ubuntu-latest
@@ -54,8 +57,11 @@ jobs:
           path: venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
+      - name: Install developer tools
+        run: make bootstrap
+
       - name: Install dependencies
-        run: make requirements-dev
+        run: invoke requirements-dev
 
       - name: Test script
         run: venv/bin/python ${{ matrix.script }}

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,21 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+.DEFAULT_GOAL := bootstrap
 
-requirements-dev: virtualenv requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements-dev.txt
+%:
+	-@[ -z "$$TERM" ] || tput setaf 1  # red
+	@>&2 echo warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	-@[ -z "$$TERM" ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
+	@exit
 
-test: show-environment test-flake8 test-python
+help:
+	invoke --list
 
-test-flake8: virtualenv
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-test-python: virtualenv
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST-ARGS}
-
-show-environment:
-	@echo "Environment variables in use:"
-	@env | grep DM_ || true
-
-.PHONY: virtualenv requirements-for-test test-flake8 test-python show-environment
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	-@[ -z "$$TERM" ] || tput setaf 2  # green
+	@>&2 echo dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	-@[ -z "$$TERM" ] || tput setaf 9  # default

--- a/README.md
+++ b/README.md
@@ -184,10 +184,16 @@ Running the tests
 The tests check that the YAML files are valid and that they match a schema.
 
 Install dependencies
-`make requirements-dev`
+```
+make bootstrap
+invoke requirements-dev
+```
 
 Run the tests
-`make test`
+
+```
+invoke test
+```
 
 Versioning
 ----------

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,1 @@
+from dmdevtools.invoke_tasks import library_tasks as ns


### PR DESCRIPTION
We want to be able to reduce duplication of code across our repos; one
of the places we have a lot of duplicated code is in our Makefiles; all
of our repos have very similar Makefiles with small historical
differences.

This commit replaces Make with invoke, using the tasks from
alphagov/digitalmarketplace-developer-tools.