### PR TITLE
Version bump (minor) to 18.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.10",
+  "version": "18.2.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.1.10",
+  "version": "18.2.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
### New features

- The lot descriptions for DOS5 have been updated for the new choose a lot journey (#674)
- The default branch has been renamed to `main` (#672)
- You can now use invoke instead of make (#675)