### PR TITLE
Exclude price question from G-Cloud 13

### DIFF
--- a/frameworks/g-cloud-13/metadata/copy_services.yml
+++ b/frameworks/g-cloud-13/metadata/copy_services.yml
@@ -1,2 +1,3 @@
-questions_to_exclude: []
+questions_to_exclude:
+  - price
 source_framework: g-cloud-12


### PR DESCRIPTION
This PR simply excludes de price question from G-cloud 13 for lot 1, 2 and 3, regardless of the unit chosen. Not the most user friendly choice but there was no nice way to filter out only day rates and this ensures the data copies is consistent, at least.

https://trello.com/c/GcJG9TPK/79-3-g-cloud-13-handle-pricing-question-on-services-copied-from-previous-frameworks