### PR TITLE
Update content for create a supplier account journey

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
@@ -19,7 +19,7 @@ open: |
   - user research participants
 
 pending: &can_not_apply |
-  Digital Outcomes and Specialists is closed for applications.
+  Digital Outcomes and Specialists is closed for applications. You can create an account when it is open.
 
   You will be able to apply to sell:
 

--- a/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/messages/become-a-supplier.yml
@@ -1,4 +1,6 @@
 coming: |
+  ### Digital Outcomes and Specialists
+
   Digital Outcomes and Specialists is opening for applications.
 
   You will be able to apply to sell:
@@ -9,6 +11,8 @@ coming: |
   - user research participants
 
 open: |
+  ### Digital Outcomes and Specialists
+
   Digital Outcomes and Specialists is open for applications.
 
   You can apply to sell:
@@ -19,6 +23,8 @@ open: |
   - user research participants
 
 pending: &can_not_apply |
+  ### Digital Outcomes and Specialists
+
   Digital Outcomes and Specialists is closed for applications. You can create an account when it is open.
 
   You will be able to apply to sell:

--- a/frameworks/g-cloud-12/messages/become-a-supplier.yml
+++ b/frameworks/g-cloud-12/messages/become-a-supplier.yml
@@ -17,7 +17,7 @@ open: |
   - cloud support
 
 pending: &can_not_apply |
-  G-Cloud is closed for applications.
+  G-Cloud is closed for applications. You can create an account when it is open.
 
   You will be able to apply to sell:
 

--- a/frameworks/g-cloud-12/messages/become-a-supplier.yml
+++ b/frameworks/g-cloud-12/messages/become-a-supplier.yml
@@ -1,4 +1,6 @@
 coming: |
+  ### G-Cloud
+
   G-Cloud is opening for applications.
 
   You will be able to apply to sell:
@@ -8,6 +10,8 @@ coming: |
   - cloud support
 
 open: |
+  ### G-Cloud
+
   G-Cloud is open for applications.
 
   You can apply to sell:
@@ -17,6 +21,8 @@ open: |
   - cloud support
 
 pending: &can_not_apply |
+  ### G-Cloud
+
   G-Cloud is closed for applications. You can create an account when it is open.
 
   You will be able to apply to sell:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.2.1",
+  "version": "18.2.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.2.1",
+  "version": "18.2.2",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
Ticket: https://trello.com/c/Ajssa0oq/890-3-update-content-for-create-a-supplier-account-journey

Tweaks the content on the 'Become a supplier' page to make it clear when suppliers can create an account, and also adds a heading to separate the content better.

I couldn't figure out how to add the headings in the supplier frontend rather than here, because we don't have the framework family name in the framework object or in the framework content.