### PR TITLE
Add G-Cloud 13 to validation schema script

### DIFF
--- a/schema_generator/validation.py
+++ b/schema_generator/validation.py
@@ -45,6 +45,7 @@ FRAMEWORKS_AND_LOTS = {
         {'framework_slug': 'g-cloud-10', 'framework_name': "G-Cloud 10", 'lots': G_CLOUD_LOTS},
         {'framework_slug': 'g-cloud-11', 'framework_name': "G-Cloud 11", 'lots': G_CLOUD_LOTS},
         {'framework_slug': 'g-cloud-12', 'framework_name': "G-Cloud 12", 'lots': G_CLOUD_LOTS},
+        {'framework_slug': 'g-cloud-13', 'framework_name': "G-Cloud 13", 'lots': G_CLOUD_LOTS},
     ],
     "digital-outcomes-and-specialists": [
         {


### PR DESCRIPTION
We know G-Cloud 13 will have a fourth lot, but we don't know exactly what that will be at the moment. Therefore, add the new framework to the schema generation script using the same lots as G-Cloud 12 so we can test things out locally.

https://trello.com/c/3SULJbtw/78-1-g-cloud-13-filter-a-person-from-lots-1-2-3-pricing-question