### PR TITLE
Add employment status question to DOS buyer journey

### DIFF
--- a/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/display_brief.yml
@@ -2,6 +2,7 @@
   name: Overview
   questions:
     - specialistRole
+    - employmentStatus
     - summary
     - startDate
     - contractLength

--- a/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/manifests/edit_brief.yml
@@ -56,6 +56,12 @@
     - budgetRangeOutcomesParticipants
     - budgetRangeSpecialists
     - summary
+-
+  name: Off-payroll working rules (IR35) determination
+  editable: True
+  step: 1
+  questions:
+    - employmentStatus
 
 -
   name: Shortlist and evaluation process

--- a/frameworks/digital-outcomes-and-specialists-5/questions/briefs/employmentStatus.yml
+++ b/frameworks/digital-outcomes-and-specialists-5/questions/briefs/employmentStatus.yml
@@ -1,0 +1,22 @@
+name: Off-payroll (IR35) determination
+question: Confirm if you require a managed service or supply of resource
+id: employmentStatus
+question_advice: |
+  As the buyer, you are the client when buying a supply of resource. As a result, you are responsible for determining if the off-payroll working rules (IR35) apply.
+
+  Is the requirement for a contracted out service (where you outsource all ownership and responsibility for delivery to a supplier) or
+  a supply of resource (where you engage an individual or team of individuals to work with your staff, and exercise operational direction and control)?
+type: radios
+options:
+  - label: "Contracted out service: the off-payroll rules do not apply"
+  - label: "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
+depends:
+  - "on": "lot"
+    being:
+      - digital-outcomes
+      - digital-specialists
+validations:
+  -
+    name: answer_required
+    message: 'Select the employment status of your opportunity'
+empty_message: Select an answer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.2.2",
+  "version": "18.3.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frameworks",
-  "version": "18.2.2",
+  "version": "18.3.0",
   "description": "Data files for Digital Marketplace’s procurement frameworks",
   "repository": "git@github.com:alphagov/digitalmarketplace-frameworks",
   "author": "enquiries@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
HMRC has strongly encouraged Public Sector Bodies (PSB)  to advertise roles as inside or outside IR35 in order to set the expectations of suppliers from the outset. The  HMRC off-payroll rules come [into force](https://www.gov.uk/guidance/april-2020-changes-to-off-payroll-working-for-intermediaries) in April 2021. As such, the DOS team has determined that all published (outcomes and specialist) opportunities will need clear indication if they are inside or outside of IR35. 

Add a new question into the buyer journey that asks our buyers the IR35 status of an opportunity.

The wording of the question has been approved by CCS and the Tax Centre of Excellence at HMRC - see https://trello.com/c/apbMZmVd/12-5-confirm-wording-for-the-new-ir35-question

https://trello.com/c/aIJAqcQ4/954-3-allow-briefs-to-store-the-answer-to-the-new-ir35-question and 
https://trello.com/c/l9lnd1GD/955-2-add-new-ir35-question-to-the-create-an-opportunity-journey